### PR TITLE
Use local network with tests

### DIFF
--- a/src/utils/apiEndpoints.ts
+++ b/src/utils/apiEndpoints.ts
@@ -5,6 +5,7 @@ export const NetworkToIndexerAPI: Record<string, string> = {
   mainnet: "https://indexer.mainnet.aptoslabs.com/v1/graphql",
   testnet: "https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql",
   devnet: "https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql",
+  local: "http://127.0.0.1:8090/v1/graphql",
 };
 
 export const NetworkToNodeAPI: Record<string, string> = {

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -4,6 +4,7 @@
 import { Account, Aptos, AptosConfig, Network } from "../../../src";
 import { U64 } from "../../../src/bcs/serializable/move-primitives";
 import { SigningScheme } from "../../../src/types";
+import { sleep } from "../../../src/utils/helpers";
 
 describe("account api", () => {
   const FUND_AMOUNT = 100_000_000;
@@ -111,7 +112,7 @@ describe("account api", () => {
     });
 
     test("it fetches account transactions count", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
       const senderAccount = Account.generate({ scheme: SigningScheme.Ed25519 });
       const response = await aptos.fundAccount({
@@ -127,7 +128,7 @@ describe("account api", () => {
     });
 
     test("it fetches account coins data", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
       const senderAccount = Account.generate({ scheme: SigningScheme.Ed25519 });
       const response = await aptos.fundAccount({
@@ -136,6 +137,8 @@ describe("account api", () => {
       });
 
       await aptos.waitForTransaction({ txnHash: response });
+      // to help with indexer latency
+      await sleep(1000);
       const accountCoinData = await aptos.getAccountCoinsData({
         accountAddress: senderAccount.accountAddress.toString(),
       });
@@ -144,7 +147,7 @@ describe("account api", () => {
     });
 
     test("it fetches account coins count", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
       const senderAccount = Account.generate({ scheme: SigningScheme.Ed25519 });
       const response = await aptos.fundAccount({

--- a/tests/e2e/api/coin.test.ts
+++ b/tests/e2e/api/coin.test.ts
@@ -3,10 +3,11 @@ import { waitForTransaction } from "../../../src/internal/transaction";
 import { RawTransaction, TransactionPayloadEntryFunction } from "../../../src/transactions/instances";
 import { TypeTagStruct } from "../../../src/transactions/typeTag/typeTag";
 import { SigningScheme } from "../../../src/types";
+import { sleep } from "../../../src/utils/helpers";
 
 describe("coin", () => {
   test("it generates a transfer coin transaction with AptosCoin coin type", async () => {
-    const config = new AptosConfig({ network: Network.DEVNET });
+    const config = new AptosConfig({ network: Network.LOCAL });
     const aptos = new Aptos(config);
     const sender = Account.generate({ scheme: SigningScheme.Ed25519 });
     const recipient = Account.generate({ scheme: SigningScheme.Ed25519 });
@@ -27,7 +28,7 @@ describe("coin", () => {
   });
 
   test("it generates a transfer coin transaction with a custom coin type", async () => {
-    const config = new AptosConfig({ network: Network.DEVNET });
+    const config = new AptosConfig({ network: Network.LOCAL });
     const aptos = new Aptos(config);
     const sender = Account.generate({ scheme: SigningScheme.Ed25519 });
     const recipient = Account.generate({ scheme: SigningScheme.Ed25519 });
@@ -49,7 +50,7 @@ describe("coin", () => {
   });
 
   test("it transfers APT coin aomunt from sender to recipient", async () => {
-    const config = new AptosConfig({ network: Network.DEVNET });
+    const config = new AptosConfig({ network: Network.LOCAL });
     const aptos = new Aptos(config);
     const sender = Account.generate({ scheme: SigningScheme.Ed25519 });
     const recipient = Account.generate({ scheme: SigningScheme.Ed25519 });
@@ -65,7 +66,8 @@ describe("coin", () => {
     const response = await aptos.signAndSubmitTransaction({ signer: sender, transaction });
 
     await waitForTransaction({ aptosConfig: config, txnHash: response.hash });
-
+    // to help with indexer latency
+    await sleep(1000);
     const recipientCoins = await aptos.getAccountCoinsData({ accountAddress: recipient.accountAddress.toString() });
     const senderCoinsAfter = await aptos.getAccountCoinsData({ accountAddress: sender.accountAddress.toString() });
 

--- a/tests/e2e/api/transaction_submission.test.ts
+++ b/tests/e2e/api/transaction_submission.test.ts
@@ -4,6 +4,7 @@
 import { Account, AptosConfig, Ed25519PrivateKey, Network, Aptos, Deserializer } from "../../../src";
 import { U64 } from "../../../src/bcs/serializable/move-primitives";
 import { MoveObject } from "../../../src/bcs/serializable/move-structs";
+import { waitForTransaction } from "../../../src/internal/transaction";
 import { AccountAuthenticator, AccountAuthenticatorEd25519 } from "../../../src/transactions/authenticator/account";
 import { RawTransaction } from "../../../src/transactions/instances";
 import {
@@ -16,13 +17,10 @@ import { SigningScheme } from "../../../src/types";
 describe("transaction submission", () => {
   describe("generateTransaction", () => {
     test("it generates a script transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
         data: {
@@ -39,13 +37,10 @@ describe("transaction submission", () => {
     });
 
     test("it generates a multi sig transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
@@ -64,13 +59,10 @@ describe("transaction submission", () => {
     });
 
     test("it generates an entry function transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
@@ -89,18 +81,12 @@ describe("transaction submission", () => {
   });
   describe("simulateTransaction", () => {
     test("it simulates a multi agent script transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
-      const bob = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0xc1e06f150f7fa79c1ca0ad0f8d0b26d83abaf1bed0fc31de24b500d81a2ff924",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
+      const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: bob.accountAddress.toString(), amount: 1000000000 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
         secondarySignerAddresses: [bob.accountAddress.toString()],
@@ -128,13 +114,10 @@ describe("transaction submission", () => {
   });
   describe("signTransaction", () => {
     test("it signs a script transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
         data: {
@@ -154,13 +137,10 @@ describe("transaction submission", () => {
     });
 
     test("it signs a multi sig transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
@@ -182,13 +162,10 @@ describe("transaction submission", () => {
     });
 
     test("it signs an entry function transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
@@ -210,18 +187,12 @@ describe("transaction submission", () => {
   });
   describe("submitTransaction", () => {
     test("it submits a script transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
-      const bob = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0xc1e06f150f7fa79c1ca0ad0f8d0b26d83abaf1bed0fc31de24b500d81a2ff924",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
+      const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: bob.accountAddress.toString(), amount: 1000000000 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
         secondarySignerAddresses: [bob.accountAddress.toString()],
@@ -253,25 +224,14 @@ describe("transaction submission", () => {
           additionalSignersAuthenticators: [bobauthenticator],
         },
       });
-      expect(response).toHaveProperty("hash");
+      await waitForTransaction({ aptosConfig: config, txnHash: response.hash });
     });
 
-    // Currently this test fails because we don't wait for the previous transaction to be executed
-    // and we end up with transaction is already in mempool. This is because we are still missing
-    // waitForTransaction query and/or the fund query (so we can create an account and then fund it
-    // to create it on chain) - Anyhow, I tested each test individually and it works.
-    // The whole test flow should work once we have the option to wait for transaction and/or fund
-    // an account to create it on chain
-    // FIXME: Fix this test
-    /*test("it submits an entry function transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
+    test("it submits an entry function transaction", async () => {
+      const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput:
-            "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const rawTxn = await aptos.generateTransaction({
         sender: alice.accountAddress.toString(),
@@ -289,7 +249,7 @@ describe("transaction submission", () => {
         transaction: rawTxn,
         senderAuthenticator: authenticator,
       });
-      expect(response).toHaveProperty("hash");
-    });*/
+      await waitForTransaction({ aptosConfig: config, txnHash: response.hash });
+    });
   });
 });

--- a/tests/unit/aptos_config.test.ts
+++ b/tests/unit/aptos_config.test.ts
@@ -14,7 +14,7 @@ describe("aptos config", () => {
     expect(aptosConfig.network).toEqual("local");
     expect(aptosConfig.getRequestUrl(AptosApiType.FULLNODE)).toBe(NetworkToNodeAPI[Network.LOCAL]);
     expect(aptosConfig.getRequestUrl(AptosApiType.FAUCET)).toBe(NetworkToFaucetAPI[Network.LOCAL]);
-    expect(aptosConfig.getRequestUrl(AptosApiType.INDEXER)).toBeUndefined();
+    expect(aptosConfig.getRequestUrl(AptosApiType.INDEXER)).toBe(NetworkToIndexerAPI[Network.LOCAL]);
   });
 
   test("it should set urls based on a given network", async () => {

--- a/tests/unit/transaction_builder.test.ts
+++ b/tests/unit/transaction_builder.test.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account, AptosConfig, Deserializer, Ed25519PrivateKey, Network } from "../../src";
+import { Account, Aptos, AptosConfig, Deserializer, Ed25519PrivateKey, Network } from "../../src";
 import { AccountAuthenticator, AccountAuthenticatorEd25519 } from "../../src/transactions/authenticator/account";
 import {
   FeePayerRawTransaction,
@@ -62,12 +62,10 @@ describe("transaction builder", () => {
   });
   describe("generate raw transaction", () => {
     test("it generates a raw transaction with script payload", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
@@ -90,12 +88,10 @@ describe("transaction builder", () => {
     });
 
     test("it generates a raw transaction with a multi sig payload", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         multisigAddress: bob.accountAddress,
@@ -113,12 +109,10 @@ describe("transaction builder", () => {
     });
 
     test("it generates a raw transaction with an entry function payload", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
@@ -136,12 +130,10 @@ describe("transaction builder", () => {
   });
   describe("generate transaction", () => {
     test("it returns a serialized raw transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
@@ -165,12 +157,10 @@ describe("transaction builder", () => {
     });
 
     test("it returns a serialized raw transaction and secondary signers addresses", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
@@ -196,12 +186,10 @@ describe("transaction builder", () => {
     });
 
     test("it returns a serialized raw transaction and a fee payer address", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
@@ -222,12 +210,10 @@ describe("transaction builder", () => {
     });
 
     test("it returns a serialized raw transaction, secondary signers addresses and a fee payer address", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
@@ -257,12 +243,10 @@ describe("transaction builder", () => {
   });
   describe("generateSignedTransactionForSimulation", () => {
     test("it generates a signed raw transaction for simulation", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
@@ -293,12 +277,10 @@ describe("transaction builder", () => {
   });
   describe("sign", () => {
     test("it signs a raw transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
@@ -327,12 +309,10 @@ describe("transaction builder", () => {
     });
 
     test("it signs a fee payer transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         multisigAddress: bob.accountAddress,
@@ -359,12 +339,10 @@ describe("transaction builder", () => {
     });
 
     test("it signs a multi agent transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         bytecode:
@@ -396,12 +374,10 @@ describe("transaction builder", () => {
   });
   describe("generateSignedTransaction", () => {
     test("it generates a single signer signed transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
@@ -431,12 +407,10 @@ describe("transaction builder", () => {
     });
 
     test("it generates a multi agent signed transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.fromPrivateKey({
         privateKey: new Ed25519PrivateKey({
           hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
@@ -472,12 +446,10 @@ describe("transaction builder", () => {
     });
 
     test("it generates a fee payer signed transaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
@@ -510,12 +482,10 @@ describe("transaction builder", () => {
   });
   describe("deriveTransactionType", () => {
     test("it derieves the transaction type as a RawTransaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
@@ -532,12 +502,10 @@ describe("transaction builder", () => {
     });
 
     test("it derieves the transaction type as a FeePayerRawTransaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
@@ -558,12 +526,10 @@ describe("transaction builder", () => {
     });
 
     test("it derieves the transaction type as a MultiAgentRawTransaction", async () => {
-      const config = new AptosConfig({ network: Network.DEVNET });
-      const alice = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
-      });
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const alice = Account.generate({ scheme: SigningScheme.Ed25519 });
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: 1000000000 });
       const bob = Account.generate({ scheme: SigningScheme.Ed25519 });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",


### PR DESCRIPTION
### Description
Change tall tests to use local network.
@banool do we need docker in CI?

There is a latency chance when querying indexer right after we submit a transaction, therefore adding `sleep(100)` - can think about a different approach for our test framework we want to have or in a following PR.

### Test Plan
```
 PASS  tests/unit/account.test.ts
 PASS  tests/unit/ed25519.test.ts
 PASS  tests/e2e/api/general.test.ts
 PASS  tests/e2e/api/faucet.test.ts
 PASS  tests/unit/memoize.test.ts
 PASS  tests/unit/secp256k1.test.ts
 PASS  tests/unit/bcs-helper.test.ts
 PASS  tests/unit/aptos_config.test.ts
 PASS  tests/unit/multi_ed25519.test.ts
 PASS  tests/unit/type_tag.test.ts
 PASS  tests/unit/account_address.test.ts
 PASS  tests/unit/serializer.test.ts
 PASS  tests/unit/script_transaction_arguments.test.ts
 PASS  tests/unit/hex.test.ts
 PASS  tests/unit/authentication_key.test.ts
 PASS  tests/unit/deserializer.test.ts
 PASS  tests/e2e/api/transaction.test.ts (5.712 s)
 PASS  tests/e2e/api/coin.test.ts (7.394 s)
 PASS  tests/e2e/api/account.test.ts (9.325 s)
 PASS  tests/e2e/api/transaction_submission.test.ts (10.225 s)
 PASS  tests/unit/transaction_builder.test.ts (13.372 s)
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->