### PR TITLE
Show local testnet logs on failure, free up needed ports

### DIFF
--- a/.github/actions/run-e2e-tests/action.yaml
+++ b/.github/actions/run-e2e-tests/action.yaml
@@ -26,8 +26,24 @@ runs:
     - run: pnpm install -g @aptos-labs/aptos-cli
       shell: bash
 
+    # Kill anything running on ports we need. This is what GH recommends, see more:
+    # https://github.com/actions/runner-images/issues/2820#issuecomment-790367908
+    # Eventually we'll make it possible for the CLI to do this itself.
+    - run: |
+        declare -a PORTS=("8080" "8081" "8070" "8090" "43234" "43235" "43236" "43237" "43238" "43239" "43240" "43241" "43242" "43243" "43244" "43245" "43246" "43247" "43248" "43249" "50051" "50052")
+        for PORT in "${PORTS[@]}"; do
+          PID=$(sudo lsof -t -i:$PORT) || true
+          if [ -z "$PID" ]; then
+            echo "Nothing running on port $PORT that we have to kill"
+            continue
+          fi
+          sudo kill -9 $PID || true
+          echo "Killed process $PID running on port $PORT"
+        done
+      shell: bash
+
     # Run a local testnet in the background.
-    - run: aptos node run-local-testnet --force-restart --assume-yes --with-indexer-api &
+    - run: aptos node run-local-testnet --force-restart --assume-yes --with-indexer-api --log-to-stdout >& ${{ runner.temp }}/local-testnet-logs.txt &
       shell: bash
 
     # Wait for the local testnet to be ready by hitting the readiness endpoint.
@@ -35,7 +51,7 @@ runs:
     # actually running the local testnet, which can take a while.
     - run: pnpm install -g wait-on
       shell: bash
-    - run: wait-on -t 120000 --httpTimeout 120000 http-get://127.0.0.1:8070
+    - run: wait-on --verbose --interval 1500 --timeout 120000 --httpTimeout 120000 http-get://127.0.0.1:8070
       shell: bash
 
     # Run the TS SDK tests.
@@ -50,3 +66,8 @@ runs:
         max_attempts: 3
         timeout_minutes: 25
         command: pnpm run test
+
+    - name: Print local testnet logs on failure
+      shell: bash
+      if: failure()
+      run: cat ${{ runner.temp }}/local-testnet-logs.txt


### PR DESCRIPTION
### Description
This works until we come up with a solution in the CLI. Nothing running on the ports we kill is essential to the functioning of the runner.

### Test Plan
CI.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->