### PR TITLE
[typeTag] Fix nested struct tag consumption

### DIFF
--- a/src/transactions/typeTag/typeTag.ts
+++ b/src/transactions/typeTag/typeTag.ts
@@ -279,8 +279,9 @@ export class TypeTagParser {
       // If it is nested, we have to consume another nested generic
       if (this.tokens[0][1] === "<") {
         this.consumeWholeGeneric();
+      } else {
+        this.tokens.shift();
       }
-      this.tokens.shift();
     }
     this.consume(">");
   }

--- a/tests/unit/type_tag.test.ts
+++ b/tests/unit/type_tag.test.ts
@@ -124,7 +124,7 @@ describe("TypeTagParser", () => {
       expect(result instanceof TypeTagAddress).toBeTruthy();
 
       const typeTag2 = "0x1::object::Object<0x1::coin::Fun<A, B<C>>>";
-      const parser2 = new TypeTagParser(typeTag);
+      const parser2 = new TypeTagParser(typeTag2);
       const result2 = parser2.parseTypeTag();
       expect(result2 instanceof TypeTagAddress).toBeTruthy();
     });


### PR DESCRIPTION
### Description
The previous code would double consume a nested type.  For example:

`A<B<C>>` Would consume `A<B<C>` and then skip over the last `>` which then made it crash.

### Test Plan
`pnpm test`

### Related Links
Mirror of https://github.com/aptos-labs/aptos-core/pull/10484