### PR TITLE
[lint] Fixes a bad code pattern

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -4,21 +4,21 @@
 import { AptosConfig } from "./aptos_config";
 import {
   AccountData,
+  GetAccountCoinsDataResponse,
+  GetAccountCollectionsWithOwnedTokenResponse,
+  GetAccountOwnedObjectsResponse,
+  GetAccountOwnedTokensFromCollectionResponse,
+  GetAccountOwnedTokensQueryResponse,
+  HexInput,
+  IndexerPaginationArgs,
   LedgerVersion,
   MoveModuleBytecode,
   MoveResource,
   MoveResourceType,
-  PaginationArgs,
-  TransactionResponse,
-  HexInput,
-  IndexerPaginationArgs,
-  TokenStandard,
   OrderBy,
-  GetAccountOwnedTokensQueryResponse,
-  GetAccountCollectionsWithOwnedTokenResponse,
-  GetAccountCoinsDataResponse,
-  GetAccountOwnedObjectsResponse,
-  GetAccountOwnedTokensFromCollectionResponse,
+  PaginationArgs,
+  TokenStandard,
+  TransactionResponse,
 } from "../types";
 import {
   getAccountCoinsCount,
@@ -65,8 +65,7 @@ export class Account {
    * ```
    */
   async getAccountInfo(args: { accountAddress: HexInput }): Promise<AccountData> {
-    const data = await getInfo({ aptosConfig: this.config, ...args });
-    return data;
+    return getInfo({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -83,8 +82,7 @@ export class Account {
     accountAddress: HexInput;
     options?: PaginationArgs & LedgerVersion;
   }): Promise<MoveModuleBytecode[]> {
-    const modules = await getModules({ aptosConfig: this.config, ...args });
-    return modules;
+    return getModules({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -108,8 +106,7 @@ export class Account {
     moduleName: string;
     options?: LedgerVersion;
   }): Promise<MoveModuleBytecode> {
-    const module = await getModule({ aptosConfig: this.config, ...args });
-    return module;
+    return getModule({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -126,11 +123,10 @@ export class Account {
     accountAddress: HexInput;
     options?: PaginationArgs;
   }): Promise<TransactionResponse[]> {
-    const transactions = await getTransactions({
+    return getTransactions({
       aptosConfig: this.config,
       ...args,
     });
-    return transactions;
   }
 
   /**
@@ -146,8 +142,7 @@ export class Account {
     accountAddress: HexInput;
     options?: PaginationArgs & LedgerVersion;
   }): Promise<MoveResource[]> {
-    const resources = await getResources({ aptosConfig: this.config, ...args });
-    return resources;
+    return getResources({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -171,8 +166,7 @@ export class Account {
     resourceType: MoveResourceType;
     options?: LedgerVersion;
   }): Promise<MoveResource> {
-    const resource = await getResource({ aptosConfig: this.config, ...args });
-    return resource;
+    return getResource({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -185,8 +179,7 @@ export class Account {
     authenticationKey: HexInput;
     options?: LedgerVersion;
   }): Promise<AccountAddress> {
-    const address = await lookupOriginalAccountAddress({ aptosConfig: this.config, ...args });
-    return address;
+    return lookupOriginalAccountAddress({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -196,11 +189,10 @@ export class Account {
    * @returns An object { count : number }
    */
   async getAccountTokensCount(args: { accountAddress: HexInput }): Promise<number> {
-    const count = await getAccountTokensCount({
+    return getAccountTokensCount({
       aptosConfig: this.config,
       ...args,
     });
-    return count;
   }
 
   /**
@@ -220,11 +212,10 @@ export class Account {
       orderBy?: OrderBy<GetAccountOwnedTokensQueryResponse[0]>;
     };
   }): Promise<GetAccountOwnedTokensQueryResponse> {
-    const tokens = await getAccountOwnedTokens({
+    return getAccountOwnedTokens({
       aptosConfig: this.config,
       ...args,
     });
-    return tokens;
   }
 
   /**
@@ -246,11 +237,10 @@ export class Account {
       orderBy?: OrderBy<GetAccountOwnedTokensFromCollectionResponse[0]>;
     };
   }): Promise<GetAccountOwnedTokensFromCollectionResponse> {
-    const tokens = await getAccountOwnedTokensFromCollectionAddress({
+    return getAccountOwnedTokensFromCollectionAddress({
       aptosConfig: this.config,
       ...args,
     });
-    return tokens;
   }
 
   /**
@@ -270,11 +260,10 @@ export class Account {
       orderBy?: OrderBy<GetAccountCollectionsWithOwnedTokenResponse[0]>;
     };
   }): Promise<GetAccountCollectionsWithOwnedTokenResponse> {
-    const collections = await getAccountCollectionsWithOwnedTokens({
+    return getAccountCollectionsWithOwnedTokens({
       aptosConfig: this.config,
       ...args,
     });
-    return collections;
   }
 
   /**
@@ -284,11 +273,10 @@ export class Account {
    * @returns An object { count : number }
    */
   async getAccountTransactionsCount(args: { accountAddress: HexInput }): Promise<number> {
-    const count = getAccountTransactionsCount({
+    return getAccountTransactionsCount({
       aptosConfig: this.config,
       ...args,
     });
-    return count;
   }
 
   /**
@@ -304,11 +292,10 @@ export class Account {
       orderBy?: OrderBy<GetAccountCoinsDataResponse[0]>;
     };
   }): Promise<GetAccountCoinsDataResponse> {
-    const data = await getAccountCoinsData({
+    return getAccountCoinsData({
       aptosConfig: this.config,
       ...args,
     });
-    return data;
   }
 
   /**
@@ -318,8 +305,7 @@ export class Account {
    * @returns An object { count : number } where `number` is the aggregated count of all account's coin
    */
   async getAccountCoinsCount(args: { accountAddress: HexInput }): Promise<number> {
-    const count = getAccountCoinsCount({ aptosConfig: this.config, ...args });
-    return count;
+    return getAccountCoinsCount({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -335,10 +321,9 @@ export class Account {
       orderBy?: OrderBy<GetAccountOwnedObjectsResponse[0]>;
     };
   }): Promise<GetAccountOwnedObjectsResponse> {
-    const objects = getAccountOwnedObjects({
+    return getAccountOwnedObjects({
       aptosConfig: this.config,
       ...args,
     });
-    return objects;
   }
 }

--- a/src/api/coin.ts
+++ b/src/api/coin.ts
@@ -34,7 +34,6 @@ export class Coin {
     coinType?: MoveResourceType;
     options?: GenerateTransactionOptions;
   }): Promise<SingleSignerTransaction> {
-    const response = await transferCoinTransaction({ aptosConfig: this.config, ...args });
-    return response;
+    return transferCoinTransaction({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/collection.ts
+++ b/src/api/collection.ts
@@ -32,8 +32,7 @@ export class Collection {
       tokenStandard?: TokenStandard;
     };
   }): Promise<GetCollectionDataResponse> {
-    const data = await getCollectionData({ aptosConfig: this.config, ...args });
-    return data;
+    return getCollectionData({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -50,7 +49,6 @@ export class Collection {
       tokenStandard?: TokenStandard;
     };
   }): Promise<string> {
-    const data = await getCollectionAddress({ aptosConfig: this.config, ...args });
-    return data;
+    return getCollectionAddress({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -23,7 +23,6 @@ export class Event {
    * @returns Promise<GetEventsByCreationNumberResponse>
    */
   async getEventsByCreationNumber(args: { address: string; creationNumber: AnyNumber }): Promise<GetEventsResponse> {
-    const data = await getEventsByCreationNumber({ aptosConfig: this.config, ...args });
-    return data;
+    return getEventsByCreationNumber({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/faucet.ts
+++ b/src/api/faucet.ts
@@ -25,7 +25,6 @@ export class Faucet {
    * @returns Hashes of submitted transactions
    */
   async fundAccount(args: { accountAddress: HexInput; amount: number; timeoutSecs?: number }): Promise<string> {
-    const txnStrings = await fundAccount({ aptosConfig: this.config, ...args });
-    return txnStrings;
+    return fundAccount({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -53,8 +53,7 @@ export class General {
    * ```
    */
   async getLedgerInfo(): Promise<LedgerInfo> {
-    const data = await getLedgerInfo({ aptosConfig: this.config });
-    return data;
+    return getLedgerInfo({ aptosConfig: this.config });
   }
 
   /**
@@ -76,11 +75,10 @@ export class General {
    * @returns Block
    */
   async getBlockByVersion(args: { blockVersion: number; options?: { withTransactions?: boolean } }): Promise<Block> {
-    const block = await getBlockByVersion({
+    return getBlockByVersion({
       aptosConfig: this.config,
       ...args,
     });
-    return block;
   }
 
   /**
@@ -92,8 +90,7 @@ export class General {
    * @returns Block
    */
   async getBlockByHeight(args: { blockHeight: number; options?: { withTransactions?: boolean } }): Promise<Block> {
-    const block = await getBlockByHeight({ aptosConfig: this.config, ...args });
-    return block;
+    return getBlockByHeight({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -112,8 +109,7 @@ export class General {
    * @returns Table item value rendered in JSON
    */
   async getTableItem(args: { handle: string; data: TableItemRequest; options?: LedgerVersion }): Promise<any> {
-    const item = await getTableItem({ aptosConfig: this.config, ...args });
-    return item;
+    return getTableItem({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -170,10 +166,9 @@ export class General {
    * @return The provided T type
    */
   async queryIndexer<T>(args: { query: GraphqlQuery }): Promise<T> {
-    const response = await queryIndexer<T>({
+    return queryIndexer<T>({
       aptosConfig: this.config,
       ...args,
     });
-    return response;
   }
 }

--- a/src/api/staking.ts
+++ b/src/api/staking.ts
@@ -26,8 +26,7 @@ export class Staking {
    * @returns The number of delegators for the given pool
    */
   async getNumberOfDelegators(args: { poolAddress: HexInput }): Promise<number> {
-    const numDelegators = await getNumberOfDelegators({ aptosConfig: this.config, ...args });
-    return numDelegators;
+    return getNumberOfDelegators({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -41,8 +40,7 @@ export class Staking {
       orderBy?: OrderBy<GetNumberOfDelegatorsResponse[0]>;
     };
   }): Promise<GetNumberOfDelegatorsResponse> {
-    const numDelegatorData = await getNumberOfDelegatorsForAllPools({ aptosConfig: this.config, ...args });
-    return numDelegatorData;
+    return getNumberOfDelegatorsForAllPools({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -56,7 +54,6 @@ export class Staking {
     delegatorAddress: HexInput;
     poolAddress: HexInput;
   }): Promise<GetDelegatedStakingActivitiesResponse> {
-    const delegatedStakingActivities = await getDelegatedStakingActivities({ aptosConfig: this.config, ...args });
-    return delegatedStakingActivities;
+    return getDelegatedStakingActivities({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -28,11 +28,10 @@ export class Transaction {
    * @returns Array of on-chain transactions
    */
   async getTransactions(args?: { options?: PaginationArgs }): Promise<TransactionResponse[]> {
-    const transactions = await getTransactions({
+    return getTransactions({
       aptosConfig: this.config,
       ...args,
     });
-    return transactions;
   }
 
   /**
@@ -41,11 +40,10 @@ export class Transaction {
    * function cannot be used to query pending transactions.
    */
   async getTransactionByVersion(args: { txnVersion: AnyNumber }): Promise<TransactionResponse> {
-    const transaction = await getTransactionByVersion({
+    return getTransactionByVersion({
       aptosConfig: this.config,
       ...args,
     });
-    return transaction;
   }
 
   /**
@@ -53,11 +51,10 @@ export class Transaction {
    * @returns Transaction from mempool (pending) or on-chain (committed) transaction
    */
   async getTransactionByHash(args: { txnHash: HexInput }): Promise<TransactionResponse> {
-    const transaction = await getTransactionByHash({
+    return getTransactionByHash({
       aptosConfig: this.config,
       ...args,
     });
-    return transaction;
   }
 
   /**
@@ -73,11 +70,10 @@ export class Transaction {
    * @returns `true` if transaction is in pending state and `false` otherwise
    */
   async isPendingTransaction(args: { txnHash: HexInput }): Promise<boolean> {
-    const isPending = await isTransactionPending({
+    return isTransactionPending({
       aptosConfig: this.config,
       ...args,
     });
-    return isPending;
   }
 
   /**
@@ -106,11 +102,10 @@ export class Transaction {
     txnHash: HexInput;
     extraArgs?: { timeoutSecs?: number; checkSuccess?: boolean };
   }): Promise<TransactionResponse> {
-    const transaction = await waitForTransaction({
+    return waitForTransaction({
       aptosConfig: this.config,
       ...args,
     });
-    return transaction;
   }
 
   /**
@@ -129,9 +124,8 @@ export class Transaction {
    * ```
    */
   async getGasPriceEstimation(): Promise<GasEstimation> {
-    const gasEstimation = getGasPriceEstimation({
+    return getGasPriceEstimation({
       aptosConfig: this.config,
     });
-    return gasEstimation;
   }
 }

--- a/src/api/transaction_submission.ts
+++ b/src/api/transaction_submission.ts
@@ -82,8 +82,7 @@ export class TransactionSubmission {
    * ```
    */
   async generateTransaction(args: GenerateTransactionInput): Promise<AnyRawTransaction> {
-    const transaction = await generateTransaction({ aptosConfig: this.config, ...args });
-    return transaction;
+    return generateTransaction({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -103,8 +102,7 @@ export class TransactionSubmission {
    */
   /* eslint-disable class-methods-use-this */
   signTransaction(args: { signer: Account; transaction: AnyRawTransaction }): AccountAuthenticator {
-    const accountAuthenticator = signTransaction({ ...args });
-    return accountAuthenticator;
+    return signTransaction({ ...args });
   }
 
   /**
@@ -117,8 +115,7 @@ export class TransactionSubmission {
    * @param options optional. A config to simulate the transaction with
    */
   async simulateTransaction(args: SimulateTransactionData): Promise<Array<UserTransactionResponse>> {
-    const data = await simulateTransaction({ aptosConfig: this.config, ...args });
-    return data;
+    return simulateTransaction({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -138,8 +135,7 @@ export class TransactionSubmission {
       additionalSignersAuthenticators?: Array<AccountAuthenticator>;
     };
   }): Promise<PendingTransactionResponse> {
-    const data = await submitTransaction({ aptosConfig: this.config, ...args });
-    return data;
+    return submitTransaction({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -163,11 +159,10 @@ export class TransactionSubmission {
   }): Promise<PendingTransactionResponse> {
     const { signer, transaction } = args;
     const authenticator = signTransaction({ signer, transaction });
-    const response = await submitTransaction({
+    return submitTransaction({
       aptosConfig: this.config,
       transaction,
       senderAuthenticator: authenticator,
     });
-    return response;
   }
 }


### PR DESCRIPTION
### Description
Fixes a bad code pattern that was previously used to avoid a lint.

```
async outer(): Promise<> {
  const ret = await inner();
  return ret;
}
```

is now the below because the inner one doesn't have to be awaited (just passed back out)
```
async outer(): Promise<> {
  return inner();
}
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
CI

### Related Links
<!-- Please link to any relevant issues or pull requests! -->