### PR TITLE
[Types] Update the signature types in API types to use their actual `type` strings and include Secp256k1

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -523,8 +523,14 @@ export type MoveScriptBytecode = {
   abi?: MoveFunction;
 };
 
+/**
+ * These are the JSON representations of transaction signatures.
+ * @see TransactionSignature enum in api/types/transaction.rs
+ * https://github.com/aptos-labs/aptos-core/blob/3e1f8dd9c508d5f241aba48a03fe76cf2e934d61/api/types/src/transaction.rs
+ */
 export type TransactionSignature =
   | TransactionEd25519Signature
+  | TransactionSecp256k1Signature
   | TransactionMultiEd25519Signature
   | TransactionMultiAgentSignature
   | TransactionFeePayerSignature;
@@ -532,11 +538,17 @@ export type TransactionSignature =
 export type TransactionEd25519Signature = {
   type: string;
   public_key: string;
-  signature: string;
+  signature: "ed25519_signature";
+};
+
+export type TransactionSecp256k1Signature = {
+  type: string;
+  public_key: string;
+  signature: "secp256k1_ecdsa_signature";
 };
 
 export type TransactionMultiEd25519Signature = {
-  type: string;
+  type: "multi_ed25519_signature";
   /**
    * The public keys for the Ed25519 signature
    */
@@ -553,7 +565,7 @@ export type TransactionMultiEd25519Signature = {
 };
 
 export type TransactionMultiAgentSignature = {
-  type: string;
+  type: "multi_agent_signature";
   sender: AccountSignature;
   /**
    * The other involved parties' addresses
@@ -566,7 +578,7 @@ export type TransactionMultiAgentSignature = {
 };
 
 export type TransactionFeePayerSignature = {
-  type: string;
+  type: "fee_payer_signature";
   sender: AccountSignature;
   /**
    * The other involved parties' addresses
@@ -580,30 +592,16 @@ export type TransactionFeePayerSignature = {
   fee_payer_signer: AccountSignature;
 };
 
-export type AccountSignature = AccountEd25519Signature | AccountMultiEd25519Signature;
+/**
+ * The union of all single account signatures.
+ */
+export type AccountSignature = AccountEd25519Signature | AccountSecp256k1Signature | AccountMultiEd25519Signature;
 
-export type AccountEd25519Signature = {
-  type: string;
-  public_key: string;
-  signature: string;
-};
+export type AccountEd25519Signature = TransactionEd25519Signature;
 
-export type AccountMultiEd25519Signature = {
-  type: string;
-  /**
-   * The public keys for the Ed25519 signature
-   */
-  public_keys: Array<string>;
-  /**
-   * Signature associated with the public keys in the same order
-   */
-  signatures: Array<string>;
-  /**
-   * The number of signatures required for a successful transaction
-   */
-  threshold: number;
-  bitmap: string;
-};
+export type AccountSecp256k1Signature = TransactionSecp256k1Signature;
+
+export type AccountMultiEd25519Signature = TransactionMultiEd25519Signature;
 
 export type WriteSet = ScriptWriteSet | DirectWriteSet;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -524,9 +524,7 @@ export type MoveScriptBytecode = {
 };
 
 /**
- * These are the JSON representations of transaction signatures.
- * @see TransactionSignature enum in api/types/transaction.rs
- * https://github.com/aptos-labs/aptos-core/blob/3e1f8dd9c508d5f241aba48a03fe76cf2e934d61/api/types/src/transaction.rs
+ * These are the JSON representations of transaction signatures returned from the node API.
  */
 export type TransactionSignature =
   | TransactionEd25519Signature


### PR DESCRIPTION
### Description
Updated the signature types in our API types to use Secp256k1

Added the actual strings for all signature types:

```typescript
export type TransactionEd25519Signature = {
  type: string;
  public_key: string;
  signature: "ed25519_signature";
};

// etc
````

Also removed some duplicated type code e.g.:

```typescript
export type AccountEd25519Signature = TransactionEd25519Signature;

// instead of redefining the same exact type...
```
### Test Plan
#74 will cover testing for these

### Related Links
https://github.com/aptos-labs/aptos-core/tree/main/api/src/tests/transactions_test.rs