### PR TITLE
Refactor object as params for single param funcs

### DIFF
--- a/src/bcs/serializable/fixed-bytes.ts
+++ b/src/bcs/serializable/fixed-bytes.ts
@@ -44,7 +44,7 @@ export class FixedBytes extends Serializable implements TransactionArgument {
 
   constructor(value: HexInput) {
     super();
-    this.value = Hex.fromHexInput({ hexInput: value }).toUint8Array();
+    this.value = Hex.fromHexInput(value).toUint8Array();
   }
 
   serialize(serializer: Serializer): void {

--- a/src/bcs/serializable/move-structs.ts
+++ b/src/bcs/serializable/move-structs.ts
@@ -94,7 +94,7 @@ export class MoveVector<T extends Serializable> extends Serializable implements 
     if (Array.isArray(values) && typeof values[0] === "number") {
       numbers = values;
     } else if (typeof values === "string") {
-      const hex = Hex.fromHexInput({ hexInput: values });
+      const hex = Hex.fromHexInput(values);
       numbers = Array.from(hex.toUint8Array());
     } else if (values instanceof Uint8Array) {
       numbers = Array.from(values);

--- a/src/bcs/serializer.ts
+++ b/src/bcs/serializer.ts
@@ -36,7 +36,7 @@ export abstract class Serializable {
    */
   bcsToHex(): Hex {
     const bcsBytes = this.bcsToBytes();
-    return Hex.fromHexInput({ hexInput: bcsBytes });
+    return Hex.fromHexInput(bcsBytes);
   }
 }
 

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -193,7 +193,7 @@ export class Account {
    */
   verifySignature(args: { message: HexInput; signature: Signature }): boolean {
     const { message, signature } = args;
-    const rawMessage = Hex.fromHexInput({ hexInput: message }).toUint8Array();
+    const rawMessage = Hex.fromHexInput(message).toUint8Array();
     return this.publicKey.verifySignature({ message: rawMessage, signature });
   }
 }

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -148,7 +148,7 @@ export class Account {
       .join(" ");
 
     const { key } = derivePath(path, bytesToHex(bip39.mnemonicToSeedSync(normalizeMnemonics)));
-    const privateKey = new Ed25519PrivateKey({ hexInput: key });
+    const privateKey = new Ed25519PrivateKey(key);
     return Account.fromPrivateKey({ privateKey });
   }
 
@@ -176,11 +176,11 @@ export class Account {
    *
    * TODO: Add sign transaction or specific types
    *
-   * @param args.data in HexInput format
+   * @param data in HexInput format
    * @returns Signature
    */
-  sign(args: { data: HexInput }): Signature {
-    const signature = this.privateKey.sign({ message: args.data });
+  sign(data: HexInput): Signature {
+    const signature = this.privateKey.sign(data);
     return signature;
   }
 

--- a/src/core/authentication_key.ts
+++ b/src/core/authentication_key.ts
@@ -32,7 +32,7 @@ export class AuthenticationKey {
 
   constructor(args: { data: HexInput }) {
     const { data } = args;
-    const hex = Hex.fromHexInput({ hexInput: data });
+    const hex = Hex.fromHexInput(data);
     if (hex.toUint8Array().length !== AuthenticationKey.LENGTH) {
       throw new Error(`Authentication Key length should be ${AuthenticationKey.LENGTH}`);
     }
@@ -55,7 +55,7 @@ export class AuthenticationKey {
    */
   private static fromBytesAndScheme(args: { bytes: HexInput; scheme: AuthenticationKeyScheme }) {
     const { bytes, scheme } = args;
-    const inputBytes = Hex.fromHexInput({ hexInput: bytes }).toUint8Array();
+    const inputBytes = Hex.fromHexInput(bytes).toUint8Array();
     const authKeyBytes = new Uint8Array(inputBytes.length + 1);
     authKeyBytes.set(inputBytes);
     authKeyBytes.set([scheme], inputBytes.length);

--- a/src/core/crypto/asymmetric_crypto.ts
+++ b/src/core/crypto/asymmetric_crypto.ts
@@ -37,7 +37,7 @@ export abstract class PrivateKey extends Serializable {
    * Sign a message with the key
    * @param args
    */
-  abstract sign(args: { message: HexInput }): Signature;
+  abstract sign(message: HexInput): Signature;
 
   /**
    * Get the raw private key bytes

--- a/src/core/crypto/ed25519.ts
+++ b/src/core/crypto/ed25519.ts
@@ -28,10 +28,10 @@ export class Ed25519PublicKey extends PublicKey {
    *
    * @param args.hexInput A HexInput (string or Uint8Array)
    */
-  constructor(args: { hexInput: HexInput }) {
+  constructor(hexInput: HexInput) {
     super();
 
-    const hex = Hex.fromHexInput(args);
+    const hex = Hex.fromHexInput(hexInput);
     if (hex.toUint8Array().length !== Ed25519PublicKey.LENGTH) {
       throw new Error(`PublicKey length should be ${Ed25519PublicKey.LENGTH}`);
     }
@@ -64,9 +64,7 @@ export class Ed25519PublicKey extends PublicKey {
   verifySignature(args: { message: HexInput; signature: Ed25519Signature }): boolean {
     const { message, signature } = args;
     const rawMessage = Hex.fromHexInput(message).toUint8Array();
-    const rawSignature = Hex.fromHexInput({
-      hexInput: signature.toUint8Array(),
-    }).toUint8Array();
+    const rawSignature = Hex.fromHexInput(signature.toUint8Array()).toUint8Array();
     return nacl.sign.detached.verify(rawMessage, rawSignature, this.key.toUint8Array());
   }
 
@@ -76,7 +74,7 @@ export class Ed25519PublicKey extends PublicKey {
 
   static deserialize(deserializer: Deserializer): Ed25519PublicKey {
     const bytes = deserializer.deserializeBytes();
-    return new Ed25519PublicKey({ hexInput: bytes });
+    return new Ed25519PublicKey(bytes);
   }
 }
 
@@ -100,10 +98,10 @@ export class Ed25519PrivateKey extends PrivateKey {
    *
    * @param args.hexInput HexInput (string or Uint8Array)
    */
-  constructor(args: { hexInput: HexInput }) {
+  constructor(hexInput: HexInput) {
     super();
 
-    const privateKeyHex = Hex.fromHexInput(args);
+    const privateKeyHex = Hex.fromHexInput(hexInput);
     if (privateKeyHex.toUint8Array().length !== Ed25519PrivateKey.LENGTH) {
       throw new Error(`PrivateKey length should be ${Ed25519PrivateKey.LENGTH}`);
     }
@@ -137,10 +135,10 @@ export class Ed25519PrivateKey extends PrivateKey {
    * @param args.message in HexInput format
    * @returns Signature
    */
-  sign(args: { message: HexInput }): Ed25519Signature {
-    const hex = Hex.fromHexInput(args.message);
+  sign(message: HexInput): Ed25519Signature {
+    const hex = Hex.fromHexInput(message);
     const signature = nacl.sign.detached(hex.toUint8Array(), this.signingKeyPair.secretKey);
-    return new Ed25519Signature({ hexInput: signature });
+    return new Ed25519Signature(signature);
   }
 
   serialize(serializer: Serializer): void {
@@ -149,7 +147,7 @@ export class Ed25519PrivateKey extends PrivateKey {
 
   static deserialize(deserializer: Deserializer): Ed25519PrivateKey {
     const bytes = deserializer.deserializeBytes();
-    return new Ed25519PrivateKey({ hexInput: bytes });
+    return new Ed25519PrivateKey(bytes);
   }
 
   /**
@@ -159,9 +157,7 @@ export class Ed25519PrivateKey extends PrivateKey {
    */
   static generate(): Ed25519PrivateKey {
     const keyPair = nacl.sign.keyPair();
-    return new Ed25519PrivateKey({
-      hexInput: keyPair.secretKey.slice(0, Ed25519PrivateKey.LENGTH),
-    });
+    return new Ed25519PrivateKey(keyPair.secretKey.slice(0, Ed25519PrivateKey.LENGTH));
   }
 
   /**
@@ -171,7 +167,7 @@ export class Ed25519PrivateKey extends PrivateKey {
    */
   publicKey(): Ed25519PublicKey {
     const bytes = this.signingKeyPair.publicKey;
-    return new Ed25519PublicKey({ hexInput: bytes });
+    return new Ed25519PublicKey(bytes);
   }
 }
 
@@ -190,9 +186,9 @@ export class Ed25519Signature extends Signature {
    */
   private readonly data: Hex;
 
-  constructor(args: { hexInput: HexInput }) {
+  constructor(hexInput: HexInput) {
     super();
-    const hex = Hex.fromHexInput(args);
+    const hex = Hex.fromHexInput(hexInput);
     if (hex.toUint8Array().length !== Ed25519Signature.LENGTH) {
       throw new Error(`Signature length should be ${Ed25519Signature.LENGTH}`);
     }
@@ -224,6 +220,6 @@ export class Ed25519Signature extends Signature {
 
   static deserialize(deserializer: Deserializer): Ed25519Signature {
     const bytes = deserializer.deserializeBytes();
-    return new Ed25519Signature({ hexInput: bytes });
+    return new Ed25519Signature(bytes);
   }
 }

--- a/src/core/crypto/ed25519.ts
+++ b/src/core/crypto/ed25519.ts
@@ -63,7 +63,7 @@ export class Ed25519PublicKey extends PublicKey {
    */
   verifySignature(args: { message: HexInput; signature: Ed25519Signature }): boolean {
     const { message, signature } = args;
-    const rawMessage = Hex.fromHexInput({ hexInput: message }).toUint8Array();
+    const rawMessage = Hex.fromHexInput(message).toUint8Array();
     const rawSignature = Hex.fromHexInput({
       hexInput: signature.toUint8Array(),
     }).toUint8Array();
@@ -128,7 +128,7 @@ export class Ed25519PrivateKey extends PrivateKey {
    * @returns string representation of the private key
    */
   toString(): string {
-    return Hex.fromHexInput({ hexInput: this.toUint8Array() }).toString();
+    return Hex.fromHexInput(this.toUint8Array()).toString();
   }
 
   /**
@@ -138,7 +138,7 @@ export class Ed25519PrivateKey extends PrivateKey {
    * @returns Signature
    */
   sign(args: { message: HexInput }): Ed25519Signature {
-    const hex = Hex.fromHexInput({ hexInput: args.message });
+    const hex = Hex.fromHexInput(args.message);
     const signature = nacl.sign.detached(hex.toUint8Array(), this.signingKeyPair.secretKey);
     return new Ed25519Signature({ hexInput: signature });
   }

--- a/src/core/crypto/multi_ed25519.ts
+++ b/src/core/crypto/multi_ed25519.ts
@@ -106,11 +106,7 @@ export class MultiEd25519PublicKey extends PublicKey {
 
     for (let i = 0; i < bytes.length - 1; i += Ed25519PublicKey.LENGTH) {
       const begin = i;
-      keys.push(
-        new Ed25519PublicKey({
-          hexInput: bytes.subarray(begin, begin + Ed25519PublicKey.LENGTH),
-        }),
-      );
+      keys.push(new Ed25519PublicKey(bytes.subarray(begin, begin + Ed25519PublicKey.LENGTH)));
     }
     return new MultiEd25519PublicKey({ publicKeys: keys, threshold });
   }
@@ -248,11 +244,7 @@ export class MultiEd25519Signature extends Signature {
 
     for (let i = 0; i < bytes.length - bitmap.length; i += Ed25519Signature.LENGTH) {
       const begin = i;
-      signatures.push(
-        new Ed25519Signature({
-          hexInput: bytes.subarray(begin, begin + Ed25519Signature.LENGTH),
-        }),
-      );
+      signatures.push(new Ed25519Signature(bytes.subarray(begin, begin + Ed25519Signature.LENGTH)));
     }
     return new MultiEd25519Signature({ signatures, bitmap });
   }

--- a/src/core/crypto/multi_ed25519.ts
+++ b/src/core/crypto/multi_ed25519.ts
@@ -86,7 +86,7 @@ export class MultiEd25519PublicKey extends PublicKey {
   }
 
   toString(): string {
-    return Hex.fromHexInput({ hexInput: this.toUint8Array() }).toString();
+    return Hex.fromHexInput(this.toUint8Array()).toString();
   }
 
   // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
@@ -185,7 +185,7 @@ export class MultiEd25519Signature extends Signature {
   }
 
   toString(): string {
-    return Hex.fromHexInput({ hexInput: this.toUint8Array() }).toString();
+    return Hex.fromHexInput(this.toUint8Array()).toString();
   }
 
   /**

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -21,12 +21,12 @@ export class Secp256k1PublicKey extends PublicKey {
   /**
    * Create a new PublicKey instance from a Uint8Array or String.
    *
-   * @param args.hexInput A HexInput (string or Uint8Array)
+   * @param hexInput A HexInput (string or Uint8Array)
    */
-  constructor(args: { hexInput: HexInput }) {
+  constructor(hexInput: HexInput) {
     super();
 
-    const hex = Hex.fromHexInput(args);
+    const hex = Hex.fromHexInput(hexInput);
     if (hex.toUint8Array().length !== Secp256k1PublicKey.LENGTH) {
       throw new Error(`PublicKey length should be ${Secp256k1PublicKey.LENGTH}`);
     }
@@ -60,7 +60,7 @@ export class Secp256k1PublicKey extends PublicKey {
    */
   verifySignature(args: { message: HexInput; signature: Secp256k1Signature }): boolean {
     const { message, signature } = args;
-    const msgHex = Hex.fromHexInput({ hexInput: message }).toUint8Array();
+    const msgHex = Hex.fromHexInput(message).toUint8Array();
     const sha256Message = sha256(msgHex);
     const rawSignature = signature.toUint8Array();
     return secp256k1.verify(rawSignature, sha256Message, this.toUint8Array());
@@ -72,7 +72,7 @@ export class Secp256k1PublicKey extends PublicKey {
 
   static deserialize(deserializer: Deserializer): Secp256k1PublicKey {
     const bytes = deserializer.deserializeBytes();
-    return new Secp256k1PublicKey({ hexInput: bytes });
+    return new Secp256k1PublicKey(bytes);
   }
 }
 
@@ -94,12 +94,12 @@ export class Secp256k1PrivateKey extends PrivateKey {
   /**
    * Create a new PrivateKey instance from a Uint8Array or String.
    *
-   * @param args.hexInput A HexInput (string or Uint8Array)
+   * @param hexInput A HexInput (string or Uint8Array)
    */
-  constructor(args: { hexInput: HexInput }) {
+  constructor(hexInput: HexInput) {
     super();
 
-    const privateKeyHex = Hex.fromHexInput(args);
+    const privateKeyHex = Hex.fromHexInput(hexInput);
     if (privateKeyHex.toUint8Array().length !== Secp256k1PrivateKey.LENGTH) {
       throw new Error(`PrivateKey length should be ${Secp256k1PrivateKey.LENGTH}`);
     }
@@ -128,14 +128,14 @@ export class Secp256k1PrivateKey extends PrivateKey {
   /**
    * Sign the given message with the private key.
    *
-   * @param args.message in HexInput format
+   * @param message in HexInput format
    * @returns Signature
    */
-  sign(args: { message: HexInput }): Secp256k1Signature {
-    const msgHex = Hex.fromHexInput({ hexInput: args.message });
+  sign(message: HexInput): Secp256k1Signature {
+    const msgHex = Hex.fromHexInput(message);
     const sha256Message = sha256(msgHex.toUint8Array());
     const signature = secp256k1.sign(sha256Message, this.key.toUint8Array());
-    return new Secp256k1Signature({ hexInput: signature.toCompactRawBytes() });
+    return new Secp256k1Signature(signature.toCompactRawBytes());
   }
 
   serialize(serializer: Serializer): void {
@@ -144,7 +144,7 @@ export class Secp256k1PrivateKey extends PrivateKey {
 
   static deserialize(deserializer: Deserializer): Secp256k1PrivateKey {
     const bytes = deserializer.deserializeBytes();
-    return new Secp256k1PrivateKey({ hexInput: bytes });
+    return new Secp256k1PrivateKey(bytes);
   }
 
   /**
@@ -154,7 +154,7 @@ export class Secp256k1PrivateKey extends PrivateKey {
    */
   static generate(): Secp256k1PrivateKey {
     const hexInput = secp256k1.utils.randomPrivateKey();
-    return new Secp256k1PrivateKey({ hexInput });
+    return new Secp256k1PrivateKey(hexInput);
   }
 
   /**
@@ -164,7 +164,7 @@ export class Secp256k1PrivateKey extends PrivateKey {
    */
   publicKey(): Secp256k1PublicKey {
     const bytes = secp256k1.getPublicKey(this.key.toUint8Array(), false);
-    return new Secp256k1PublicKey({ hexInput: bytes });
+    return new Secp256k1PublicKey(bytes);
   }
 }
 
@@ -188,10 +188,10 @@ export class Secp256k1Signature extends Signature {
    *
    * @param args.hexInput A HexInput (string or Uint8Array)
    */
-  constructor(args: { hexInput: HexInput }) {
+  constructor(hexInput: HexInput) {
     super();
 
-    const hex = Hex.fromHexInput(args);
+    const hex = Hex.fromHexInput(hexInput);
     if (hex.toUint8Array().length !== Secp256k1Signature.LENGTH) {
       throw new Error(`Signature length should be ${Secp256k1Signature.LENGTH}`);
     }
@@ -222,6 +222,6 @@ export class Secp256k1Signature extends Signature {
 
   static deserialize(deserializer: Deserializer): Secp256k1Signature {
     const hex = deserializer.deserializeBytes();
-    return new Secp256k1Signature({ hexInput: hex });
+    return new Secp256k1Signature(hex);
   }
 }

--- a/src/core/hex.ts
+++ b/src/core/hex.ts
@@ -28,7 +28,7 @@ export enum HexInvalidReason {
  *
  * ```ts
  * getTransactionByHash(txnHash: HexInput): Promise<Transaction> {
- *   const txnHashString = Hex.fromHexInput({ hexInput: txnHash }).toString();
+ *   const txnHashString = Hex.fromHexInput(txnHash).toString();
  *   return await getTransactionByHashInner(txnHashString);
  * }
  * ```
@@ -38,7 +38,7 @@ export enum HexInvalidReason {
  *
  * These are some other ways to chain the functions together:
  * - `Hex.fromString({ hexInput: "0x1f" }).toUint8Array()`
- * - `new Hex({ data: [1, 3] }).toStringWithoutPrefix()`
+ * - `new Hex([1, 3]).toStringWithoutPrefix()`
  */
 export class Hex {
   private data: Uint8Array;
@@ -48,8 +48,8 @@ export class Hex {
    *
    * @param hex Uint8Array
    */
-  constructor(args: { data: Uint8Array }) {
-    this.data = args.data;
+  constructor(data: Uint8Array) {
+    this.data = data;
   }
 
   // ===
@@ -95,8 +95,8 @@ export class Hex {
    *
    * @returns Hex
    */
-  static fromString(args: { str: string }): Hex {
-    let input = args.str;
+  static fromString(str: string): Hex {
+    let input = str;
 
     if (input.startsWith("0x")) {
       input = input.slice(2);
@@ -114,7 +114,7 @@ export class Hex {
     }
 
     try {
-      return new Hex({ data: hexToBytes(input) });
+      return new Hex(hexToBytes(input));
     } catch (e) {
       const error = e as Error;
       throw new ParsingError(
@@ -131,9 +131,9 @@ export class Hex {
    *
    * @returns Hex
    */
-  static fromHexInput(args: { hexInput: HexInput }): Hex {
-    if (args.hexInput instanceof Uint8Array) return new Hex({ data: args.hexInput });
-    return Hex.fromString({ str: args.hexInput });
+  static fromHexInput(hexInput: HexInput): Hex {
+    if (hexInput instanceof Uint8Array) return new Hex(hexInput);
+    return Hex.fromString(hexInput);
   }
 
   // ===
@@ -149,9 +149,9 @@ export class Hex {
    * valid, invalidReason and invalidReasonMessage will be set explaining why it is
    * invalid.
    */
-  static isValid(args: { str: string }): ParsingResult<HexInvalidReason> {
+  static isValid(str: string): ParsingResult<HexInvalidReason> {
     try {
-      Hex.fromString(args);
+      Hex.fromString(str);
       return { valid: true };
     } catch (e) {
       const error = e as ParsingError<HexInvalidReason>;

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -317,9 +317,7 @@ export async function getAccountOwnedTokensFromCollectionAddress(args: {
   const accountAddress = AccountAddress.fromHexInput({
     input: ownerAddress,
   }).toString();
-  const collAddress = Hex.fromHexInput({
-    hexInput: collectionAddress,
-  }).toString();
+  const collAddress = Hex.fromHexInput(collectionAddress).toString();
 
   const whereCondition: any = {
     owner_address: { _eq: accountAddress },

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -213,7 +213,7 @@ export async function lookupOriginalAccountAddress(args: {
       aptosConfig,
       handle,
       data: {
-        key: Hex.fromHexInput({ hexInput: authenticationKey }).toString(),
+        key: Hex.fromHexInput(authenticationKey).toString(),
         key_type: "address",
         value_type: "address",
       },

--- a/src/internal/collection.ts
+++ b/src/internal/collection.ts
@@ -34,7 +34,7 @@ export async function getCollectionData(args: {
   };
 }): Promise<GetCollectionDataResponse> {
   const { aptosConfig, creatorAddress, collectionName, options } = args;
-  const address = Hex.fromHexInput({ hexInput: creatorAddress }).toString();
+  const address = Hex.fromHexInput(creatorAddress).toString();
 
   const whereCondition: any = {
     collection_name: { _eq: collectionName },

--- a/src/internal/staking.ts
+++ b/src/internal/staking.ts
@@ -20,7 +20,7 @@ export async function getNumberOfDelegators(args: {
   poolAddress: HexInput;
 }): Promise<number> {
   const { aptosConfig, poolAddress } = args;
-  const address = Hex.fromHexInput({ hexInput: poolAddress }).toString();
+  const address = Hex.fromHexInput(poolAddress).toString();
   const query = {
     query: GetNumberOfDelegators,
     variables: { where_condition: { pool_address: { _eq: address } } },
@@ -59,8 +59,8 @@ export async function getDelegatedStakingActivities(args: {
   const query = {
     query: GetDelegatedStakingActivities,
     variables: {
-      delegatorAddress: Hex.fromHexInput({ hexInput: delegatorAddress }).toString(),
-      poolAddress: Hex.fromHexInput({ hexInput: poolAddress }).toString(),
+      delegatorAddress: Hex.fromHexInput(delegatorAddress).toString(),
+      poolAddress: Hex.fromHexInput(poolAddress).toString(),
     },
   };
   const data = await queryIndexer<GetDelegatedStakingActivitiesQuery>({ aptosConfig, query });

--- a/src/transactions/transaction_builder/transaction_builder.ts
+++ b/src/transactions/transaction_builder/transaction_builder.ts
@@ -272,19 +272,19 @@ export function generateSignedTransactionForSimulation(args: SimulateTransaction
       transaction.feePayerAddress,
     );
     const accountAuthenticator = new AccountAuthenticatorEd25519(
-      new Ed25519PublicKey({ hexInput: signerPublicKey.toUint8Array() }),
-      new Ed25519Signature({ hexInput: new Uint8Array(64) }),
+      new Ed25519PublicKey(signerPublicKey.toUint8Array()),
+      new Ed25519Signature(new Uint8Array(64)),
     );
     const secondaryAccountAuthenticators = secondarySignersPublicKeys!.map(
       (publicKey) =>
         new AccountAuthenticatorEd25519(
-          new Ed25519PublicKey({ hexInput: publicKey.toUint8Array() }),
-          new Ed25519Signature({ hexInput: new Uint8Array(64) }),
+          new Ed25519PublicKey(publicKey.toUint8Array()),
+          new Ed25519Signature(new Uint8Array(64)),
         ),
     );
     const feePayerAuthenticator = new AccountAuthenticatorEd25519(
-      new Ed25519PublicKey({ hexInput: feePayerPublicKey!.toUint8Array() }),
-      new Ed25519Signature({ hexInput: new Uint8Array(64) }),
+      new Ed25519PublicKey(feePayerPublicKey!.toUint8Array()),
+      new Ed25519Signature(new Uint8Array(64)),
     );
     const transactionAuthenticator = new TransactionAuthenticatorFeePayer(
       accountAuthenticator,
@@ -306,15 +306,15 @@ export function generateSignedTransactionForSimulation(args: SimulateTransaction
     );
 
     const accountAuthenticator = new AccountAuthenticatorEd25519(
-      new Ed25519PublicKey({ hexInput: signerPublicKey.toUint8Array() }),
-      new Ed25519Signature({ hexInput: new Uint8Array(64) }),
+      new Ed25519PublicKey(signerPublicKey.toUint8Array()),
+      new Ed25519Signature(new Uint8Array(64)),
     );
 
     const secondaryAccountAuthenticators = secondarySignersPublicKeys!.map(
       (publicKey) =>
         new AccountAuthenticatorEd25519(
-          new Ed25519PublicKey({ hexInput: publicKey.toUint8Array() }),
-          new Ed25519Signature({ hexInput: new Uint8Array(64) }),
+          new Ed25519PublicKey(publicKey.toUint8Array()),
+          new Ed25519Signature(new Uint8Array(64)),
         ),
     );
 
@@ -330,8 +330,8 @@ export function generateSignedTransactionForSimulation(args: SimulateTransaction
   // raw transaction
 
   const accountAuthenticator = new AccountAuthenticatorEd25519(
-    new Ed25519PublicKey({ hexInput: signerPublicKey.toUint8Array() }),
-    new Ed25519Signature({ hexInput: new Uint8Array(64) }),
+    new Ed25519PublicKey(signerPublicKey.toUint8Array()),
+    new Ed25519Signature(new Uint8Array(64)),
   );
 
   const transactionAuthenticator = new TransactionAuthenticatorEd25519(
@@ -358,19 +358,19 @@ export function sign(args: { signer: Account; transaction: AnyRawTransaction }):
   const message = getSigningMessage(transactionToSign);
 
   // account.signMessage
-  const signerSignature = signer.sign({ data: message });
+  const signerSignature = signer.sign(message);
 
   // return account authentication
   switch (signer.signingScheme) {
     case SigningScheme.Ed25519:
       return new AccountAuthenticatorEd25519(
-        new Ed25519PublicKey({ hexInput: signer.publicKey.toUint8Array() }),
-        new Ed25519Signature({ hexInput: signerSignature.toUint8Array() }),
+        new Ed25519PublicKey(signer.publicKey.toUint8Array()),
+        new Ed25519Signature(signerSignature.toUint8Array()),
       );
     case SigningScheme.Secp256k1Ecdsa:
       return new AccountAuthenticatorSecp256k1(
-        new Secp256k1PublicKey({ hexInput: signer.publicKey.toUint8Array() }),
-        new Secp256k1Signature({ hexInput: signerSignature.toUint8Array() }),
+        new Secp256k1PublicKey(signer.publicKey.toUint8Array()),
+        new Secp256k1Signature(signerSignature.toUint8Array()),
       );
     // TODO support MultiEd25519
     default:

--- a/tests/e2e/api/transaction_builder.test.ts
+++ b/tests/e2e/api/transaction_builder.test.ts
@@ -414,9 +414,7 @@ describe("transaction builder", () => {
       const alice = Account.generate();
       await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: FUND_AMOUNT });
       const bob = Account.fromPrivateKey({
-        privateKey: new Ed25519PrivateKey({
-          hexInput: "0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c",
-        }),
+        privateKey: new Ed25519PrivateKey("0x5aba8dab1c523be32bd4dafe2cc612f7f8050ce42a3322b60216ef67dc97768c"),
       });
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -32,28 +32,24 @@ describe("Ed25519 Account", () => {
 
   it("should create a new account from a provided private key", () => {
     const { privateKey: privateKeyBytes, publicKey, address } = ed25519;
-    const privateKey = new Ed25519PrivateKey({ hexInput: privateKeyBytes });
+    const privateKey = new Ed25519PrivateKey(privateKeyBytes);
     const newAccount = Account.fromPrivateKey({ privateKey });
     expect(newAccount).toBeInstanceOf(Account);
     expect((newAccount.privateKey as Ed25519PrivateKey).toString()).toEqual(privateKey.toString());
-    expect((newAccount.publicKey as Ed25519PublicKey).toString()).toEqual(
-      new Ed25519PublicKey({ hexInput: publicKey }).toString(),
-    );
+    expect((newAccount.publicKey as Ed25519PublicKey).toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
     expect(newAccount.accountAddress.toString()).toEqual(address);
   });
 
   it("should create a new account from a provided private key and address", () => {
     const { privateKey: privateKeyBytes, publicKey, address } = ed25519;
-    const privateKey = new Ed25519PrivateKey({ hexInput: privateKeyBytes });
+    const privateKey = new Ed25519PrivateKey(privateKeyBytes);
     const newAccount = Account.fromPrivateKeyAndAddress({
       privateKey,
       address: AccountAddress.fromString({ input: address }),
     });
     expect(newAccount).toBeInstanceOf(Account);
     expect((newAccount.privateKey as Ed25519PrivateKey).toString()).toEqual(privateKey.toString());
-    expect((newAccount.publicKey as Ed25519PublicKey).toString()).toEqual(
-      new Ed25519PublicKey({ hexInput: publicKey }).toString(),
-    );
+    expect((newAccount.publicKey as Ed25519PublicKey).toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
     expect(newAccount.accountAddress.toString()).toEqual(address);
   });
 
@@ -78,7 +74,7 @@ describe("Ed25519 Account", () => {
 
   it("should return the authentication key for a public key", () => {
     const { publicKey: publicKeyBytes, address } = ed25519;
-    const publicKey = new Ed25519PublicKey({ hexInput: publicKeyBytes });
+    const publicKey = new Ed25519PublicKey(publicKeyBytes);
     const authKey = Account.authKey({ publicKey });
     expect(authKey).toBeInstanceOf(Hex);
     expect(authKey.toString()).toEqual(address);
@@ -86,15 +82,15 @@ describe("Ed25519 Account", () => {
 
   it("should sign data, return a Hex signature, and verify", () => {
     const { privateKey: privateKeyBytes, address, message, signedMessage } = ed25519;
-    const privateKey = new Ed25519PrivateKey({ hexInput: privateKeyBytes });
+    const privateKey = new Ed25519PrivateKey(privateKeyBytes);
     const account = Account.fromPrivateKeyAndAddress({
       privateKey,
       address: AccountAddress.fromString({ input: address }),
     });
-    expect(account.sign({ data: message }).toString()).toEqual(signedMessage);
+    expect(account.sign(message).toString()).toEqual(signedMessage);
 
     // Verify the signature
-    const signature = new Ed25519Signature({ hexInput: signedMessage });
+    const signature = new Ed25519Signature(signedMessage);
     expect(account.verifySignature({ message, signature })).toBe(true);
   });
 });
@@ -109,19 +105,19 @@ describe("Secp256k1 Account", () => {
 
   it("should create a new account from a provided private key", () => {
     const { privateKey: privateKeyBytes, publicKey, address } = secp256k1TestObject;
-    const privateKey = new Secp256k1PrivateKey({ hexInput: privateKeyBytes });
+    const privateKey = new Secp256k1PrivateKey(privateKeyBytes);
     const newAccount = Account.fromPrivateKey({ privateKey });
     expect(newAccount).toBeInstanceOf(Account);
     expect((newAccount.privateKey as Secp256k1PrivateKey).toString()).toEqual(privateKey.toString());
     expect((newAccount.publicKey as Secp256k1PublicKey).toString()).toEqual(
-      new Secp256k1PublicKey({ hexInput: publicKey }).toString(),
+      new Secp256k1PublicKey(publicKey).toString(),
     );
     expect(newAccount.accountAddress.toString()).toEqual(address);
   });
 
   it("should create a new account from a provided private key and address", () => {
     const { privateKey: privateKeyBytes, publicKey, address } = secp256k1TestObject;
-    const privateKey = new Secp256k1PrivateKey({ hexInput: privateKeyBytes });
+    const privateKey = new Secp256k1PrivateKey(privateKeyBytes);
     const newAccount = Account.fromPrivateKeyAndAddress({
       privateKey,
       address: AccountAddress.fromString({ input: address }),
@@ -129,7 +125,7 @@ describe("Secp256k1 Account", () => {
     expect(newAccount).toBeInstanceOf(Account);
     expect((newAccount.privateKey as Secp256k1PrivateKey).toString()).toEqual(privateKey.toString());
     expect((newAccount.publicKey as Secp256k1PublicKey).toString()).toEqual(
-      new Secp256k1PublicKey({ hexInput: publicKey }).toString(),
+      new Secp256k1PublicKey(publicKey).toString(),
     );
     expect(newAccount.accountAddress.toString()).toEqual(address);
   });
@@ -155,7 +151,7 @@ describe("Secp256k1 Account", () => {
 
   it("should return the authentication key for a public key", () => {
     const { publicKey: publicKeyBytes, address } = secp256k1TestObject;
-    const publicKey = new Secp256k1PublicKey({ hexInput: publicKeyBytes });
+    const publicKey = new Secp256k1PublicKey(publicKeyBytes);
     const authKey = Account.authKey({ publicKey });
     expect(authKey).toBeInstanceOf(Hex);
     expect(authKey.toString()).toEqual(address);
@@ -165,18 +161,16 @@ describe("Secp256k1 Account", () => {
     const { privateKey: privateKeyBytes, address, signatureHex, messageEncoded } = secp256k1TestObject;
 
     // Sign the message
-    const secp256k1PrivateKey = new Secp256k1PrivateKey({
-      hexInput: privateKeyBytes,
-    });
+    const secp256k1PrivateKey = new Secp256k1PrivateKey(privateKeyBytes);
     const account = Account.fromPrivateKeyAndAddress({
       privateKey: secp256k1PrivateKey,
       address: AccountAddress.fromString({ input: address }),
     });
-    const signedMessage = account.sign({ data: messageEncoded });
+    const signedMessage = account.sign(messageEncoded);
     expect(signedMessage.toString()).toEqual(signatureHex);
 
     // Verify the signature
-    const signature = new Secp256k1Signature({ hexInput: signatureHex });
+    const signature = new Secp256k1Signature(signatureHex);
     expect(account.verifySignature({ message: messageEncoded, signature })).toBe(true);
   });
 });

--- a/tests/unit/authentication_key.test.ts
+++ b/tests/unit/authentication_key.test.ts
@@ -29,7 +29,7 @@ describe("AuthenticationKey", () => {
   });
 
   it("should create AuthenticationKey from Ed25519PublicKey", () => {
-    const publicKey = new Ed25519PublicKey({ hexInput: ed25519.publicKey });
+    const publicKey = new Ed25519PublicKey(ed25519.publicKey);
     const authKey = AuthenticationKey.fromPublicKey({ publicKey });
     expect(authKey).toBeInstanceOf(AuthenticationKey);
     expect(authKey.data.toString()).toEqual(ed25519.authKey);
@@ -39,11 +39,7 @@ describe("AuthenticationKey", () => {
     // create the MultiPublicKey
     let edPksArray = [];
     for (let i = 0; i < multiEd25519PkTestObject.public_keys.length; i++) {
-      edPksArray.push(
-        new Ed25519PublicKey({
-          hexInput: multiEd25519PkTestObject.public_keys[i],
-        }),
-      );
+      edPksArray.push(new Ed25519PublicKey(multiEd25519PkTestObject.public_keys[i]));
     }
 
     const pubKeyMultiSig = new MultiEd25519PublicKey({

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -8,7 +8,7 @@ describe("Ed25519PublicKey", () => {
   it("should create the instance correctly without error", () => {
     // Create from string
     const hexStr = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    const publicKey = new Ed25519PublicKey({ hexInput: hexStr });
+    const publicKey = new Ed25519PublicKey(hexStr);
     expect(publicKey).toBeInstanceOf(Ed25519PublicKey);
     expect(publicKey.toString()).toEqual(hexStr);
 
@@ -17,21 +17,21 @@ describe("Ed25519PublicKey", () => {
       1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35, 69, 103, 137, 171, 205, 239, 1, 35,
       69, 103, 137, 171, 205, 239,
     ]);
-    const publicKey2 = new Ed25519PublicKey({ hexInput: hexUint8Array });
+    const publicKey2 = new Ed25519PublicKey(hexUint8Array);
     expect(publicKey2).toBeInstanceOf(Ed25519PublicKey);
     expect(publicKey2.toUint8Array()).toEqual(hexUint8Array);
   });
 
   it("should throw an error with invalid hex input length", () => {
     const invalidHexInput = "0123456789abcdef"; // Invalid length
-    expect(() => new Ed25519PublicKey({ hexInput: invalidHexInput })).toThrowError(
+    expect(() => new Ed25519PublicKey(invalidHexInput)).toThrowError(
       `PublicKey length should be ${Ed25519PublicKey.LENGTH}`,
     );
   });
 
   it("should verify the signature correctly", () => {
-    const pubKey = new Ed25519PublicKey({ hexInput: ed25519.publicKey });
-    const signature = new Ed25519Signature({ hexInput: ed25519.signedMessage });
+    const pubKey = new Ed25519PublicKey(ed25519.publicKey);
+    const signature = new Ed25519Signature(ed25519.signedMessage);
 
     // Verify with correct signed message
     expect(pubKey.verifySignature({ message: ed25519.message, signature })).toBe(true);
@@ -39,9 +39,7 @@ describe("Ed25519PublicKey", () => {
     // Verify with incorrect signed message
     const incorrectSignedMessage =
       "0xc5de9e40ac00b371cd83b1c197fa5b665b7449b33cd3cdd305bb78222e06a671a49625ab9aea8a039d4bb70e275768084d62b094bc1b31964f2357b7c1af7e0a";
-    const invalidSignature = new Ed25519Signature({
-      hexInput: incorrectSignedMessage,
-    });
+    const invalidSignature = new Ed25519Signature(incorrectSignedMessage);
     expect(
       pubKey.verifySignature({
         message: ed25519.message,
@@ -51,7 +49,7 @@ describe("Ed25519PublicKey", () => {
   });
 
   it("should serialize correctly", () => {
-    const publicKey = new Ed25519PublicKey({ hexInput: ed25519.publicKey });
+    const publicKey = new Ed25519PublicKey(ed25519.publicKey);
     const serializer = new Serializer();
     publicKey.serialize(serializer);
 
@@ -75,7 +73,7 @@ describe("Ed25519PublicKey", () => {
 
   it("should serialize and deserialize correctly", () => {
     const hexInput = "0x0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-    const publicKey = new Ed25519PublicKey({ hexInput });
+    const publicKey = new Ed25519PublicKey(hexInput);
     const serializer = new Serializer();
     publicKey.serialize(serializer);
 
@@ -89,7 +87,7 @@ describe("Ed25519PublicKey", () => {
 describe("PrivateKey", () => {
   it("should create the instance correctly without error", () => {
     // Create from string
-    const privateKey = new Ed25519PrivateKey({ hexInput: ed25519.privateKey });
+    const privateKey = new Ed25519PrivateKey(ed25519.privateKey);
     expect(privateKey).toBeInstanceOf(Ed25519PrivateKey);
     expect(privateKey.toString()).toEqual(ed25519.privateKey);
 
@@ -98,26 +96,26 @@ describe("PrivateKey", () => {
       197, 51, 140, 210, 81, 194, 45, 170, 140, 156, 156, 201, 79, 73, 140, 200, 165, 199, 225, 210, 231, 82, 135, 165,
       221, 169, 16, 150, 254, 100, 239, 165,
     ]);
-    const privateKey2 = new Ed25519PrivateKey({ hexInput: hexUint8Array });
+    const privateKey2 = new Ed25519PrivateKey(hexUint8Array);
     expect(privateKey2).toBeInstanceOf(Ed25519PrivateKey);
     expect(privateKey2.toString()).toEqual(Hex.fromHexInput(hexUint8Array).toString());
   });
 
   it("should throw an error with invalid hex input length", () => {
     const invalidHexInput = "0123456789abcdef"; // Invalid length
-    expect(() => new Ed25519PrivateKey({ hexInput: invalidHexInput })).toThrowError(
+    expect(() => new Ed25519PrivateKey(invalidHexInput)).toThrowError(
       `PrivateKey length should be ${Ed25519PrivateKey.LENGTH}`,
     );
   });
 
   it("should sign the message correctly", () => {
-    const privateKey = new Ed25519PrivateKey({ hexInput: ed25519.privateKey });
-    const signedMessage = privateKey.sign({ message: ed25519.message });
+    const privateKey = new Ed25519PrivateKey(ed25519.privateKey);
+    const signedMessage = privateKey.sign(ed25519.message);
     expect(signedMessage.toString()).toEqual(ed25519.signedMessage);
   });
 
   it("should serialize correctly", () => {
-    const privateKey = new Ed25519PrivateKey({ hexInput: ed25519.privateKey });
+    const privateKey = new Ed25519PrivateKey(ed25519.privateKey);
     const serializer = new Serializer();
     privateKey.serialize(serializer);
 
@@ -140,7 +138,7 @@ describe("PrivateKey", () => {
   });
 
   it("should serialize and deserialize correctly", () => {
-    const privateKey = new Ed25519PrivateKey({ hexInput: ed25519.privateKey });
+    const privateKey = new Ed25519PrivateKey(ed25519.privateKey);
     const serializer = new Serializer();
     privateKey.serialize(serializer);
 
@@ -162,7 +160,7 @@ describe("PrivateKey", () => {
   });
 
   it("should derive the public key correctly", () => {
-    const privateKey = new Ed25519PrivateKey({ hexInput: ed25519.privateKey });
+    const privateKey = new Ed25519PrivateKey(ed25519.privateKey);
     const publicKey = privateKey.publicKey();
     expect(publicKey).toBeInstanceOf(Ed25519PublicKey);
     expect(publicKey.toString()).toEqual(ed25519.publicKey);
@@ -172,28 +170,26 @@ describe("PrivateKey", () => {
 describe("Signature", () => {
   it("should create an instance correctly without error", () => {
     // Create from string
-    const signatureStr = new Ed25519Signature({
-      hexInput: ed25519.signedMessage,
-    });
+    const signatureStr = new Ed25519Signature(ed25519.signedMessage);
     expect(signatureStr).toBeInstanceOf(Ed25519Signature);
     expect(signatureStr.toString()).toEqual(ed25519.signedMessage);
 
     // Create from Uint8Array
     const signatureValue = new Uint8Array(Ed25519Signature.LENGTH);
-    const signature = new Ed25519Signature({ hexInput: signatureValue });
+    const signature = new Ed25519Signature(signatureValue);
     expect(signature).toBeInstanceOf(Ed25519Signature);
     expect(signature.toUint8Array()).toEqual(signatureValue);
   });
 
   it("should throw an error with invalid value length", () => {
     const invalidSignatureValue = new Uint8Array(Ed25519Signature.LENGTH - 1); // Invalid length
-    expect(() => new Ed25519Signature({ hexInput: invalidSignatureValue })).toThrowError(
+    expect(() => new Ed25519Signature(invalidSignatureValue)).toThrowError(
       `Signature length should be ${Ed25519Signature.LENGTH}`,
     );
   });
 
   it("should serialize correctly", () => {
-    const signature = new Ed25519Signature({ hexInput: ed25519.signedMessage });
+    const signature = new Ed25519Signature(ed25519.signedMessage);
     const serializer = new Serializer();
     signature.serialize(serializer);
 
@@ -219,7 +215,7 @@ describe("Signature", () => {
 
   it("should serialize and deserialize correctly", () => {
     const signatureValue = new Uint8Array(Ed25519Signature.LENGTH);
-    const signature = new Ed25519Signature({ hexInput: signatureValue });
+    const signature = new Ed25519Signature(signatureValue);
     const serializer = new Serializer();
     signature.serialize(serializer);
 

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -100,7 +100,7 @@ describe("PrivateKey", () => {
     ]);
     const privateKey2 = new Ed25519PrivateKey({ hexInput: hexUint8Array });
     expect(privateKey2).toBeInstanceOf(Ed25519PrivateKey);
-    expect(privateKey2.toString()).toEqual(Hex.fromHexInput({ hexInput: hexUint8Array }).toString());
+    expect(privateKey2.toString()).toEqual(Hex.fromHexInput(hexUint8Array).toString());
   });
 
   it("should throw an error with invalid hex input length", () => {

--- a/tests/unit/hex.test.ts
+++ b/tests/unit/hex.test.ts
@@ -10,93 +10,89 @@ const mockHex = {
 };
 
 test("creates a new Hex instance from bytes", () => {
-  const hex = new Hex({ data: mockHex.bytes });
+  const hex = new Hex(mockHex.bytes);
   expect(hex.toUint8Array()).toEqual(mockHex.bytes);
 });
 
 test("creates a new Hex instance from string", () => {
-  const hex = new Hex({ data: mockHex.bytes });
+  const hex = new Hex(mockHex.bytes);
   expect(hex.toString()).toEqual(mockHex.withPrefix);
 });
 
 test("converts hex bytes input into hex data", () => {
-  const hex = new Hex({ data: mockHex.bytes });
+  const hex = new Hex(mockHex.bytes);
   expect(hex instanceof Hex).toBeTruthy();
   expect(hex.toUint8Array()).toEqual(mockHex.bytes);
 });
 
 test("converts hex string input into hex data", () => {
-  const hex = Hex.fromString({ str: mockHex.withPrefix });
+  const hex = Hex.fromString(mockHex.withPrefix);
   expect(hex instanceof Hex).toBeTruthy();
   expect(hex.toUint8Array()).toEqual(mockHex.bytes);
 });
 
 test("accepts hex string input without prefix", () => {
-  const hex = Hex.fromString({ str: mockHex.withoutPrefix });
+  const hex = Hex.fromString(mockHex.withoutPrefix);
   expect(hex instanceof Hex).toBeTruthy();
   expect(hex.toUint8Array()).toEqual(mockHex.bytes);
 });
 
 test("accepts hex string with prefix", () => {
-  const hex = Hex.fromString({ str: mockHex.withPrefix });
+  const hex = Hex.fromString(mockHex.withPrefix);
   expect(hex instanceof Hex).toBeTruthy();
   expect(hex.toUint8Array()).toEqual(mockHex.bytes);
 });
 
 test("converts hex string to bytes", () => {
-  const hex = Hex.fromHexInput({ hexInput: mockHex.withPrefix }).toUint8Array();
+  const hex = Hex.fromHexInput(mockHex.withPrefix).toUint8Array();
   expect(hex instanceof Uint8Array).toBeTruthy();
   expect(hex).toEqual(mockHex.bytes);
 });
 
 test("converts hex bytes to string", () => {
-  const hex = Hex.fromHexInput({ hexInput: mockHex.bytes }).toString();
+  const hex = Hex.fromHexInput(mockHex.bytes).toString();
   expect(typeof hex).toEqual("string");
   expect(hex).toEqual(mockHex.withPrefix);
 });
 
 test("converts hex bytes to string without 0x prefix", () => {
-  const hex = Hex.fromHexInput({
-    hexInput: mockHex.withPrefix,
-  }).toStringWithoutPrefix();
+  const hex = Hex.fromHexInput(mockHex.withPrefix).toStringWithoutPrefix();
   expect(hex).toEqual(mockHex.withoutPrefix);
 });
 
 test("throws when parsing invalid hex char", () => {
-  expect(() => Hex.fromString({ str: "0xzyzz" })).toThrow(
-    "Hex string contains invalid hex characters: Invalid byte sequence",
-  );
+  expect(() => Hex.fromString("0xzyzz")).toThrow("Hex string contains invalid hex characters: Invalid byte sequence");
 });
 
 test("throws when parsing hex of length zero", () => {
-  expect(() => Hex.fromString({ str: "0x" })).toThrow(
+  expect(() => Hex.fromString("0x")).toThrow(
     "Hex string is too short, must be at least 1 char long, excluding the optional leading 0x.",
   );
-  expect(() => Hex.fromString({ str: "" })).toThrow(
+  expect(() => Hex.fromString("")).toThrow(
     "Hex string is too short, must be at least 1 char long, excluding the optional leading 0x.",
   );
 });
 
 test("throws when parsing hex of invalid length", () => {
-  expect(() => Hex.fromString({ str: "0x1" })).toThrow("Hex string must be an even number of hex characters.");
+  expect(() => Hex.fromString("0x1")).toThrow("Hex string must be an even number of hex characters.");
 });
 
 test("isValid returns true when parsing valid string", () => {
-  const result = Hex.isValid({ str: "0x11aabb" });
+  const result = Hex.isValid("0x11aabb");
   expect(result.valid).toBe(true);
   expect(result.invalidReason).toBeUndefined();
   expect(result.invalidReasonMessage).toBeUndefined();
 });
 
 test("isValid returns false when parsing hex of invalid length", () => {
-  const result = Hex.isValid({ str: "0xa" });
+  const result = Hex.isValid("0xa");
   expect(result.valid).toBe(false);
   expect(result.invalidReason).toBe(HexInvalidReason.INVALID_LENGTH);
   expect(result.invalidReasonMessage).toBe("Hex string must be an even number of hex characters.");
 });
 
 test("compares equality with equals as expected", () => {
-  const hexOne = Hex.fromString({ str: "0x11" });
-  const hexTwo = Hex.fromString({ str: "0x11" });
+  const hexOne = Hex.fromString("0x11");
+  const hexTwo = Hex.fromString("0x11");
   expect(hexOne.equals(hexTwo)).toBeTruthy();
 });

--- a/tests/unit/multi_ed25519.test.ts
+++ b/tests/unit/multi_ed25519.test.ts
@@ -51,11 +51,9 @@ describe("MultiPublicKey", () => {
       threshold: multiEd25519PkTestObject.threshold,
     });
 
-    expect(
-      Hex.fromHexInput({
-        hexInput: pubKeyMultiSig.toUint8Array(),
-      }).toStringWithoutPrefix(),
-    ).toEqual(multiEd25519PkTestObject.bytesInStringWithoutPrefix);
+    expect(Hex.fromHexInput(pubKeyMultiSig.toUint8Array()).toStringWithoutPrefix()).toEqual(
+      multiEd25519PkTestObject.bytesInStringWithoutPrefix,
+    );
   });
 
   it("should deserializes from bytes correctly", async () => {
@@ -76,7 +74,7 @@ describe("MultiPublicKey", () => {
     const serializer = new Serializer();
     serializer.serialize(pubKeyMultiSig);
     const deserialzed = MultiEd25519PublicKey.deserialize(new Deserializer(serializer.toUint8Array()));
-    expect(new Hex({ data: deserialzed.toUint8Array() })).toEqual(new Hex({ data: pubKeyMultiSig.toUint8Array() }));
+    expect(new Hex(deserialzed.toUint8Array())).toEqual(new Hex(pubKeyMultiSig.toUint8Array()));
   });
 });
 
@@ -86,25 +84,19 @@ describe("MultiSignature", () => {
     for (let i = 0; i < multiEd25519SigTestObject.signatures.length; i++) {
       edSigsArray.push(
         new Ed25519Signature({
-          hexInput: Hex.fromString({
-            str: multiEd25519SigTestObject.signatures[i],
-          }).toUint8Array(),
+          hexInput: Hex.fromString(multiEd25519SigTestObject.signatures[i]).toUint8Array(),
         }),
       );
     }
 
     const multisig = new MultiEd25519Signature({
       signatures: edSigsArray,
-      bitmap: Hex.fromString({
-        str: multiEd25519SigTestObject.bitmap,
-      }).toUint8Array(),
+      bitmap: Hex.fromString(multiEd25519SigTestObject.bitmap).toUint8Array(),
     });
 
-    expect(
-      Hex.fromHexInput({
-        hexInput: multisig.toUint8Array(),
-      }).toStringWithoutPrefix(),
-    ).toEqual(multiEd25519SigTestObject.bytesInStringWithoutPrefix);
+    expect(Hex.fromHexInput(multisig.toUint8Array()).toStringWithoutPrefix()).toEqual(
+      multiEd25519SigTestObject.bytesInStringWithoutPrefix,
+    );
   });
 
   it("should deserializes from bytes correctly", async () => {
@@ -112,26 +104,20 @@ describe("MultiSignature", () => {
     for (let i = 0; i < multiEd25519SigTestObject.signatures.length; i++) {
       edSigsArray.push(
         new Ed25519Signature({
-          hexInput: Hex.fromString({
-            str: multiEd25519SigTestObject.signatures[i],
-          }).toUint8Array(),
+          hexInput: Hex.fromString(multiEd25519SigTestObject.signatures[i]).toUint8Array(),
         }),
       );
     }
 
     const multisig = new MultiEd25519Signature({
       signatures: edSigsArray,
-      bitmap: Hex.fromString({
-        str: multiEd25519SigTestObject.bitmap,
-      }).toUint8Array(),
+      bitmap: Hex.fromString(multiEd25519SigTestObject.bitmap).toUint8Array(),
     });
 
     const serializer = new Serializer();
     serializer.serialize(multisig);
     const deserialzed = MultiEd25519Signature.deserialize(new Deserializer(serializer.toUint8Array()));
-    expect(Hex.fromHexInput({ hexInput: deserialzed.toUint8Array() })).toEqual(
-      Hex.fromHexInput({ hexInput: multisig.toUint8Array() }),
-    );
+    expect(Hex.fromHexInput(deserialzed.toUint8Array())).toEqual(Hex.fromHexInput(multisig.toUint8Array()));
   });
 
   it("should creates a valid bitmap", () => {

--- a/tests/unit/multi_ed25519.test.ts
+++ b/tests/unit/multi_ed25519.test.ts
@@ -20,9 +20,9 @@ describe("MultiPublicKey", () => {
 
     const multiPubKey = new MultiEd25519PublicKey({
       publicKeys: [
-        new Ed25519PublicKey({ hexInput: publicKey1 }),
-        new Ed25519PublicKey({ hexInput: publicKey2 }),
-        new Ed25519PublicKey({ hexInput: publicKey3 }),
+        new Ed25519PublicKey(publicKey1),
+        new Ed25519PublicKey(publicKey2),
+        new Ed25519PublicKey(publicKey3),
       ],
       threshold: 2,
     });
@@ -39,11 +39,7 @@ describe("MultiPublicKey", () => {
   it("should serializes to bytes correctly", async () => {
     let edPksArray = [];
     for (let i = 0; i < multiEd25519PkTestObject.public_keys.length; i++) {
-      edPksArray.push(
-        new Ed25519PublicKey({
-          hexInput: multiEd25519PkTestObject.public_keys[i],
-        }),
-      );
+      edPksArray.push(new Ed25519PublicKey(multiEd25519PkTestObject.public_keys[i]));
     }
 
     const pubKeyMultiSig = new MultiEd25519PublicKey({
@@ -59,11 +55,7 @@ describe("MultiPublicKey", () => {
   it("should deserializes from bytes correctly", async () => {
     let edPksArray = [];
     for (let i = 0; i < multiEd25519PkTestObject.public_keys.length; i++) {
-      edPksArray.push(
-        new Ed25519PublicKey({
-          hexInput: multiEd25519PkTestObject.public_keys[i],
-        }),
-      );
+      edPksArray.push(new Ed25519PublicKey(multiEd25519PkTestObject.public_keys[i]));
     }
 
     const pubKeyMultiSig = new MultiEd25519PublicKey({
@@ -82,11 +74,7 @@ describe("MultiSignature", () => {
   it("should serializes to bytes correctly", async () => {
     let edSigsArray = [];
     for (let i = 0; i < multiEd25519SigTestObject.signatures.length; i++) {
-      edSigsArray.push(
-        new Ed25519Signature({
-          hexInput: Hex.fromString(multiEd25519SigTestObject.signatures[i]).toUint8Array(),
-        }),
-      );
+      edSigsArray.push(new Ed25519Signature(Hex.fromString(multiEd25519SigTestObject.signatures[i]).toUint8Array()));
     }
 
     const multisig = new MultiEd25519Signature({
@@ -102,11 +90,7 @@ describe("MultiSignature", () => {
   it("should deserializes from bytes correctly", async () => {
     let edSigsArray = [];
     for (let i = 0; i < multiEd25519SigTestObject.signatures.length; i++) {
-      edSigsArray.push(
-        new Ed25519Signature({
-          hexInput: Hex.fromString(multiEd25519SigTestObject.signatures[i]).toUint8Array(),
-        }),
-      );
+      edSigsArray.push(new Ed25519Signature(Hex.fromString(multiEd25519SigTestObject.signatures[i]).toUint8Array()));
     }
 
     const multisig = new MultiEd25519Signature({

--- a/tests/unit/secp256k1.test.ts
+++ b/tests/unit/secp256k1.test.ts
@@ -37,7 +37,7 @@ describe("Secp256k1PublicKey", () => {
     });
 
     // Convert message to hex
-    const hexMsg = Hex.fromString({ str: secp256k1TestObject.messageEncoded });
+    const hexMsg = Hex.fromString(secp256k1TestObject.messageEncoded);
 
     // Verify with correct signed message
     expect(pubKey.verifySignature({ message: hexMsg.toUint8Array(), signature })).toBe(true);
@@ -99,7 +99,7 @@ describe("Secp256k1PrivateKey", () => {
     }).toUint8Array();
     const privateKey2 = new Secp256k1PrivateKey({ hexInput: hexUint8Array });
     expect(privateKey2).toBeInstanceOf(Secp256k1PrivateKey);
-    expect(privateKey2.toString()).toEqual(Hex.fromHexInput({ hexInput: hexUint8Array }).toString());
+    expect(privateKey2.toString()).toEqual(Hex.fromHexInput(hexUint8Array).toString());
   });
 
   it("should throw an error with invalid hex input length", () => {

--- a/tests/unit/secp256k1.test.ts
+++ b/tests/unit/secp256k1.test.ts
@@ -8,33 +8,27 @@ import { Deserializer, Hex, Secp256k1PrivateKey, Secp256k1PublicKey, Secp256k1Si
 describe("Secp256k1PublicKey", () => {
   it("should create the instance correctly without error", () => {
     // Create from string
-    const publicKey = new Secp256k1PublicKey({
-      hexInput: secp256k1TestObject.publicKey,
-    });
+    const publicKey = new Secp256k1PublicKey(secp256k1TestObject.publicKey);
     expect(publicKey).toBeInstanceOf(Secp256k1PublicKey);
     expect(publicKey.toString()).toEqual(secp256k1TestObject.publicKey);
 
     // // Create from Uint8Array
     const hexUint8Array = secp256k1.getPublicKey(secp256k1.utils.randomPrivateKey(), false);
-    const publicKey2 = new Secp256k1PublicKey({ hexInput: hexUint8Array });
+    const publicKey2 = new Secp256k1PublicKey(hexUint8Array);
     expect(publicKey2).toBeInstanceOf(Secp256k1PublicKey);
     expect(publicKey2.toUint8Array()).toEqual(hexUint8Array);
   });
 
   it("should throw an error with invalid hex input length", () => {
     const invalidHexInput = "0123456789abcdef"; // Invalid length
-    expect(() => new Secp256k1PublicKey({ hexInput: invalidHexInput })).toThrowError(
+    expect(() => new Secp256k1PublicKey(invalidHexInput)).toThrowError(
       `PublicKey length should be ${Secp256k1PublicKey.LENGTH}`,
     );
   });
 
   it("should verify the signature correctly", () => {
-    const pubKey = new Secp256k1PublicKey({
-      hexInput: secp256k1TestObject.publicKey,
-    });
-    const signature = new Secp256k1Signature({
-      hexInput: secp256k1TestObject.signatureHex,
-    });
+    const pubKey = new Secp256k1PublicKey(secp256k1TestObject.publicKey);
+    const signature = new Secp256k1Signature(secp256k1TestObject.signatureHex);
 
     // Convert message to hex
     const hexMsg = Hex.fromString(secp256k1TestObject.messageEncoded);
@@ -45,9 +39,7 @@ describe("Secp256k1PublicKey", () => {
     // Verify with incorrect signed message
     const incorrectSignedMessage =
       "0xc5de9e40ac00b371cd83b1c197fa5b665b7449b33cd3cdd305bb78222e06a671a49625ab9aea8a039d4bb70e275768084d62b094bc1b31964f2357b7c1af7e0a";
-    const invalidSignature = new Secp256k1Signature({
-      hexInput: incorrectSignedMessage,
-    });
+    const invalidSignature = new Secp256k1Signature(incorrectSignedMessage);
     expect(
       pubKey.verifySignature({
         message: secp256k1TestObject.messageEncoded,
@@ -57,15 +49,11 @@ describe("Secp256k1PublicKey", () => {
   });
 
   it("should serialize correctly", () => {
-    const publicKey = new Secp256k1PublicKey({
-      hexInput: secp256k1TestObject.publicKey,
-    });
+    const publicKey = new Secp256k1PublicKey(secp256k1TestObject.publicKey);
     const serializer = new Serializer();
     publicKey.serialize(serializer);
 
-    const serialized = Hex.fromHexInput({
-      hexInput: serializer.toUint8Array(),
-    }).toString();
+    const serialized = Hex.fromHexInput(serializer.toUint8Array()).toString();
     const expected =
       "0x4104acdd16651b839c24665b7e2033b55225f384554949fef46c397b5275f37f6ee95554d70fb5d9f93c5831ebf695c7206e7477ce708f03ae9bb2862dc6c9e033ea";
     expect(serialized).toEqual(expected);
@@ -74,9 +62,7 @@ describe("Secp256k1PublicKey", () => {
   it("should deserialize correctly", () => {
     const serializedPublicKeyStr =
       "0x4104acdd16651b839c24665b7e2033b55225f384554949fef46c397b5275f37f6ee95554d70fb5d9f93c5831ebf695c7206e7477ce708f03ae9bb2862dc6c9e033ea";
-    const serializedPublicKey = Hex.fromString({
-      str: serializedPublicKeyStr,
-    }).toUint8Array();
+    const serializedPublicKey = Hex.fromString(serializedPublicKeyStr).toUint8Array();
     const deserializer = new Deserializer(serializedPublicKey);
     const publicKey = Secp256k1PublicKey.deserialize(deserializer);
 
@@ -87,57 +73,43 @@ describe("Secp256k1PublicKey", () => {
 describe("Secp256k1PrivateKey", () => {
   it("should create the instance correctly without error", () => {
     // Create from string
-    const privateKey = new Secp256k1PrivateKey({
-      hexInput: secp256k1TestObject.privateKey,
-    });
+    const privateKey = new Secp256k1PrivateKey(secp256k1TestObject.privateKey);
     expect(privateKey).toBeInstanceOf(Secp256k1PrivateKey);
     expect(privateKey.toString()).toEqual(secp256k1TestObject.privateKey);
 
     // Create from Uint8Array
-    const hexUint8Array = Hex.fromString({
-      str: secp256k1TestObject.privateKey,
-    }).toUint8Array();
-    const privateKey2 = new Secp256k1PrivateKey({ hexInput: hexUint8Array });
+    const hexUint8Array = Hex.fromString(secp256k1TestObject.privateKey).toUint8Array();
+    const privateKey2 = new Secp256k1PrivateKey(hexUint8Array);
     expect(privateKey2).toBeInstanceOf(Secp256k1PrivateKey);
     expect(privateKey2.toString()).toEqual(Hex.fromHexInput(hexUint8Array).toString());
   });
 
   it("should throw an error with invalid hex input length", () => {
     const invalidHexInput = "0123456789abcdef"; // Invalid length
-    expect(() => new Secp256k1PrivateKey({ hexInput: invalidHexInput })).toThrowError(
+    expect(() => new Secp256k1PrivateKey(invalidHexInput)).toThrowError(
       `PrivateKey length should be ${Secp256k1PrivateKey.LENGTH}`,
     );
   });
 
   it("should sign the message correctly", () => {
-    const privateKey = new Secp256k1PrivateKey({
-      hexInput: secp256k1TestObject.privateKey,
-    });
-    const signedMessage = privateKey.sign({
-      message: secp256k1TestObject.messageEncoded,
-    });
+    const privateKey = new Secp256k1PrivateKey(secp256k1TestObject.privateKey);
+    const signedMessage = privateKey.sign(secp256k1TestObject.messageEncoded);
     expect(signedMessage.toString()).toEqual(secp256k1TestObject.signatureHex);
   });
 
   it("should serialize correctly", () => {
-    const privateKey = new Secp256k1PrivateKey({
-      hexInput: secp256k1TestObject.privateKey,
-    });
+    const privateKey = new Secp256k1PrivateKey(secp256k1TestObject.privateKey);
     const serializer = new Serializer();
     privateKey.serialize(serializer);
 
-    const received = Hex.fromHexInput({
-      hexInput: serializer.toUint8Array(),
-    }).toString();
+    const received = Hex.fromHexInput(serializer.toUint8Array()).toString();
     const expected = "0x20d107155adf816a0a94c6db3c9489c13ad8a1eda7ada2e558ba3bfa47c020347e";
     expect(received).toEqual(expected);
   });
 
   it("should deserialize correctly", () => {
     const serializedPrivateKeyStr = "0x20d107155adf816a0a94c6db3c9489c13ad8a1eda7ada2e558ba3bfa47c020347e";
-    const serializedPrivateKey = Hex.fromString({
-      str: serializedPrivateKeyStr,
-    }).toUint8Array();
+    const serializedPrivateKey = Hex.fromString(serializedPrivateKeyStr).toUint8Array();
     const deserializer = new Deserializer(serializedPrivateKey);
     const privateKey = Secp256k1PrivateKey.deserialize(deserializer);
 
@@ -145,9 +117,7 @@ describe("Secp256k1PrivateKey", () => {
   });
 
   it("should serialize and deserialize correctly", () => {
-    const privateKey = new Secp256k1PrivateKey({
-      hexInput: secp256k1TestObject.privateKey,
-    });
+    const privateKey = new Secp256k1PrivateKey(secp256k1TestObject.privateKey);
     const serializer = new Serializer();
     privateKey.serialize(serializer);
 
@@ -161,36 +131,30 @@ describe("Secp256k1PrivateKey", () => {
 describe("Secp256k1Signature", () => {
   it("should create an instance correctly without error", () => {
     // Create from string
-    const signatureStr = new Secp256k1Signature({
-      hexInput: secp256k1TestObject.signatureHex,
-    });
+    const signatureStr = new Secp256k1Signature(secp256k1TestObject.signatureHex);
     expect(signatureStr).toBeInstanceOf(Secp256k1Signature);
     expect(signatureStr.toString()).toEqual(secp256k1TestObject.signatureHex);
 
     // Create from Uint8Array
     const signatureValue = new Uint8Array(Secp256k1Signature.LENGTH);
-    const signature = new Secp256k1Signature({ hexInput: signatureValue });
+    const signature = new Secp256k1Signature(signatureValue);
     expect(signature).toBeInstanceOf(Secp256k1Signature);
     expect(signature.toUint8Array()).toEqual(signatureValue);
   });
 
   it("should throw an error with invalid value length", () => {
     const invalidSignatureValue = new Uint8Array(Secp256k1Signature.LENGTH - 1); // Invalid length
-    expect(() => new Secp256k1Signature({ hexInput: invalidSignatureValue })).toThrowError(
+    expect(() => new Secp256k1Signature(invalidSignatureValue)).toThrowError(
       `Signature length should be ${Secp256k1Signature.LENGTH}`,
     );
   });
 
   it("should serialize correctly", () => {
-    const signature = new Secp256k1Signature({
-      hexInput: secp256k1TestObject.signatureHex,
-    });
+    const signature = new Secp256k1Signature(secp256k1TestObject.signatureHex);
     const serializer = new Serializer();
     signature.serialize(serializer);
 
-    const received = Hex.fromHexInput({
-      hexInput: serializer.toUint8Array(),
-    }).toString();
+    const received = Hex.fromHexInput(serializer.toUint8Array()).toString();
     const expected =
       "0x403eda29841168c902b154ac12dfb0f8775ece1b95315b227ede64cbd715abac665aa8c8df5b108b0d4918bb88ea58c892972af375a71761a7e590655ff5de3859";
     expect(received).toEqual(expected);
@@ -199,9 +163,7 @@ describe("Secp256k1Signature", () => {
   it("should deserialize correctly", () => {
     const serializedSignature =
       "0x403eda29841168c902b154ac12dfb0f8775ece1b95315b227ede64cbd715abac665aa8c8df5b108b0d4918bb88ea58c892972af375a71761a7e590655ff5de3859";
-    const serializedSignatureUint8Array = Hex.fromString({
-      str: serializedSignature,
-    }).toUint8Array();
+    const serializedSignatureUint8Array = Hex.fromString(serializedSignature).toUint8Array();
     const deserializer = new Deserializer(serializedSignatureUint8Array);
     const signature = Secp256k1Signature.deserialize(deserializer);
 


### PR DESCRIPTION
### Description
For functions that clearly are single param, don't use object as params.

### Test Plan
pnpm test
