### PR TITLE
Add indexer version sync

### DIFF
--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -9,6 +9,7 @@ import {
   getTableItem,
   queryIndexer,
   view,
+  getIndexerLastSuccessVersion,
 } from "../internal/general";
 import {
   Block,
@@ -170,5 +171,9 @@ export class General {
       aptosConfig: this.config,
       ...args,
     });
+  }
+
+  async getIndexerLastSuccessVersion(): Promise<number> {
+    return getIndexerLastSuccessVersion({ aptosConfig: this.config });
   }
 }

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -13,6 +13,7 @@ import { getAptosFullNode, postAptosFullNode, postAptosIndexer } from "../client
 import {
   Block,
   GetChainTopUserTransactionsResponse,
+  GetProcessorStatusResponse,
   GraphqlQuery,
   LedgerInfo,
   LedgerVersion,
@@ -20,8 +21,8 @@ import {
   TableItemRequest,
   ViewRequest,
 } from "../types";
-import { GetChainTopUserTransactionsQuery } from "../types/generated/operations";
-import { GetChainTopUserTransactions } from "../types/generated/queries";
+import { GetChainTopUserTransactionsQuery, GetProcessorStatusQuery } from "../types/generated/operations";
+import { GetChainTopUserTransactions, GetProcessorStatus } from "../types/generated/queries";
 
 export async function getLedgerInfo(args: { aptosConfig: AptosConfig }): Promise<LedgerInfo> {
   const { aptosConfig } = args;
@@ -129,4 +130,25 @@ export async function queryIndexer<T>(args: {
     overrides: { WITH_CREDENTIALS: false },
   });
   return data;
+}
+
+export async function getProcessorStatuses(args: { aptosConfig: AptosConfig }): Promise<GetProcessorStatusResponse> {
+  const { aptosConfig } = args;
+
+  const graphqlQuery = {
+    query: GetProcessorStatus,
+  };
+
+  const data = await queryIndexer<GetProcessorStatusQuery>({
+    aptosConfig,
+    query: graphqlQuery,
+    originMethod: "getProcessorStatuses",
+  });
+
+  return data.processor_status;
+}
+
+export async function getIndexerLastSuccessVersion(args: { aptosConfig: AptosConfig }): Promise<number> {
+  const response = await getProcessorStatuses({ aptosConfig: args.aptosConfig });
+  return response[0].last_success_version;
 }

--- a/src/internal/queries/getProcessorStatus.graphql
+++ b/src/internal/queries/getProcessorStatus.graphql
@@ -1,0 +1,7 @@
+query getProcessorStatus {
+  processor_status {
+    last_success_version
+    processor
+    last_updated
+  }
+}

--- a/src/internal/transaction.ts
+++ b/src/internal/transaction.ts
@@ -21,6 +21,7 @@ import {
 import { DEFAULT_TXN_TIMEOUT_SEC } from "../utils/const";
 import { sleep } from "../utils/helpers";
 import { memoizeAsync } from "../utils/memoize";
+import { getIndexerLastSuccessVersion } from "./general";
 
 export async function getTransactions(args: {
   aptosConfig: AptosConfig;
@@ -96,11 +97,12 @@ export async function isTransactionPending(args: { aptosConfig: AptosConfig; txn
 export async function waitForTransaction(args: {
   aptosConfig: AptosConfig;
   txnHash: HexInput;
-  extraArgs?: { timeoutSecs?: number; checkSuccess?: boolean };
+  extraArgs?: { timeoutSecs?: number; checkSuccess?: boolean; indexerVersionCheck?: boolean };
 }): Promise<TransactionResponse> {
   const { aptosConfig, txnHash, extraArgs } = args;
   const timeoutSecs = extraArgs?.timeoutSecs ?? DEFAULT_TXN_TIMEOUT_SEC;
   const checkSuccess = extraArgs?.checkSuccess ?? true;
+  const indexerVersionCheck = extraArgs?.indexerVersionCheck ?? true;
 
   let isPending = true;
   let timeElapsed = 0;
@@ -167,7 +169,51 @@ export async function waitForTransaction(args: {
       lastTxn,
     );
   }
+
+  // Make sure indexer is synced with the latest ledger version
+  if (indexerVersionCheck) {
+    try {
+      await waitForLastSuccessIndexerVersionSync({ aptosConfig, ledgerVersion: Number(lastTxn.version) });
+    } catch (_e) {
+      throw new WaitForTransactionError(
+        `Transaction ${txnHash} commited, but timed out waiting for indexer to sync with ledger version ${lastTxn.version}.` +
+          "You can disable this check by setting `indexerVersionCheck` to false in the `extraArgs` parameter.",
+        lastTxn,
+      );
+    }
+  }
+
   return lastTxn;
+}
+
+/**
+ * Waits for the indexer to sync up to the ledgerVersion. Timeout is 3 seconds.
+ */
+async function waitForLastSuccessIndexerVersionSync(args: {
+  aptosConfig: AptosConfig;
+  ledgerVersion: number;
+}): Promise<void> {
+  const { aptosConfig, ledgerVersion } = args;
+  const timeoutMiliseconds = 3000; // 3 seconds
+  const startTime = new Date().getTime();
+  let indexerVersion = -1;
+
+  while (indexerVersion < ledgerVersion) {
+    // check for timeout
+    if (new Date().getTime() - startTime > timeoutMiliseconds) {
+      throw new Error("waitForLastSuccessIndexerVersionSync timeout");
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    indexerVersion = await getIndexerLastSuccessVersion({ aptosConfig });
+    if (indexerVersion >= ledgerVersion) {
+      // break out immediately if we are synced
+      break;
+    }
+
+    // eslint-disable-next-line no-await-in-loop
+    await sleep(200);
+  }
 }
 
 /**

--- a/src/types/generated/operations.ts
+++ b/src/types/generated/operations.ts
@@ -404,3 +404,9 @@ export type GetNumberOfDelegatorsQueryVariables = Types.Exact<{
 export type GetNumberOfDelegatorsQuery = {
   num_active_delegator_per_pool: Array<{ num_active_delegator?: any | null; pool_address?: string | null }>;
 };
+
+export type GetProcessorStatusQueryVariables = Types.Exact<{ [key: string]: never }>;
+
+export type GetProcessorStatusQuery = {
+  processor_status: Array<{ last_success_version: any; processor: string; last_updated: any }>;
+};

--- a/src/types/generated/queries.ts
+++ b/src/types/generated/queries.ts
@@ -273,6 +273,15 @@ export const GetNumberOfDelegators = `
   }
 }
     `;
+export const GetProcessorStatus = `
+    query getProcessorStatus {
+  processor_status {
+    last_success_version
+    processor
+    last_updated
+  }
+}
+    `;
 
 export type SdkFunctionWrapper = <T>(
   action: (requestHeaders?: Record<string, string>) => Promise<T>,
@@ -476,6 +485,20 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         "getNumberOfDelegators",
+        "query",
+      );
+    },
+    getProcessorStatus(
+      variables?: Types.GetProcessorStatusQueryVariables,
+      requestHeaders?: Dom.RequestInit["headers"],
+    ): Promise<Types.GetProcessorStatusQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<Types.GetProcessorStatusQuery>(GetProcessorStatus, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        "getProcessorStatus",
         "query",
       );
     },

--- a/src/types/indexer.ts
+++ b/src/types/indexer.ts
@@ -22,6 +22,7 @@ import {
   GetCollectionDataQuery,
   GetChainTopUserTransactionsQuery,
   GetEventsQuery,
+  GetProcessorStatusQuery,
 } from "./generated/operations";
 
 /**
@@ -49,6 +50,7 @@ export type GetEventsResponse = GetEventsQuery["events"];
 export type GetNumberOfDelegatorsResponse = GetNumberOfDelegatorsQuery["num_active_delegator_per_pool"];
 export type GetDelegatedStakingActivitiesResponse = GetDelegatedStakingActivitiesQuery["delegated_staking_activities"];
 export type GetCollectionDataResponse = GetCollectionDataQuery["current_collections_v2"][0];
+export type GetProcessorStatusResponse = GetProcessorStatusQuery["processor_status"];
 
 /**
  * A generic type that being passed by each function and holds an

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -2,8 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Account, Aptos, AptosConfig, Network, U64 } from "../../../src";
-import { sleep } from "../../../src/utils/helpers";
-import { INDEXER_WAIT_TIME } from "../../unit/helper";
 
 describe("account api", () => {
   const FUND_AMOUNT = 100_000_000;
@@ -120,7 +118,6 @@ describe("account api", () => {
       });
 
       await aptos.waitForTransaction({ txnHash: response });
-      await sleep(INDEXER_WAIT_TIME);
       const accountTransactionsCount = await aptos.getAccountTransactionsCount({
         accountAddress: senderAccount.accountAddress.toString(),
       });
@@ -137,8 +134,6 @@ describe("account api", () => {
       });
 
       await aptos.waitForTransaction({ txnHash: response });
-      // to help with indexer latency
-      await sleep(INDEXER_WAIT_TIME);
       const accountCoinData = await aptos.getAccountCoinsData({
         accountAddress: senderAccount.accountAddress.toString(),
       });
@@ -156,7 +151,6 @@ describe("account api", () => {
       });
 
       await aptos.waitForTransaction({ txnHash: response });
-      await sleep(INDEXER_WAIT_TIME);
       const accountCoinsCount = await aptos.getAccountCoinsCount({
         accountAddress: senderAccount.accountAddress.toString(),
       });

--- a/tests/e2e/api/coin.test.ts
+++ b/tests/e2e/api/coin.test.ts
@@ -1,8 +1,7 @@
 import { AptosConfig, Network, Aptos, Account, Deserializer, TypeTagStruct } from "../../../src";
 import { waitForTransaction } from "../../../src/internal/transaction";
 import { RawTransaction, TransactionPayloadEntryFunction } from "../../../src/transactions/instances";
-import { sleep } from "../../../src/utils/helpers";
-import { FUND_AMOUNT, INDEXER_WAIT_TIME } from "../../unit/helper";
+import { FUND_AMOUNT } from "../../unit/helper";
 
 describe("coin", () => {
   test("it generates a transfer coin transaction with AptosCoin coin type", async () => {
@@ -55,7 +54,6 @@ describe("coin", () => {
     const recipient = Account.generate();
 
     await aptos.fundAccount({ accountAddress: sender.accountAddress.toString(), amount: FUND_AMOUNT });
-    await sleep(INDEXER_WAIT_TIME);
     const senderCoinsBefore = await aptos.getAccountCoinsData({ accountAddress: sender.accountAddress.toString() });
 
     const transaction = await aptos.transferCoinTransaction({
@@ -66,8 +64,6 @@ describe("coin", () => {
     const response = await aptos.signAndSubmitTransaction({ signer: sender, transaction });
 
     await waitForTransaction({ aptosConfig: config, txnHash: response.hash });
-    // to help with indexer latency
-    await sleep(INDEXER_WAIT_TIME);
     const recipientCoins = await aptos.getAccountCoinsData({ accountAddress: recipient.accountAddress.toString() });
     const senderCoinsAfter = await aptos.getAccountCoinsData({ accountAddress: sender.accountAddress.toString() });
 

--- a/tests/e2e/api/event.test.ts
+++ b/tests/e2e/api/event.test.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Account, Aptos, AptosConfig, Network } from "../../../src";
-import { FUND_AMOUNT, INDEXER_WAIT_TIME, longTestTimeout } from "../../unit/helper";
-import { sleep } from "../../../src/utils/helpers";
+import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
 
 describe("Event", () => {
   test("it should get fund event by creation number and address", async () => {
@@ -13,7 +12,6 @@ describe("Event", () => {
     const testAccount = Account.generate();
     await aptos.fundAccount({ accountAddress: testAccount.accountAddress.toString(), amount: FUND_AMOUNT });
 
-    await sleep(INDEXER_WAIT_TIME);
     const events = await aptos.getAccountEventsByCreationNumber({
       address: testAccount.accountAddress.toString(),
       creationNumber: 0,
@@ -32,7 +30,6 @@ describe("Event", () => {
       amount: FUND_AMOUNT,
     });
 
-    await sleep(INDEXER_WAIT_TIME);
     const events = await aptos.getAccountEventsByEventType({
       address: testAccount.accountAddress.toString(),
       eventType: "0x1::account::CoinRegisterEvent",
@@ -51,7 +48,6 @@ describe("Event", () => {
       amount: FUND_AMOUNT,
     });
 
-    await sleep(INDEXER_WAIT_TIME);
     const events = await aptos.getEvents();
 
     expect(events.length).toBeGreaterThan(0);
@@ -74,7 +70,6 @@ describe("Event", () => {
         amount: FUND_AMOUNT,
       });
 
-      await sleep(INDEXER_WAIT_TIME);
       const events = await aptos.getEvents({
         options: { where: { account_address: { _eq: testAccount1.accountAddress.toString() } } },
       });

--- a/tests/unit/helper.ts
+++ b/tests/unit/helper.ts
@@ -1,7 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-export const INDEXER_WAIT_TIME = 1000;
 export const FUND_AMOUNT = 100_000_000;
 
 export const wallet = {


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

Update waitForTransaction to include and wait for indexer sync

1. Add `getProcessorStatus` to get the latest success version from indexer
2. Add method `getIndexerLastSuccessVersion` to fetch the last success version from indexer
3. Update waitForTransaction to include this check (Developer can opt-out if preferred)

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

pnpm fmt
pnpm test

### Related Links
<!-- Please link to any relevant issues or pull requests! -->