### PR TITLE
[exports] Add more exports to allow using the SDK

### DIFF
--- a/src/bcs/index.ts
+++ b/src/bcs/index.ts
@@ -3,3 +3,4 @@
 
 export * from "./deserializer";
 export * from "./serializer";
+export * from "./serializable/move-primitives";

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,3 +6,6 @@ export * from "./api";
 export * from "./client";
 export * from "./utils/apiEndpoints";
 export * from "./bcs";
+export * from "./types";
+export * from "./transactions/types";
+export * from "./transactions/typeTag/typeTag";


### PR DESCRIPTION
### Description
As part of the external examples, adding the exports as the unit tests can't catch that these exports aren't visible outside

### Test Plan
I have two example PRs that are upcoming and dependent on this

### Related Links
<!-- Please link to any relevant issues or pull requests! -->