### PR TITLE
Fix examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,22 +1,22 @@
 ## Examples
 
-These examples show how to build common tasks in Javascript, Typescript (CommonJS) and Typescript ESM.
+These examples show how to build common tasks in Javascript and Typescript.
 
 ### Running an example
 
 These examples use a linked version of the `aptos` package from the main repository. To run a test, first build the
-package in the top level directory.
+package in the top level directory of this repo.
 
 ```bash
   pnpm build
 ```
 
-At this point, you can run any of the examples in this directory. For example, to run the `create-account` example:
+At this point, you can run any of the examples in this directory. For example, to run the `simple_transfer` example:
 
 ```bash
   cd examples/javascript/simple_transfer
   pnpm install
-  pnpm test
+  pnpm run simple_transfer
 ```
 
 This will then print out the results of the test accordingly.

--- a/examples/javascript/simple_transfer.js
+++ b/examples/javascript/simple_transfer.js
@@ -79,11 +79,7 @@ const example = async () => {
   });
 
   console.log("\n=== Transfer transaction ===\n");
-  let signature = sdk.signTransaction({ signer: alice, transaction: txn });
-  const committedTxn = await sdk.submitTransaction({
-    transaction: txn,
-    senderAuthenticator: signature,
-  });
+  let committedTxn = await sdk.signAndSubmitTransaction({ signer: alice, transaction: txn });
   console.log(`Committed transaction: ${committedTxn.hash}`);
   await sdk.waitForTransaction({ txnHash: committedTxn.hash });
 

--- a/examples/typescript/simple_transfer.ts
+++ b/examples/typescript/simple_transfer.ts
@@ -76,11 +76,8 @@ const example = async () => {
   });
 
   console.log("\n=== Transfer transaction ===\n");
-  let signature = aptos.transactionSubmission.signTransaction({ signer: alice, transaction: txn });
-  const committedTxn = await aptos.transactionSubmission.submitTransaction({
-    transaction: txn,
-    senderAuthenticator: signature,
-  });
+  let committedTxn = await aptos.signAndSubmitTransaction({ signer: alice, transaction: txn });
+
   await aptos.waitForTransaction({ txnHash: committedTxn.hash });
   console.log(`Committed transaction: ${committedTxn.hash}`);
 


### PR DESCRIPTION
### Description
* Have single signer examples use `signAndSumitTransaction`
* Update README
