### PR TITLE
[hdkey] Consolidate and add testing for seed phrase derivation

### DIFF
--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -1,13 +1,11 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import * as bip39 from "@scure/bip39";
-import { bytesToHex } from "@noble/hashes/utils";
 import { AccountAddress } from "./account_address";
 import { Hex } from "./hex";
 import { HexInput, SigningScheme } from "../types";
 import { PrivateKey, PublicKey, Signature } from "./crypto/asymmetric_crypto";
-import { derivePath } from "../utils/hdKey";
+import { derivePrivateKeyFromMnemonic, ED25519_KEY } from "../utils/hdKey";
 import { AuthenticationKey } from "./authentication_key";
 import { Ed25519PrivateKey, Ed25519PublicKey } from "./crypto/ed25519";
 import { Secp256k1PrivateKey, Secp256k1PublicKey } from "./crypto/secp256k1";
@@ -137,26 +135,10 @@ export class Account {
    */
   static fromDerivationPath(args: { path: string; mnemonic: string }): Account {
     const { path, mnemonic } = args;
-    if (!Account.isValidPath({ path })) {
-      throw new Error("Invalid derivation path");
-    }
 
-    const normalizeMnemonics = mnemonic
-      .trim()
-      .split(/\s+/)
-      .map((part) => part.toLowerCase())
-      .join(" ");
-
-    const { key } = derivePath(path, bytesToHex(bip39.mnemonicToSeedSync(normalizeMnemonics)));
+    const { key } = derivePrivateKeyFromMnemonic(ED25519_KEY, path, mnemonic);
     const privateKey = new Ed25519PrivateKey(key);
     return Account.fromPrivateKey({ privateKey });
-  }
-
-  /**
-   * Check's if the derive path is valid
-   */
-  static isValidPath(args: { path: string }): boolean {
-    return /^m\/44'\/637'\/[0-9]+'\/[0-9]+'\/[0-9]+'+$/.test(args.path);
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from "./bcs";
 export * from "./types";
 export * from "./transactions/types";
 export * from "./transactions/typeTag/typeTag";
+export * from "./utils/hdKey";

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -65,13 +65,6 @@ describe("Ed25519 Account", () => {
     expect(() => Account.fromDerivationPath({ path, mnemonic })).toThrow("Invalid derivation path");
   });
 
-  it("should check if a derivation path is valid", () => {
-    const validPath = wallet.path; // Valid path
-    const invalidPath = "invalid/path"; // Invalid path
-    expect(Account.isValidPath({ path: validPath })).toBe(true);
-    expect(Account.isValidPath({ path: invalidPath })).toBe(false);
-  });
-
   it("should return the authentication key for a public key", () => {
     const { publicKey: publicKeyBytes, address } = ed25519;
     const publicKey = new Ed25519PublicKey(publicKeyBytes);
@@ -140,13 +133,6 @@ describe("Secp256k1 Account", () => {
     const { mnemonic } = wallet;
     const path = "1234";
     expect(() => Account.fromDerivationPath({ path, mnemonic })).toThrow("Invalid derivation path");
-  });
-
-  it("should check if a derivation path is valid", () => {
-    const validPath = wallet.path; // Valid path
-    const invalidPath = "invalid/path"; // Invalid path
-    expect(Account.isValidPath({ path: validPath })).toBe(true);
-    expect(Account.isValidPath({ path: invalidPath })).toBe(false);
   });
 
   it("should return the authentication key for a public key", () => {

--- a/tests/unit/hdKey.test.ts
+++ b/tests/unit/hdKey.test.ts
@@ -1,0 +1,43 @@
+import { wallet } from "./helper";
+import { derivePrivateKeyFromMnemonic, ED25519_KEY, isValidPath } from "../../src/utils/hdKey";
+import { Hex } from "../../src";
+
+describe("Hierarchical Deterministic Key (hdkey)", () => {
+  it("Parsing a valid path should work", () => {
+    expect(isValidPath(wallet.path)).toBe(true);
+    // Combinations of hardened allowed
+    expect(isValidPath("m/44'/637'/0'/0'/1")).toBe(true);
+    expect(isValidPath("m/44'/637'/0'/0'/1'")).toBe(true);
+    // Other numbers are accepted
+    expect(isValidPath("m/44'/637'/0'/0'/2")).toBe(true);
+    expect(isValidPath("m/44'/637'/0'/2'/2")).toBe(true);
+    expect(isValidPath("m/44'/637'/22'/22'/22")).toBe(true);
+  });
+  it("Parsing a invalid path should not work", () => {
+    // All beginning fields have to be hardened
+    expect(isValidPath("m/44/637/0/0/1")).toBe(false);
+    expect(isValidPath("m/44'/637/0/0/1")).toBe(false);
+    expect(isValidPath("m/44'/637'/0/0/1")).toBe(false);
+    expect(isValidPath("m/44'/637'/0'/0/1")).toBe(false);
+    // We don't accept `h`, only `'` is accepted
+    expect(isValidPath("m/44'/637'/0h/0/0")).toBe(false);
+    // No number
+    expect(isValidPath("m/44'/637'/a/0/0")).toBe(false);
+    // Invalid chain code
+    expect(isValidPath("m/44'/638'/0/0/0")).toBe(false);
+    // Not enough pieces
+    expect(isValidPath("m/44'/637'/")).toBe(false);
+    expect(isValidPath("m/44'/637'/0")).toBe(false);
+    expect(isValidPath("m/44'/637'/0/0")).toBe(false);
+    // Extra slash
+    expect(isValidPath("m/44'/637'/0/0/0/")).toBe(false);
+  });
+
+  it("Deriving a key is valid and different with different paths", () => {
+    const keys0 = derivePrivateKeyFromMnemonic(ED25519_KEY, wallet.path, wallet.mnemonic);
+    const keys1 = derivePrivateKeyFromMnemonic(ED25519_KEY, wallet.path.replace("0", "1"), wallet.mnemonic);
+    expect(keys0.key).toEqual(Hex.fromHexInput(wallet.privateKey).toUint8Array());
+    expect(keys0.key).not.toEqual(keys1.key);
+    expect(keys0.chainCode).not.toEqual(keys1.chainCode);
+  });
+});

--- a/tests/unit/helper.ts
+++ b/tests/unit/helper.ts
@@ -8,6 +8,8 @@ export const wallet = {
   address: "0x07968dab936c1bad187c60ce4082f307d030d780e91e694ae03aef16aba73f30",
   mnemonic: "shoot island position soft burden budget tooth cruel issue economy destroy above",
   path: "m/44'/637'/0'/0'/0'",
+  privateKey: "0x5d996aa76b3212142792d9130796cd2e11e3c445a93118c08414df4f66bc60ec",
+  publicKey: "0xea526ba1710343d953461ff68641f1b7df5f23b9042ffa2d2a798d3adb3f3d6c",
 };
 
 /* eslint-disable max-len */


### PR DESCRIPTION
### Description
Cleans up and adds proper testing for seed phrase derivation.  This also opens up the path for
derivation of other keys.

Additionally, this removes `isValidPath` from the Account class, as it doesn't really belong there, but instead it is separate on it's own.

### Test Plan
Added testing for valid and invalid seed phrases, ensured that derivation changes based on the path, and that the key derivation is correct.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->