### PR TITLE
Make type_arguments optional and publically rename to typeArguments

### DIFF
--- a/examples/javascript/simple_sponsored_transaction.js
+++ b/examples/javascript/simple_sponsored_transaction.js
@@ -56,7 +56,6 @@ const TRANSFER_AMOUNT = 10;
     feePayerAddress: sponsorAddress,
     data: {
       function: "0x1::aptos_account::transfer",
-      type_arguments: [],
       arguments: [bob.accountAddress, new aptos.U64(TRANSFER_AMOUNT)],
     },
   });

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -56,7 +56,6 @@ const example = async () => {
     feePayerAddress: sponsorAddress,
     data: {
       function: "0x1::aptos_account::transfer",
-      type_arguments: [],
       arguments: [bob.accountAddress, new U64(TRANSFER_AMOUNT)],
     },
   });

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -19,7 +19,7 @@ import {
   LedgerVersion,
   MoveValue,
   TableItemRequest,
-  ViewRequest,
+  ViewRequestData,
 } from "../types";
 import { AptosConfig } from "./aptos_config";
 
@@ -127,7 +127,7 @@ export class General {
    *
    * @returns an array of Move values
    */
-  async view(args: { payload: ViewRequest; options?: LedgerVersion }): Promise<Array<MoveValue>> {
+  async view(args: { payload: ViewRequestData; options?: LedgerVersion }): Promise<Array<MoveValue>> {
     const data = await view({ aptosConfig: this.config, ...args });
     return data;
   }

--- a/src/bcs/serializable/fixed-bytes.ts
+++ b/src/bcs/serializable/fixed-bytes.ts
@@ -26,7 +26,7 @@ import { TransactionArgument } from "../../transactions/instances/transactionArg
  *  const fixedBytes = new FixedBytes(yourCustomSerializedBytes);
  *  const payload = generateTransactionPayload({
  *    function: "0xbeefcafe::your_module::your_function_that_requires_custom_serialization",
- *     *    arguments: [yourCustomBytes],
+ *    arguments: [yourCustomBytes],
  *  });
  *
  *  For example, if you store each of the 32 bytes for an address as a U8 in a MoveVector<U8>, when you

--- a/src/bcs/serializable/fixed-bytes.ts
+++ b/src/bcs/serializable/fixed-bytes.ts
@@ -26,8 +26,7 @@ import { TransactionArgument } from "../../transactions/instances/transactionArg
  *  const fixedBytes = new FixedBytes(yourCustomSerializedBytes);
  *  const payload = generateTransactionPayload({
  *    function: "0xbeefcafe::your_module::your_function_that_requires_custom_serialization",
- *    type_arguments: [],
- *    arguments: [yourCustomBytes],
+ *     *    arguments: [yourCustomBytes],
  *  });
  *
  *  For example, if you store each of the 32 bytes for an address as a U8 in a MoveVector<U8>, when you

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -22,7 +22,7 @@ export async function transferCoinTransaction(args: {
     sender: sender.accountAddress.toString(),
     data: {
       function: "0x1::aptos_account::transfer_coins",
-      type_arguments: [new TypeTagStruct(StructTag.fromString(coinStructType))],
+      typeArguments: [new TypeTagStruct(StructTag.fromString(coinStructType))],
       arguments: [AccountAddress.fromHexInput(recipient), new U64(amount)],
     },
     options,

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -20,6 +20,7 @@ import {
   MoveValue,
   TableItemRequest,
   ViewRequest,
+  ViewRequestData,
 } from "../types";
 import { GetChainTopUserTransactionsQuery, GetProcessorStatusQuery } from "../types/generated/operations";
 import { GetChainTopUserTransactions, GetProcessorStatus } from "../types/generated/queries";
@@ -83,7 +84,7 @@ export async function getTableItem(args: {
 
 export async function view(args: {
   aptosConfig: AptosConfig;
-  payload: ViewRequest;
+  payload: ViewRequestData;
   options?: LedgerVersion;
 }): Promise<MoveValue[]> {
   const { aptosConfig, payload, options } = args;
@@ -92,7 +93,11 @@ export async function view(args: {
     originMethod: "view",
     path: "view",
     params: { ledger_version: options?.ledgerVersion },
-    body: payload,
+    body: {
+      function: payload.function,
+      type_arguments: payload.typeArguments ?? [],
+      arguments: payload.arguments ?? [],
+    },
   });
   return data;
 }

--- a/src/transactions/transaction_builder/transaction_builder.ts
+++ b/src/transactions/transaction_builder/transaction_builder.ts
@@ -91,7 +91,7 @@ export function generateTransactionPayload(args: GenerateTransactionPayloadData)
   // generate script payload
   if ("bytecode" in args) {
     const scriptPayload = new TransactionPayloadScript(
-      new Script(hexToBytes(args.bytecode), args.type_arguments, args.arguments),
+      new Script(hexToBytes(args.bytecode), args.typeArguments ?? [], args.arguments),
     );
     return scriptPayload;
   }
@@ -106,7 +106,7 @@ export function generateTransactionPayload(args: GenerateTransactionPayloadData)
           EntryFunction.build(
             `${funcNameParts[0]}::${funcNameParts[1]}`,
             funcNameParts[2],
-            args.type_arguments,
+            args.typeArguments ?? [],
             args.arguments,
           ),
         ),
@@ -121,7 +121,7 @@ export function generateTransactionPayload(args: GenerateTransactionPayloadData)
     EntryFunction.build(
       `${funcNameParts[0]}::${funcNameParts[1]}`,
       funcNameParts[2],
-      args.type_arguments,
+      args.typeArguments ?? [],
       args.arguments,
     ),
   );

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -84,7 +84,7 @@ export type GenerateTransactionPayloadData = EntryFunctionData | ScriptData | Mu
  */
 export type EntryFunctionData = {
   function: MoveStructType;
-  type_arguments: Array<TypeTag>;
+  typeArguments?: Array<TypeTag>;
   arguments: Array<EntryFunctionArgumentTypes>;
 };
 
@@ -100,7 +100,7 @@ export type MultiSigData = {
  */
 export type ScriptData = {
   bytecode: string;
-  type_arguments: Array<TypeTag>;
+  typeArguments?: Array<TypeTag>;
   arguments: Array<ScriptFunctionArgumentTypes>;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -855,7 +855,7 @@ export type Block = {
 };
 
 /**
- * The data needed to generate an View Request payload
+ * The data needed to generate a View Request payload
  */
 export type ViewRequestData = {
   function: MoveStructType;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -854,6 +854,15 @@ export type Block = {
   transactions?: Array<TransactionResponse>;
 };
 
+/**
+ * The data needed to generate an View Request payload
+ */
+export type ViewRequestData = {
+  function: MoveStructType;
+  typeArguments?: Array<MoveResourceType>;
+  arguments?: Array<MoveValue>;
+};
+
 // REQUEST TYPES
 
 /**

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -89,7 +89,6 @@ describe("account api", () => {
         sender: senderAccount.accountAddress.toString(),
         data: {
           function: "0x1::aptos_account::transfer",
-          type_arguments: [],
           arguments: [bob.accountAddress, new U64(10)],
         },
       });

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig, Aptos, Network, GraphqlQuery, ViewRequest } from "../../../src";
+import { AptosConfig, Aptos, Network, GraphqlQuery, ViewRequestData } from "../../../src";
 
 describe("general api", () => {
   test("it fetches ledger info", async () => {
@@ -38,10 +38,8 @@ describe("general api", () => {
     const config = new AptosConfig({ network: Network.LOCAL });
     const aptos = new Aptos(config);
 
-    const payload: ViewRequest = {
+    const payload: ViewRequestData = {
       function: "0x1::chain_id::get",
-      type_arguments: [],
-      arguments: [],
     };
 
     const chainId = await aptos.view({ payload });

--- a/tests/e2e/api/transaction.test.ts
+++ b/tests/e2e/api/transaction.test.ts
@@ -24,7 +24,6 @@ describe("transaction api", () => {
       sender: senderAccount.accountAddress.toString(),
       data: {
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [bob.accountAddress, new U64(10)],
       },
     });
@@ -50,7 +49,6 @@ describe("transaction api", () => {
         sender: senderAccount.accountAddress.toString(),
         data: {
           function: "0x1::aptos_account::transfer",
-          type_arguments: [],
           arguments: [bob.accountAddress, new U64(10)],
         },
       });

--- a/tests/e2e/transaction/generate_transaction.test.ts
+++ b/tests/e2e/transaction/generate_transaction.test.ts
@@ -25,7 +25,6 @@ describe("generate transaction", () => {
         sender: senderAccount.accountAddress.toString(),
         data: {
           bytecode: singleSignerScriptBytecode,
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
@@ -43,7 +42,6 @@ describe("generate transaction", () => {
         data: {
           multisigAddress: secondarySignerAccount.accountAddress,
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
@@ -61,7 +59,6 @@ describe("generate transaction", () => {
         sender: senderAccount.accountAddress.toString(),
         data: {
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
@@ -82,7 +79,6 @@ describe("generate transaction", () => {
         secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
         data: {
           bytecode: singleSignerScriptBytecode,
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
@@ -101,7 +97,6 @@ describe("generate transaction", () => {
         secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
         data: {
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
@@ -122,7 +117,6 @@ describe("generate transaction", () => {
         feePayerAddress: feePayerAccount.accountAddress.toString(),
         data: {
           bytecode: singleSignerScriptBytecode,
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
@@ -142,7 +136,6 @@ describe("generate transaction", () => {
         data: {
           multisigAddress: secondarySignerAccount.accountAddress,
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
@@ -161,7 +154,6 @@ describe("generate transaction", () => {
         feePayerAddress: feePayerAccount.accountAddress.toString(),
         data: {
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
@@ -181,7 +173,6 @@ describe("generate transaction", () => {
         feePayerAddress: feePayerAccount.accountAddress.toString(),
         data: {
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          type_arguments: [],
           arguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -25,7 +25,6 @@ export async function publishModule(
     sender: senderAccount.accountAddress.toString(),
     data: {
       function: "0x1::code::publish_package_txn",
-      type_arguments: [],
       arguments: [MoveVector.U8(metadataBytes), new MoveVector([MoveVector.U8(codeBytes)])],
     },
   });
@@ -61,7 +60,7 @@ export async function rawTransactionHelper(
     sender: senderAccount.accountAddress.toString(),
     data: {
       function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::tx_args_module::${functionName}`,
-      type_arguments: typeArgs,
+      typeArguments: typeArgs,
       arguments: args,
     },
   });

--- a/tests/e2e/transaction/sign_transaction.test.ts
+++ b/tests/e2e/transaction/sign_transaction.test.ts
@@ -33,7 +33,6 @@ describe("sign transaction", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -51,7 +50,6 @@ describe("sign transaction", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -70,7 +68,6 @@ describe("sign transaction", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -91,7 +88,6 @@ describe("sign transaction", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -109,7 +105,6 @@ describe("sign transaction", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -128,7 +123,6 @@ describe("sign transaction", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });

--- a/tests/e2e/transaction/transaction_builder.test.ts
+++ b/tests/e2e/transaction/transaction_builder.test.ts
@@ -31,7 +31,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        type_arguments: [],
         arguments: [
           new U64(100),
           new U64(200),
@@ -46,7 +45,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         multisigAddress: Account.generate().accountAddress,
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [],
       });
       expect(payload instanceof TransactionPayloadMultisig).toBeTruthy();
@@ -54,7 +52,6 @@ describe("transaction builder", () => {
     test("it generates an entry function transaction payload", async () => {
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [],
       });
       expect(payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
@@ -69,7 +66,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        type_arguments: [],
         arguments: [
           new U64(100),
           new U64(200),
@@ -96,7 +92,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         multisigAddress: bob.accountAddress,
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const rawTxn = await generateRawTransaction({
@@ -116,7 +111,6 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const rawTxn = await generateRawTransaction({
@@ -137,7 +131,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        type_arguments: [],
         arguments: [
           new U64(100),
           new U64(200),
@@ -164,7 +157,6 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const secondarySignerAddress = Account.generate();
@@ -191,7 +183,6 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const feePayer = Account.generate();
@@ -217,7 +208,7 @@ describe("transaction builder", () => {
         const bob = Account.generate();
         const payload = generateTransactionPayload({
           function: "0x1::aptos_account::transfer",
-          type_arguments: [],
+          typeArguments: [],
           arguments: [new MoveObject(bob.accountAddress), new U64(1)],
         });
         const feePayer = Account.generate();
@@ -250,7 +241,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        type_arguments: [],
         arguments: [
           new U64(100),
           new U64(200),
@@ -284,7 +274,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        type_arguments: [],
         arguments: [
           new U64(100),
           new U64(200),
@@ -317,7 +306,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         multisigAddress: bob.accountAddress,
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
@@ -345,7 +333,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        type_arguments: [],
         arguments: [
           new U64(100),
           new U64(200),
@@ -379,7 +366,6 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        type_arguments: [],
         arguments: [
           new U64(100),
           new U64(200),
@@ -414,7 +400,6 @@ describe("transaction builder", () => {
       );
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
@@ -449,7 +434,6 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
@@ -485,7 +469,6 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
@@ -505,7 +488,6 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
@@ -527,7 +509,6 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        type_arguments: [],
         arguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({

--- a/tests/e2e/transaction/transaction_simulation.test.ts
+++ b/tests/e2e/transaction/transaction_simulation.test.ts
@@ -27,7 +27,6 @@ describe("transaction simulation", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -42,7 +41,6 @@ describe("transaction simulation", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -58,7 +56,6 @@ describe("transaction simulation", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -76,7 +73,6 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           data: {
             bytecode: multiSignerScriptBytecode,
-            type_arguments: [],
             arguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
@@ -103,7 +99,6 @@ describe("transaction simulation", () => {
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
               function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
-              type_arguments: [],
               arguments: [
                 new U64(100),
                 new U64(200),
@@ -131,7 +126,6 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -149,7 +143,6 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -167,7 +160,6 @@ describe("transaction simulation", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -186,7 +178,6 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
-            type_arguments: [],
             arguments: [
               new U64(100),
               new U64(200),
@@ -215,7 +206,6 @@ describe("transaction simulation", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -230,7 +220,6 @@ describe("transaction simulation", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -246,7 +235,6 @@ describe("transaction simulation", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -264,7 +252,6 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           data: {
             bytecode: multiSignerScriptBytecode,
-            type_arguments: [],
             arguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
@@ -291,7 +278,6 @@ describe("transaction simulation", () => {
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
               function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
-              type_arguments: [],
               arguments: [
                 new U64(100),
                 new U64(200),
@@ -319,7 +305,6 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -337,7 +322,6 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -355,7 +339,6 @@ describe("transaction simulation", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            type_arguments: [],
             arguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -374,7 +357,6 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
-            type_arguments: [],
             arguments: [
               new U64(100),
               new U64(200),

--- a/tests/e2e/transaction/transaction_submission.test.ts
+++ b/tests/e2e/transaction/transaction_submission.test.ts
@@ -23,7 +23,6 @@ describe("transaction submission", () => {
             bytecode:
               // eslint-disable-next-line max-len
               "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-            type_arguments: [],
             arguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
@@ -63,7 +62,6 @@ describe("transaction submission", () => {
         sender: alice.accountAddress.toString(),
         data: {
           function: "0x1::aptos_account::transfer",
-          type_arguments: [],
           arguments: [bob.accountAddress, new U64(1)],
         },
       });
@@ -87,7 +85,6 @@ describe("transaction submission", () => {
         sender: alice.accountAddress.toString(),
         data: {
           function: "0x1::aptos_account::transfer",
-          type_arguments: [],
           arguments: [bob.accountAddress, new U64(1)],
         },
       });


### PR DESCRIPTION
### Description
This makes it so that the the developer doesn't have to define type_arguments when building transactions.  This is the majority use case.  This also changes it to camelCase for consistency for public facing params.  Snake case is still required for serialization.

### Test Plan
pnpm test