### PR TITLE
Add transaction query tests

### DIFF
--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -27,7 +27,7 @@ export class Transaction {
    *
    * @returns Array of on-chain transactions
    */
-  async getTransactions(args: { options?: PaginationArgs }): Promise<TransactionResponse[]> {
+  async getTransactions(args?: { options?: PaginationArgs }): Promise<TransactionResponse[]> {
     const transactions = await getTransactions({
       aptosConfig: this.config,
       ...args,

--- a/tests/e2e/api/transaction.test.ts
+++ b/tests/e2e/api/transaction.test.ts
@@ -1,7 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig, Aptos, Network } from "../../../src";
+import { AptosConfig, Aptos, Network, Account } from "../../../src";
+import { U64 } from "../../../src/bcs/serializable/move-primitives";
+import { SigningScheme, TransactionResponse, UserTransactionResponse } from "../../../src/types";
+
+// use it here since all tests use the same configuration
+const config = new AptosConfig({ network: Network.LOCAL });
+const aptos = new Aptos(config);
 
 describe("transaction api", () => {
   test("it queries for the network estimated gas price", async () => {
@@ -13,7 +19,72 @@ describe("transaction api", () => {
     expect(data).toHaveProperty("prioritized_gas_estimate");
   });
 
-  test("it queries for transactions on the chain", async () => {
-    // TODO - add tests once transaction submission is in
+  test("returns true when transaction is pending", async () => {
+    const senderAccount = Account.generate({ scheme: SigningScheme.Ed25519 });
+    await aptos.fundAccount({ accountAddress: senderAccount.accountAddress.toString(), amount: 1000000000 });
+    const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
+    const rawTxn = await aptos.generateTransaction({
+      sender: senderAccount.accountAddress.toString(),
+      data: {
+        function: "0x1::aptos_account::transfer",
+        type_arguments: [],
+        arguments: [bob.accountAddress, new U64(10)],
+      },
+    });
+    const authenticator = aptos.signTransaction({
+      signer: senderAccount,
+      transaction: rawTxn,
+    });
+    const response = await aptos.submitTransaction({
+      transaction: rawTxn,
+      senderAuthenticator: authenticator,
+    });
+    const isPending = await aptos.isPendingTransaction({ txnHash: response.hash });
+    expect(isPending).toBeTruthy();
+  });
+
+  describe("fetch transaction queries", () => {
+    let txn: TransactionResponse;
+    beforeAll(async () => {
+      const senderAccount = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: senderAccount.accountAddress.toString(), amount: 1000000000 });
+      const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
+      const rawTxn = await aptos.generateTransaction({
+        sender: senderAccount.accountAddress.toString(),
+        data: {
+          function: "0x1::aptos_account::transfer",
+          type_arguments: [],
+          arguments: [bob.accountAddress, new U64(10)],
+        },
+      });
+      const authenticator = aptos.signTransaction({
+        signer: senderAccount,
+        transaction: rawTxn,
+      });
+      const response = await aptos.submitTransaction({
+        transaction: rawTxn,
+        senderAuthenticator: authenticator,
+      });
+      txn = await aptos.waitForTransaction({ txnHash: response.hash });
+    });
+
+    test("it queries for transactions on the chain", async () => {
+      const transactions = await aptos.getTransactions();
+      expect(transactions.length).toBeGreaterThan(0);
+    });
+
+    test("it queries for transactions by version", async () => {
+      const transaction = await aptos.getTransactionByVersion({
+        txnVersion: Number((txn as UserTransactionResponse).version),
+      });
+      expect(transaction).toStrictEqual(txn);
+    });
+
+    test("it queries for transactions by hash", async () => {
+      const transaction = await aptos.getTransactionByHash({
+        txnHash: (txn as UserTransactionResponse).hash,
+      });
+      expect(transaction).toStrictEqual(txn);
+    });
   });
 });


### PR DESCRIPTION
### Description
Add missing transaction query test, a better test framework to come after
https://aptos-org.slack.com/archives/C04339KQNUC/p1697063710300629

### Test Plan
```
transaction api
    ✓ it queries for the network estimated gas price (40 ms)
    ✓ returns true when transaction is pending (739 ms)
    fetch transaction queries
      ✓ it queries for transactions on the chain (34 ms)
      ✓ it queries for transactions by version (10 ms)
      ✓ it queries for transactions by hash (9 ms)
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->