### PR TITLE
Unify query pagination types

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -10,7 +10,6 @@ import {
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
   HexInput,
-  IndexerPaginationArgs,
   LedgerVersion,
   MoveModuleBytecode,
   MoveResource,
@@ -208,7 +207,7 @@ export class Account {
     accountAddress: HexInput;
     options?: {
       tokenStandard?: TokenStandard;
-      pagination?: IndexerPaginationArgs;
+      pagination?: PaginationArgs;
       orderBy?: OrderBy<GetAccountOwnedTokensQueryResponse[0]>;
     };
   }): Promise<GetAccountOwnedTokensQueryResponse> {
@@ -233,7 +232,7 @@ export class Account {
     collectionAddress: HexInput;
     options?: {
       tokenStandard?: TokenStandard;
-      pagination?: IndexerPaginationArgs;
+      pagination?: PaginationArgs;
       orderBy?: OrderBy<GetAccountOwnedTokensFromCollectionResponse[0]>;
     };
   }): Promise<GetAccountOwnedTokensFromCollectionResponse> {
@@ -256,7 +255,7 @@ export class Account {
     accountAddress: HexInput;
     options?: {
       tokenStandard?: TokenStandard;
-      pagination?: IndexerPaginationArgs;
+      pagination?: PaginationArgs;
       orderBy?: OrderBy<GetAccountCollectionsWithOwnedTokenResponse[0]>;
     };
   }): Promise<GetAccountCollectionsWithOwnedTokenResponse> {
@@ -288,7 +287,7 @@ export class Account {
   async getAccountCoinsData(args: {
     accountAddress: HexInput;
     options?: {
-      pagination?: IndexerPaginationArgs;
+      pagination?: PaginationArgs;
       orderBy?: OrderBy<GetAccountCoinsDataResponse[0]>;
     };
   }): Promise<GetAccountCoinsDataResponse> {
@@ -317,7 +316,7 @@ export class Account {
   async getAccountOwnedObjects(args: {
     ownerAddress: HexInput;
     options?: {
-      pagination?: IndexerPaginationArgs;
+      pagination?: PaginationArgs;
       orderBy?: OrderBy<GetAccountOwnedObjectsResponse[0]>;
     };
   }): Promise<GetAccountOwnedObjectsResponse> {

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getAccountEventsByCreationNumber, getAccountEventsByEventType, getEvents } from "../internal/event";
-import { AnyNumber, GetEventsResponse, IndexerPaginationArgs, MoveResourceType, OrderBy } from "../types";
+import { AnyNumber, GetEventsResponse, MoveResourceType, OrderBy, PaginationArgs } from "../types";
 import { EventsBoolExp } from "../types/generated/types";
 import { AptosConfig } from "./aptos_config";
 
@@ -28,7 +28,7 @@ export class Event {
     address: string;
     creationNumber: AnyNumber;
     options?: {
-      pagination?: IndexerPaginationArgs;
+      pagination?: PaginationArgs;
       orderBy?: OrderBy<GetEventsResponse[0]>;
     };
   }): Promise<GetEventsResponse> {
@@ -47,7 +47,7 @@ export class Event {
     address: string;
     eventType: MoveResourceType;
     options?: {
-      pagination?: IndexerPaginationArgs;
+      pagination?: PaginationArgs;
       orderBy?: OrderBy<GetEventsResponse[0]>;
     };
   }): Promise<GetEventsResponse> {
@@ -73,7 +73,7 @@ export class Event {
   async getEvents(args?: {
     options?: {
       where?: EventsBoolExp;
-      pagination?: IndexerPaginationArgs;
+      pagination?: PaginationArgs;
       orderBy?: OrderBy<GetEventsResponse[0]>;
     };
   }): Promise<GetEventsResponse> {

--- a/src/client/get.ts
+++ b/src/client/get.ts
@@ -81,7 +81,7 @@ export async function paginateWithCursor<Req extends Record<string, any>, Res ex
 ): Promise<Res> {
   const out = [];
   let cursor: string | undefined;
-  const requestParams = options.params as Req & { start?: string };
+  const requestParams = options.params as Req & { start?: string; limit?: number };
   // eslint-disable-next-line no-constant-condition
   while (true) {
     requestParams.start = cursor;

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -20,7 +20,6 @@ import {
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
   HexInput,
-  IndexerPaginationArgs,
   LedgerVersion,
   MoveModuleBytecode,
   MoveResource,
@@ -78,7 +77,7 @@ export async function getModules(args: {
     }).toString()}/modules`,
     params: {
       ledger_version: options?.ledgerVersion,
-      start: options?.start,
+      start: options?.offset,
       limit: options?.limit ?? 1000,
     },
   });
@@ -145,7 +144,7 @@ export async function getTransactions(args: {
     path: `accounts/${AccountAddress.fromHexInput({
       input: accountAddress,
     }).toString()}/transactions`,
-    params: { start: options?.start, limit: options?.limit },
+    params: { start: options?.offset, limit: options?.limit },
   });
   return data;
 }
@@ -164,7 +163,7 @@ export async function getResources(args: {
     }).toString()}/resources`,
     params: {
       ledger_version: options?.ledgerVersion,
-      start: options?.start,
+      start: options?.offset,
       limit: options?.limit ?? 999,
     },
   });
@@ -266,7 +265,7 @@ export async function getAccountOwnedTokens(args: {
   accountAddress: HexInput;
   options?: {
     tokenStandard?: TokenStandard;
-    pagination?: IndexerPaginationArgs;
+    pagination?: PaginationArgs;
     orderBy?: OrderBy<GetAccountOwnedTokensQueryResponse[0]>;
   };
 }): Promise<GetAccountOwnedTokensQueryResponse> {
@@ -309,7 +308,7 @@ export async function getAccountOwnedTokensFromCollectionAddress(args: {
   collectionAddress: HexInput;
   options?: {
     tokenStandard?: TokenStandard;
-    pagination?: IndexerPaginationArgs;
+    pagination?: PaginationArgs;
     orderBy?: OrderBy<GetAccountOwnedTokensFromCollectionResponse[0]>;
   };
 }): Promise<GetAccountOwnedTokensFromCollectionResponse> {
@@ -353,7 +352,7 @@ export async function getAccountCollectionsWithOwnedTokens(args: {
   accountAddress: HexInput;
   options?: {
     tokenStandard?: TokenStandard;
-    pagination?: IndexerPaginationArgs;
+    pagination?: PaginationArgs;
     orderBy?: OrderBy<GetAccountCollectionsWithOwnedTokenResponse[0]>;
   };
 }): Promise<GetAccountCollectionsWithOwnedTokenResponse> {
@@ -424,7 +423,7 @@ export async function getAccountCoinsData(args: {
   aptosConfig: AptosConfig;
   accountAddress: HexInput;
   options?: {
-    pagination?: IndexerPaginationArgs;
+    pagination?: PaginationArgs;
     orderBy?: OrderBy<GetAccountCoinsDataResponse[0]>;
   };
 }): Promise<GetAccountCoinsDataResponse> {
@@ -487,7 +486,7 @@ export async function getAccountOwnedObjects(args: {
   aptosConfig: AptosConfig;
   ownerAddress: HexInput;
   options?: {
-    pagination?: IndexerPaginationArgs;
+    pagination?: PaginationArgs;
     orderBy?: OrderBy<GetAccountOwnedObjectsResponse[0]>;
   };
 }): Promise<GetAccountOwnedObjectsResponse> {

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -10,7 +10,7 @@
 
 import { AptosConfig } from "../api/aptos_config";
 import { AccountAddress } from "../core";
-import { AnyNumber, GetEventsResponse, HexInput, IndexerPaginationArgs, MoveResourceType, OrderBy } from "../types";
+import { AnyNumber, GetEventsResponse, HexInput, PaginationArgs, MoveResourceType, OrderBy } from "../types";
 import { GetEventsQuery } from "../types/generated/operations";
 import { GetEvents } from "../types/generated/queries";
 import { EventsBoolExp } from "../types/generated/types";
@@ -37,7 +37,7 @@ export async function getAccountEventsByEventType(args: {
   address: HexInput;
   eventType: MoveResourceType;
   options?: {
-    pagination?: IndexerPaginationArgs;
+    pagination?: PaginationArgs;
     orderBy?: OrderBy<GetEventsResponse[0]>;
   };
 }): Promise<GetEventsResponse> {
@@ -62,7 +62,7 @@ export async function getEvents(args: {
   aptosConfig: AptosConfig;
   options?: {
     where?: EventsBoolExp;
-    pagination?: IndexerPaginationArgs;
+    pagination?: PaginationArgs;
     orderBy?: OrderBy<GetEventsResponse[0]>;
   };
 }): Promise<GetEventsResponse> {
@@ -70,10 +70,12 @@ export async function getEvents(args: {
 
   const graphqlQuery = {
     query: GetEvents,
-    variables: { where_condition: options?.where },
-    offset: options?.pagination?.offset,
-    limit: options?.pagination?.limit,
-    order_by: options?.orderBy,
+    variables: {
+      where_condition: options?.where,
+      offset: options?.pagination?.offset,
+      limit: options?.pagination?.limit,
+      order_by: options?.orderBy,
+    },
   };
 
   const data = await queryIndexer<GetEventsQuery>({

--- a/src/internal/transaction.ts
+++ b/src/internal/transaction.ts
@@ -32,7 +32,7 @@ export async function getTransactions(args: {
     aptosConfig,
     originMethod: "getTransactions",
     path: "transactions",
-    params: { start: options?.start, limit: options?.limit },
+    params: { start: options?.offset, limit: options?.limit },
   });
   return data;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -131,11 +131,11 @@ export type AptosSettings = {
 /**
  *
  * Controls the number of results that are returned and the starting position of those results.
- * @param start parameter specifies the starting position of the query result within the set of data. Default is 0.
+ * @param offset parameter specifies the starting position of the query result within the set of data. Default is 0.
  * @param limit specifies the maximum number of items or records to return in a query result. Default is 25.
  */
 export interface PaginationArgs {
-  start?: AnyNumber;
+  offset?: AnyNumber;
   limit?: number;
 }
 

--- a/src/types/indexer.ts
+++ b/src/types/indexer.ts
@@ -71,17 +71,6 @@ export type OrderByValue =
 export type TokenStandard = "v1" | "v2";
 
 /**
- *
- * Controls the number of results that are returned and the starting position of those results.
- * @param offset parameter specifies the starting position of the query result within the set of data. Default is 0.
- * @param limit specifies the maximum number of items or records to return in a query result. Default is 10.
- */
-export interface IndexerPaginationArgs {
-  offset?: number | bigint;
-  limit?: number;
-}
-
-/**
  * The graphql query type to pass into the `queryIndexer` function
  */
 export type GraphqlQuery = {

--- a/tests/e2e/api/paginate_query.test.ts
+++ b/tests/e2e/api/paginate_query.test.ts
@@ -1,0 +1,20 @@
+import { AptosConfig, Network, Aptos } from "../../../src";
+
+test("it should paginate correctly on indexer queries", async () => {
+  const config = new AptosConfig({ network: Network.LOCAL });
+  const aptos = new Aptos(config);
+
+  const events = await aptos.getEvents();
+  // Expect more than 10 events
+  expect(events.length).toBeGreaterThan(10);
+  const firstTenEvents = await aptos.getEvents({ options: { pagination: { limit: 10 } } });
+  // Expect fetch only first 10 events
+  expect(firstTenEvents.length).toBe(10);
+  // expect last event data is not the same as the last event data from previous call
+  expect(firstTenEvents[firstTenEvents.length - 1]).not.toStrictEqual(events[events.length - 1]);
+  const onlyNextTwentyEvents = await aptos.getEvents({ options: { pagination: { offset: 10, limit: 10 } } });
+  // expect only next 20 events
+  expect(onlyNextTwentyEvents.length).toBe(10);
+  // expect first event data is not the same as the first event data from previous call
+  expect(firstTenEvents[0]).not.toStrictEqual(onlyNextTwentyEvents[0]);
+});

--- a/tests/e2e/api/transaction_builder.test.ts
+++ b/tests/e2e/api/transaction_builder.test.ts
@@ -22,7 +22,7 @@ import {
 } from "../../../src/transactions/transaction_builder/transaction_builder";
 import { SignedTransaction } from "../../../src/transactions/instances/signedTransaction";
 import { MoveObject } from "../../../src/bcs/serializable/move-structs";
-import { FUND_AMOUNT } from "../../unit/helper";
+import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
 
 /* eslint-disable max-len */
 describe("transaction builder", () => {
@@ -207,35 +207,39 @@ describe("transaction builder", () => {
       expect(transaction.feePayerAddress?.data).toStrictEqual(feePayer.accountAddress.toUint8Array());
     });
 
-    test("it returns a serialized raw transaction, secondary signers addresses and a fee payer address", async () => {
-      const config = new AptosConfig({ network: Network.LOCAL });
-      const aptos = new Aptos(config);
-      const alice = Account.generate();
-      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: FUND_AMOUNT });
-      const bob = Account.generate();
-      const payload = generateTransactionPayload({
-        function: "0x1::aptos_account::transfer",
-        type_arguments: [],
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
-      });
-      const feePayer = Account.generate();
-      const secondarySignerAddress = Account.generate();
-      const transaction = await buildTransaction({
-        aptosConfig: config,
-        sender: alice.accountAddress.toString(),
-        payload,
-        secondarySignerAddresses: [secondarySignerAddress.accountAddress.toString()],
-        feePayerAddress: feePayer.accountAddress.toString(),
-      });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
-      expect(transaction.secondarySignerAddresses).not.toBeUndefined();
-      expect(transaction.secondarySignerAddresses?.length).toBe(1);
-      expect(transaction.secondarySignerAddresses![0].data).toStrictEqual(
-        secondarySignerAddress.accountAddress.toUint8Array(),
-      );
-      expect(transaction.feePayerAddress).not.toBeUndefined();
-      expect(transaction.feePayerAddress?.data).toStrictEqual(feePayer.accountAddress.toUint8Array());
-    });
+    test(
+      "it returns a serialized raw transaction, secondary signers addresses and a fee payer address",
+      async () => {
+        const config = new AptosConfig({ network: Network.LOCAL });
+        const aptos = new Aptos(config);
+        const alice = Account.generate();
+        await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: FUND_AMOUNT });
+        const bob = Account.generate();
+        const payload = generateTransactionPayload({
+          function: "0x1::aptos_account::transfer",
+          type_arguments: [],
+          arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        });
+        const feePayer = Account.generate();
+        const secondarySignerAddress = Account.generate();
+        const transaction = await buildTransaction({
+          aptosConfig: config,
+          sender: alice.accountAddress.toString(),
+          payload,
+          secondarySignerAddresses: [secondarySignerAddress.accountAddress.toString()],
+          feePayerAddress: feePayer.accountAddress.toString(),
+        });
+        expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+        expect(transaction.secondarySignerAddresses).not.toBeUndefined();
+        expect(transaction.secondarySignerAddresses?.length).toBe(1);
+        expect(transaction.secondarySignerAddresses![0].data).toStrictEqual(
+          secondarySignerAddress.accountAddress.toUint8Array(),
+        );
+        expect(transaction.feePayerAddress).not.toBeUndefined();
+        expect(transaction.feePayerAddress?.data).toStrictEqual(feePayer.accountAddress.toUint8Array());
+      },
+      longTestTimeout,
+    );
   });
   describe("generateSignedTransactionForSimulation", () => {
     test("it generates a signed raw transaction for simulation", async () => {

--- a/tests/e2e/api/transaction_submission.test.ts
+++ b/tests/e2e/api/transaction_submission.test.ts
@@ -11,7 +11,7 @@ import {
   TransactionPayloadMultisig,
   TransactionPayloadScript,
 } from "../../../src/transactions/instances";
-import { FUND_AMOUNT } from "../../unit/helper";
+import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
 
 describe("transaction submission", () => {
   describe("generateTransaction", () => {
@@ -186,47 +186,51 @@ describe("transaction submission", () => {
     });
   });
   describe("submitTransaction", () => {
-    test("it submits a script transaction", async () => {
-      const config = new AptosConfig({ network: Network.LOCAL });
-      const aptos = new Aptos(config);
-      const alice = Account.generate();
-      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: FUND_AMOUNT });
-      const bob = Account.generate();
-      await aptos.fundAccount({ accountAddress: bob.accountAddress.toString(), amount: FUND_AMOUNT });
-      const rawTxn = await aptos.generateTransaction({
-        sender: alice.accountAddress.toString(),
-        secondarySignerAddresses: [bob.accountAddress.toString()],
-        data: {
-          bytecode:
-            // eslint-disable-next-line max-len
-            "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-          type_arguments: [],
-          arguments: [
-            new U64(BigInt(100)),
-            new U64(BigInt(200)),
-            bob.accountAddress,
-            alice.accountAddress,
-            new U64(BigInt(50)),
-          ],
-        },
-      });
-      const authenticator = aptos.signTransaction({
-        signer: alice,
-        transaction: rawTxn,
-      });
-      const bobauthenticator = aptos.signTransaction({
-        signer: bob,
-        transaction: rawTxn,
-      });
-      const response = await aptos.submitTransaction({
-        transaction: rawTxn,
-        senderAuthenticator: authenticator,
-        secondarySignerAuthenticators: {
-          additionalSignersAuthenticators: [bobauthenticator],
-        },
-      });
-      await waitForTransaction({ aptosConfig: config, txnHash: response.hash });
-    });
+    test(
+      "it submits a script transaction",
+      async () => {
+        const config = new AptosConfig({ network: Network.LOCAL });
+        const aptos = new Aptos(config);
+        const alice = Account.generate();
+        await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: FUND_AMOUNT });
+        const bob = Account.generate();
+        await aptos.fundAccount({ accountAddress: bob.accountAddress.toString(), amount: FUND_AMOUNT });
+        const rawTxn = await aptos.generateTransaction({
+          sender: alice.accountAddress.toString(),
+          secondarySignerAddresses: [bob.accountAddress.toString()],
+          data: {
+            bytecode:
+              // eslint-disable-next-line max-len
+              "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
+            type_arguments: [],
+            arguments: [
+              new U64(BigInt(100)),
+              new U64(BigInt(200)),
+              bob.accountAddress,
+              alice.accountAddress,
+              new U64(BigInt(50)),
+            ],
+          },
+        });
+        const authenticator = aptos.signTransaction({
+          signer: alice,
+          transaction: rawTxn,
+        });
+        const bobauthenticator = aptos.signTransaction({
+          signer: bob,
+          transaction: rawTxn,
+        });
+        const response = await aptos.submitTransaction({
+          transaction: rawTxn,
+          senderAuthenticator: authenticator,
+          secondarySignerAuthenticators: {
+            additionalSignersAuthenticators: [bobauthenticator],
+          },
+        });
+        await waitForTransaction({ aptosConfig: config, txnHash: response.hash });
+      },
+      longTestTimeout,
+    );
 
     test("it submits an entry function transaction", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
@@ -239,7 +243,7 @@ describe("transaction submission", () => {
         data: {
           function: "0x1::aptos_account::transfer",
           type_arguments: [],
-          arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+          arguments: [bob.accountAddress, new U64(1)],
         },
       });
       const authenticator = aptos.signTransaction({


### PR DESCRIPTION
### Description
Unify indexer and fullnode pagination type into one type and handle the proper assignment in the function.

Note: pagination currently doesnt work for any (fullnode) function that uses `paginateWithCursor` (pretty sure it had never worked) - there is an open item for it, can work on it later.

now 
```
export interface PaginationArgs {
  offset?: AnyNumber;
  limit?: number;
}
```

before
```
export interface PaginationArgs {
  offset?: AnyNumber;
  limit?: number;
}

export interface IndexerPaginationArgs {
  offset?: number | bigint;
  limit?: number;
}
```

### Test Plan
pnpm test