### PR TITLE
Run the indexer API with the local testnet in the E2E tests

### DIFF
--- a/.github/actions/run-e2e-tests/action.yaml
+++ b/.github/actions/run-e2e-tests/action.yaml
@@ -27,20 +27,16 @@ runs:
       shell: bash
 
     # Run a local testnet in the background.
-    - run: aptos node run-local-testnet --force-restart --assume-yes --with-faucet &
+    - run: aptos node run-local-testnet --force-restart --assume-yes --with-indexer-api &
       shell: bash
-
-    # Use this instead when the new CLI lands.
-    # - run: aptos node run-local-testnet --force-restart --assume-yes --with-indexer-api &
 
     # Wait for the local testnet to be ready by hitting the readiness endpoint.
+    # We give it a while because the CLI will have to download some images before
+    # actually running the local testnet, which can take a while.
     - run: pnpm install -g wait-on
       shell: bash
-    - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8081
+    - run: wait-on -t 120000 --httpTimeout 120000 http-get://127.0.0.1:8070
       shell: bash
-
-    # Use this instead when the new CLI lands.
-    # - run: wait-on -t 60000 --httpTimeout 60000 http-get://127.0.0.1:8070
 
     # Run the TS SDK tests.
     - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2


### PR DESCRIPTION
### Description
This will let us have E2E tests that rely on the indexer API being present.

### Test Plan
See that CI passes.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->