### PR TITLE
[api] Fix view functions to return multiple values

### DIFF
--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -124,11 +124,11 @@ export class General {
    * };
    * `
    *
-   * @returns a Move value
+   * @returns an array of Move values
    */
-  async view(args: { payload: ViewRequest; options?: LedgerVersion }): Promise<MoveValue> {
+  async view(args: { payload: ViewRequest; options?: LedgerVersion }): Promise<Array<MoveValue>> {
     const data = await view({ aptosConfig: this.config, ...args });
-    return data[0];
+    return data;
   }
 
   /**

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -47,7 +47,7 @@ describe("general api", () => {
 
     const chainId = await aptos.view({ payload });
 
-    expect(chainId).toBe(4);
+    expect(chainId[0]).toBe(4);
   });
 
   test("it fetches table item data", async () => {


### PR DESCRIPTION
### Description
If a view function returns a tuple, it will return multiple values. This changes the assumption that there is only one return value.


### Test Plan
Adjusted the existing test, but need a new contract to show a view function that has more than one return value 

### Related Links
<!-- Please link to any relevant issues or pull requests! -->