### PR TITLE
[tests] Combine and shorten imports where applicable

### DIFF
--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -1,8 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Aptos, AptosConfig } from "../../../src";
-import { Network } from "../../../src/utils/apiEndpoints";
+import { Aptos, AptosConfig, Network } from "../../../src";
 
 // TODO
 // add account getTransactions tests once sdk v2 supports faucet (which needs transaction operation support)

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -1,9 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig, Aptos } from "../../../src";
+import { AptosConfig, Aptos, Network } from "../../../src";
 import { GraphqlQuery, ViewRequest } from "../../../src/types";
-import { Network } from "../../../src/utils/apiEndpoints";
 
 describe("general api", () => {
   test("it fetches ledger info", async () => {

--- a/tests/e2e/api/transaction.test.ts
+++ b/tests/e2e/api/transaction.test.ts
@@ -1,8 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig, Aptos } from "../../../src";
-import { Network } from "../../../src/utils/apiEndpoints";
+import { AptosConfig, Aptos, Network } from "../../../src";
 
 describe("transaction api", () => {
   test("it queries for the network estimated gas price", async () => {

--- a/tests/e2e/api/transaction_submission.test.ts
+++ b/tests/e2e/api/transaction_submission.test.ts
@@ -11,12 +11,10 @@ import {
   RawTransaction,
   ScriptTransactionArgumentAddress,
   ScriptTransactionArgumentU64,
-} from "../../../src/transactions/instances";
-import {
   TransactionPayloadEntryFunction,
   TransactionPayloadMultisig,
   TransactionPayloadScript,
-} from "../../../src/transactions/instances/transactionPayload";
+} from "../../../src/transactions/instances";
 import { SigningScheme } from "../../../src/types";
 
 describe("transaction submission", () => {

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Account } from "../../src/core/account";
-import { AccountAddress } from "../../src/core/account_address";
-import { Hex } from "../../src/core/hex";
+import { AccountAddress, Hex } from "../../src/core";
 import { Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
 import { Secp256k1PrivateKey, Secp256k1PublicKey, Secp256k1Signature } from "../../src/crypto/secp256k1";
 import { SigningScheme } from "../../src/types";

--- a/tests/unit/account_address.test.ts
+++ b/tests/unit/account_address.test.ts
@@ -1,8 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Deserializer, Serializer } from "../../src/bcs";
-import { AccountAddress, AddressInvalidReason } from "../../src/core/account_address";
+import { Deserializer, Serializer } from "../../src";
+import { AccountAddress, AddressInvalidReason } from "../../src/core";
 
 type Addresses = {
   shortWith0x: string;

--- a/tests/unit/aptos_config.test.ts
+++ b/tests/unit/aptos_config.test.ts
@@ -1,9 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig } from "../../src";
+import { AptosConfig, Network, NetworkToFaucetAPI, NetworkToNodeAPI, NetworkToIndexerAPI } from "../../src";
 import { AptosSettings } from "../../src/types";
-import { Network, NetworkToFaucetAPI, NetworkToNodeAPI, NetworkToIndexerAPI } from "../../src/utils/apiEndpoints";
 import { AptosApiType } from "../../src/utils/const";
 
 describe("aptos config", () => {

--- a/tests/unit/authentication_key.test.ts
+++ b/tests/unit/authentication_key.test.ts
@@ -6,7 +6,7 @@ import { Ed25519PublicKey } from "../../src/crypto/ed25519";
 import { MultiEd25519PublicKey } from "../../src/crypto/multi_ed25519";
 import { ed25519, multiEd25519PkTestObject } from "./helper";
 import { PublicKey, Signature } from "../../src/crypto/asymmetric_crypto";
-import { Serializer, Deserializer } from "../../src/bcs";
+import { Serializer, Deserializer } from "../../src";
 import { HexInput } from "../../src/types";
 
 describe("AuthenticationKey", () => {

--- a/tests/unit/bcs-helper.test.ts
+++ b/tests/unit/bcs-helper.test.ts
@@ -1,11 +1,10 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Deserializable, Deserializer } from "../../src/bcs/deserializer";
 import { FixedBytes } from "../../src/bcs/serializable/fixed-bytes";
 import { Bool, U128, U16, U256, U32, U64, U8 } from "../../src/bcs/serializable/move-primitives";
 import { MoveObject, MoveOption, MoveString, MoveVector } from "../../src/bcs/serializable/move-structs";
-import { Serializable, Serializer } from "../../src/bcs/serializer";
+import { Deserializable, Deserializer, Serializable, Serializer } from "../../src";
 import { AccountAddress } from "../../src/core";
 
 describe("Tests for the Serializable class", () => {

--- a/tests/unit/deserializer.test.ts
+++ b/tests/unit/deserializer.test.ts
@@ -1,8 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account } from "../../src/api/account";
-import { Serializable, Serializer, Deserializer } from "../../src/bcs";
+import { Serializable, Serializer, Deserializer } from "../../src";
 import { AccountAddress } from "../../src/core";
 
 describe("BCS Deserializer", () => {

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -1,9 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Deserializer } from "../../src/bcs/deserializer";
-import { Serializer } from "../../src/bcs/serializer";
-import { Hex } from "../../src/core/hex";
+import { Deserializer, Serializer } from "../../src";
+import { Hex } from "../../src/core";
 import { Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
 import { ed25519 } from "./helper";
 

--- a/tests/unit/hex.test.ts
+++ b/tests/unit/hex.test.ts
@@ -1,8 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { ParsingError } from "../../src/core";
-import { Hex, HexInvalidReason } from "../../src/core/hex";
+import { Hex, HexInvalidReason } from "../../src/core";
 
 const mockHex = {
   withoutPrefix: "007711b4d0",

--- a/tests/unit/multi_ed25519.test.ts
+++ b/tests/unit/multi_ed25519.test.ts
@@ -1,9 +1,8 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Deserializer } from "../../src/bcs/deserializer";
-import { Serializer } from "../../src/bcs/serializer";
-import { Hex } from "../../src/core/hex";
+import { Deserializer, Serializer } from "../../src";
+import { Hex } from "../../src/core";
 import { Ed25519PublicKey, Ed25519Signature } from "../../src/crypto/ed25519";
 import { MultiEd25519PublicKey, MultiEd25519Signature } from "../../src/crypto/multi_ed25519";
 import { multiEd25519PkTestObject, multiEd25519SigTestObject } from "./helper";

--- a/tests/unit/secp256k1.test.ts
+++ b/tests/unit/secp256k1.test.ts
@@ -1,12 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Hex } from "../../src/core/hex";
+import { Hex } from "../../src/core";
 import { Secp256k1PrivateKey, Secp256k1PublicKey, Secp256k1Signature } from "../../src/crypto/secp256k1";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { secp256k1TestObject } from "./helper";
-import { Serializer } from "../../src/bcs/serializer";
-import { Deserializer } from "../../src/bcs/deserializer";
+import { Deserializer, Serializer } from "../../src";
 
 describe("Secp256k1PublicKey", () => {
   it("should create the instance correctly without error", () => {

--- a/tests/unit/serializer.test.ts
+++ b/tests/unit/serializer.test.ts
@@ -1,7 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { error } from "console";
 import {
   MAX_U128_BIG_INT,
   MAX_U16_NUMBER,
@@ -10,7 +9,7 @@ import {
   MAX_U8_NUMBER,
   MAX_U256_BIG_INT,
 } from "../../src/bcs/consts";
-import { Serializable, Serializer, ensureBoolean, outOfRangeErrorMessage } from "../../src/bcs/serializer";
+import { Serializable, Serializer, ensureBoolean, outOfRangeErrorMessage } from "../../src";
 import { AccountAddress } from "../../src/core";
 
 describe("BCS Serializer", () => {

--- a/tests/unit/transaction_builder.test.ts
+++ b/tests/unit/transaction_builder.test.ts
@@ -1,8 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig } from "../../src";
-import { Deserializer } from "../../src/bcs";
+import { AptosConfig, Deserializer, Network } from "../../src";
 import { Account } from "../../src/core/account";
 import { Ed25519PrivateKey } from "../../src/crypto/ed25519";
 import { AccountAuthenticator, AccountAuthenticatorEd25519 } from "../../src/transactions/authenticator/account";
@@ -26,7 +25,6 @@ import {
   signTransaction,
 } from "../../src/transactions/transaction_builder/transaction_builder";
 import { SigningScheme } from "../../src/types";
-import { Network } from "../../src/utils/apiEndpoints";
 import { SignedTransaction } from "../../src/transactions/instances/signedTransaction";
 import { U64 } from "../../src/bcs/serializable/move-primitives";
 import { MoveObject } from "../../src/bcs/serializable/move-structs";

--- a/tests/unit/type_tag.test.ts
+++ b/tests/unit/type_tag.test.ts
@@ -18,7 +18,7 @@ import {
   TypeTagU8,
   TypeTagVector,
 } from "../../src/transactions/typeTag/typeTag";
-import { Deserializer, Serializer } from "../../src/bcs";
+import { Deserializer, Serializer } from "../../src";
 import { AccountAddress, AddressInvalidReason, ParsingError } from "../../src/core";
 
 const expectedTypeTag = {


### PR DESCRIPTION
### Description
We export many of our types and functions up to the top level, which is where all of them should be in the end for the SDK. This is a good way to view the user experience when using the SDK.

### Test Plan
```
pnpm fmt && pnpm lint && pnpm test
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->