### PR TITLE
[typeTag] Add new type tag parser for struct tags

### DIFF
--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -146,7 +146,7 @@ export function parseTypeTag(typeStr: string) {
       // The next space MUST be a comma, or a closing > if there was something parsed before
       // e.g. `u8 u8` is invalid but `u8, u8` is valid
       const nextChar = typeStr[cur];
-      if (parsedTypeTag && nextChar !== "," && nextChar !== ">") {
+      if (cur < typeStr.length && parsedTypeTag && nextChar !== "," && nextChar !== ">") {
         throw new TypeTagParserError(typeStr, `Invalid character after space ${nextChar}`);
       }
 
@@ -166,11 +166,17 @@ export function parseTypeTag(typeStr: string) {
   }
 
   // This prevents 'u8, u8' as an input
-  if (curTypes.length > 0) {
-    throw new TypeTagParserError(typeStr, "Unexpected ','");
+  switch (curTypes.length) {
+    case 0:
+      return parseTypeTagInner(currentStr, innerTypes);
+    case 1:
+      if (currentStr === "") {
+        return curTypes[0];
+      }
+      throw new TypeTagParserError(typeStr, "Unexpected ' '");
+    default:
+      throw new TypeTagParserError(typeStr, "Unexpected ','");
   }
-
-  return parseTypeTagInner(currentStr, innerTypes);
 }
 
 /**

--- a/src/transactions/typeTag/typeTagParser.ts
+++ b/src/transactions/typeTag/typeTagParser.ts
@@ -1,0 +1,246 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable class-methods-use-this */
+/* eslint-disable max-classes-per-file */
+import {
+  StructTag,
+  TypeTag,
+  TypeTagAddress,
+  TypeTagBool,
+  TypeTagParserError,
+  TypeTagStruct,
+  TypeTagU128,
+  TypeTagU16,
+  TypeTagU256,
+  TypeTagU32,
+  TypeTagU64,
+  TypeTagU8,
+  TypeTagVector,
+} from "./typeTag";
+import { AccountAddress } from "../../core";
+import { Identifier } from "../instances";
+
+function isValidIdentifier(str: string) {
+  return !!str.match(/^[_a-zA-Z0-9]+$/);
+}
+
+function isValidWhitespaceCharacter(char: string) {
+  return !!char.match(/\s/);
+}
+
+function consumeWhitespace(tagStr: string, pos: number) {
+  let i = pos;
+  for (; i < tagStr.length; i += 1) {
+    const innerChar = tagStr[i];
+
+    if (!isValidWhitespaceCharacter(innerChar)) {
+      // If it's not colons, and it's an invalid character, we will stop here
+      break;
+    }
+  }
+  return i;
+}
+
+/**
+ * All types are made of a few parts they're either:
+ * 1. A simple type e.g. u8
+ * 2. A standalone struct e.g. 0x1::account::Account
+ * 3. A nested struct e.g. 0x1::coin::Coin<0x1234::coin::MyCoin>
+ *
+ * There are a few more special cases that need to be handled, however.
+ * 1. Multiple generics e.g 0x1::pair::Pair<u8, u16>
+ * 2. Spacing in the generics e.g. 0x1::pair::Pair< u8 , u16>
+ * 3. Nested generics of different depths e.g. 0x1::pair::Pair<0x1::coin::Coin<0x1234::coin::MyCoin>, u8>
+ * 4. Generics for types in ABIs are filled in with placeholders e.g T1, T2, T3
+ */
+export function parseTypeTag(typeStr: string) {
+  const saved: Array<{ savedExpectedTypes: number; savedStr: string; savedTypes: Array<TypeTag> }> = [];
+  // This represents the internal types for a type tag e.g. '0x1::coin::Coin<innerTypes>'
+  let innerTypes: Array<TypeTag> = [];
+  // This represents the current parsed types in a comma list e.g. 'u8, u8'
+  let curTypes: Array<TypeTag> = [];
+  // This represents the current character index
+  let cur = 0;
+  // This represents the current working string as a type or struct name
+  let currentStr = "";
+  let expectedTypes = 1;
+
+  // Iterate through each character, and handle the border conditions
+  while (cur < typeStr.length) {
+    const char = typeStr[cur];
+
+    if (char === "<") {
+      // Start of a type argument, push current state onto a stack
+      saved.push({
+        savedExpectedTypes: expectedTypes,
+        savedStr: currentStr,
+        savedTypes: curTypes,
+      });
+
+      // Clear current state
+      currentStr = "";
+      curTypes = [];
+      expectedTypes = 1;
+    } else if (char === ">") {
+      // Process last type, if there is no type string, then don't parse it
+      if (currentStr !== "") {
+        const newType = parseTypeTagInner(currentStr, innerTypes);
+        curTypes.push(newType);
+      }
+
+      // Pop off stack outer type, if there's nothing left, there were too many '>'
+      const savedPop = saved.pop();
+      if (savedPop === undefined) {
+        throw new TypeTagParserError("Failed to parse typeTag, unexpected '>'");
+      }
+
+      // If the expected types don't match the number of commas, then we also fail
+      if (expectedTypes !== curTypes.length) {
+        throw new TypeTagParserError("Failed to parse typeTag, type argument count mismatch");
+      }
+
+      // Add in the new created type, shifting the current types to the inner types
+      const { savedStr, savedTypes, savedExpectedTypes } = savedPop;
+      innerTypes = curTypes;
+      curTypes = savedTypes;
+      currentStr = savedStr;
+      expectedTypes = savedExpectedTypes;
+    } else if (char === ",") {
+      // Comma means we need to start parsing a new tag, push the previous one to the curTypes
+      // Process last type, if there is no type string, then don't parse it
+      if (currentStr.length !== 0) {
+        const newType = parseTypeTagInner(currentStr, innerTypes);
+
+        // parse type tag and push it on the types
+        innerTypes = [];
+        curTypes.push(newType);
+        currentStr = "";
+        expectedTypes += 1;
+      }
+    } else if (isValidWhitespaceCharacter(char)) {
+      // This means we should save what we have and everything else should skip until the next ,
+      let parsedTypeTag = false;
+      if (currentStr.length !== 0) {
+        const newType = parseTypeTagInner(currentStr, innerTypes);
+
+        // parse type tag and push it on the types
+        innerTypes = [];
+        curTypes.push(newType);
+        currentStr = "";
+        parsedTypeTag = true;
+      }
+
+      // Skip ahead on any more whitespace
+      cur = consumeWhitespace(typeStr, cur);
+
+      // The next space MUST be a comma, or a closing > if there was something parsed before
+      // e.g. `u8 u8` is invalid but `u8, u8` is valid
+      const nextChar = typeStr[cur];
+      if (parsedTypeTag && nextChar !== "," && nextChar !== ">") {
+        throw new TypeTagParserError(`Failed to parse typeTag, invalid character after space ${nextChar}`);
+      }
+
+      // eslint-disable-next-line no-continue
+      continue;
+    } else {
+      // Any other characters just append to the current string
+      currentStr += char;
+    }
+
+    cur += 1;
+  }
+
+  // This prevents a missing '>' on type arguments
+  if (saved.length > 0) {
+    throw new TypeTagParserError("Invalid typeTag, no matching '>' for '<'");
+  }
+
+  // This prevents 'u8, u8' as an input
+  if (curTypes.length > 0) {
+    throw new TypeTagParserError("Invalid typeTag, unexpected ','");
+  }
+
+  return parseTypeTagInner(currentStr, innerTypes);
+}
+
+/**
+ * Parses a type tag with internal types associated
+ * @param str
+ * @param types
+ */
+function parseTypeTagInner(str: string, types: Array<TypeTag>): TypeTag {
+  switch (str) {
+    case "bool":
+      if (types.length > 0) {
+        throw new TypeTagParserError("Invalid typeTag, bool should not have a type argument");
+      }
+      return new TypeTagBool();
+    case "address":
+      if (types.length > 0) {
+        throw new TypeTagParserError("Invalid typeTag, address should not have a type argument");
+      }
+      return new TypeTagAddress();
+    case "u8":
+      if (types.length > 0) {
+        throw new TypeTagParserError("Invalid typeTag, u8 should not have a type argument");
+      }
+      return new TypeTagU8();
+    case "u16":
+      if (types.length > 0) {
+        throw new TypeTagParserError("Invalid typeTag, u16 should not have a type argument");
+      }
+      return new TypeTagU16();
+    case "u32":
+      if (types.length > 0) {
+        throw new TypeTagParserError("Invalid typeTag, u32 should not have a type argument");
+      }
+      return new TypeTagU32();
+    case "u64":
+      if (types.length > 0) {
+        throw new TypeTagParserError("Invalid typeTag, u64 should not have a type argument");
+      }
+      return new TypeTagU64();
+    case "u128":
+      if (types.length > 0) {
+        throw new TypeTagParserError("Invalid typeTag, u128 should not have a type argument");
+      }
+      return new TypeTagU128();
+    case "u256":
+      if (types.length > 0) {
+        throw new TypeTagParserError("Invalid typeTag, u256 should not have a type argument");
+      }
+      return new TypeTagU256();
+    case "vector":
+      if (types.length !== 1) {
+        throw new TypeTagParserError("Invalid typeTag, vector must have exactly 1 type argument");
+      }
+      return new TypeTagVector(types[0]);
+    default:
+      // Try to parse as a struct
+      // Parse for a struct tag
+      // eslint-disable-next-line no-case-declarations
+      const structParts = str.split("::");
+      if (structParts.length !== 3) {
+        throw new TypeTagParserError(`Invalid typeTag, unexpected format for ${structParts}`);
+      }
+
+      // Validate identifier characters
+      if (!isValidIdentifier(structParts[1])) {
+        throw new TypeTagParserError(`Invalid typeTag, unexpected module name characters ${structParts[1]}`);
+      }
+      if (!isValidIdentifier(structParts[2])) {
+        throw new TypeTagParserError(`Invalid typeTag, unexpected struct name characters ${structParts[2]}`);
+      }
+
+      return new TypeTagStruct(
+        new StructTag(
+          AccountAddress.fromString(structParts[0]),
+          new Identifier(structParts[1]),
+          new Identifier(structParts[2]),
+          types,
+        ),
+      );
+  }
+}

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -20,7 +20,7 @@ import {
   TypeTag,
 } from "../../src";
 import { Identifier } from "../../src/transactions/instances";
-import { parseTypeTag } from "../../src/transactions/typeTag/typeTagParser";
+import { parseTypeTag } from "../../src/transactions/typeTag/parser";
 
 const MODULE_NAME = new Identifier("tag");
 const STRUCT_NAME = new Identifier("Tag");
@@ -88,6 +88,12 @@ describe("TypeTagParser", () => {
     expect(parseTypeTag("u256")).toEqual(new TypeTagU256());
     expect(parseTypeTag("bool")).toEqual(new TypeTagBool());
     expect(parseTypeTag("address")).toEqual(new TypeTagAddress());
+  });
+
+  test("outside spacing", () => {
+    expect(parseTypeTag(" address")).toEqual(new TypeTagAddress());
+    expect(parseTypeTag("address ")).toEqual(new TypeTagAddress());
+    expect(parseTypeTag(" address ")).toEqual(new TypeTagAddress());
   });
 
   test("vector", () => {

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -1,0 +1,207 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  StructTag,
+  TypeTagStruct,
+  TypeTagU8,
+  AccountAddress,
+  TypeTagU16,
+  TypeTagU32,
+  TypeTagU128,
+  TypeTagU64,
+  TypeTagU256,
+  TypeTagBool,
+  TypeTagAddress,
+  TypeTagVector,
+  stringStructTag,
+  objectStructTag,
+  optionStructTag,
+  TypeTag,
+} from "../../src";
+import { Identifier } from "../../src/transactions/instances";
+import { parseTypeTag } from "../../src/transactions/typeTag/typeTagParser";
+
+const MODULE_NAME = new Identifier("tag");
+const STRUCT_NAME = new Identifier("Tag");
+
+const structTagType = (typeTags?: Array<TypeTag>) =>
+  new TypeTagStruct(new StructTag(AccountAddress.ONE, MODULE_NAME, STRUCT_NAME, typeTags ?? []));
+
+describe("TypeTagParser", () => {
+  test("invalid types", () => {
+    // Missing 8
+    expect(() => parseTypeTag("8")).toThrow();
+
+    // Addr isn't a type
+    expect(() => parseTypeTag("addr")).toThrow();
+
+    // No references
+    expect(() => parseTypeTag("&address")).toThrow();
+
+    // Standalone generic
+    expect(() => parseTypeTag("T1")).toThrow();
+
+    // Not enough colons
+    expect(() => parseTypeTag("0x1:tag::Tag")).toThrow();
+    expect(() => parseTypeTag("0x1::tag:Tag")).toThrow();
+
+    // Invalid inner type
+    expect(() => parseTypeTag("0x1::tag::Tag<8>")).toThrow();
+
+    // Invalid address
+    expect(() => parseTypeTag("1::tag::Tag")).toThrow();
+    expect(() => parseTypeTag("1::tag::Tag<u8>")).toThrow();
+
+    // Invalid spacing around type arguments
+    expect(() => parseTypeTag("0x1::tag::Tag <u8>")).toThrow();
+
+    // Invalid type argument combinations
+    expect(() => parseTypeTag("0x1::tag::Tag<<u8>")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<<u8 u8>")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<u8>>")).toThrow();
+
+    // Comma separated arguments not in type arguments
+    expect(() => parseTypeTag("u8, u8")).toThrow();
+    expect(() => parseTypeTag("u8,u8")).toThrow();
+    expect(() => parseTypeTag("u8 ,u8")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<u8>,0x1::tag::Tag")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<u8>, 0x1::tag::Tag")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<u8> ,0x1::tag::Tag")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<u8> , 0x1::tag::Tag")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<u8><u8>")).toThrow();
+
+    // Invalid type tags without arguments
+    expect(() => parseTypeTag("0x1::tag::Tag<>")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<,>")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<u8,>")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag< , >")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<u8, >")).toThrow();
+  });
+
+  test("standard types", () => {
+    expect(parseTypeTag("u8")).toEqual(new TypeTagU8());
+    expect(parseTypeTag("u16")).toEqual(new TypeTagU16());
+    expect(parseTypeTag("u32")).toEqual(new TypeTagU32());
+    expect(parseTypeTag("u64")).toEqual(new TypeTagU64());
+    expect(parseTypeTag("u128")).toEqual(new TypeTagU128());
+    expect(parseTypeTag("u256")).toEqual(new TypeTagU256());
+    expect(parseTypeTag("bool")).toEqual(new TypeTagBool());
+    expect(parseTypeTag("address")).toEqual(new TypeTagAddress());
+  });
+
+  test("vector", () => {
+    expect(parseTypeTag("vector<u8>")).toEqual(new TypeTagVector(new TypeTagU8()));
+    expect(parseTypeTag("vector<u16>")).toEqual(new TypeTagVector(new TypeTagU16()));
+    expect(parseTypeTag("vector<u32>")).toEqual(new TypeTagVector(new TypeTagU32()));
+    expect(parseTypeTag("vector<u64>")).toEqual(new TypeTagVector(new TypeTagU64()));
+    expect(parseTypeTag("vector<u128>")).toEqual(new TypeTagVector(new TypeTagU128()));
+    expect(parseTypeTag("vector<u256>")).toEqual(new TypeTagVector(new TypeTagU256()));
+    expect(parseTypeTag("vector<bool>")).toEqual(new TypeTagVector(new TypeTagBool()));
+    expect(parseTypeTag("vector<address>")).toEqual(new TypeTagVector(new TypeTagAddress()));
+    expect(parseTypeTag("vector<0x1::string::String>")).toEqual(
+      new TypeTagVector(new TypeTagStruct(stringStructTag())),
+    );
+  });
+
+  test("nested vector", () => {
+    expect(parseTypeTag("vector<vector<u8>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU8())));
+    expect(parseTypeTag("vector<vector<u16>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU16())));
+    expect(parseTypeTag("vector<vector<u32>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU32())));
+    expect(parseTypeTag("vector<vector<u64>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU64())));
+    expect(parseTypeTag("vector<vector<u128>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU128())));
+    expect(parseTypeTag("vector<vector<u256>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU256())));
+    expect(parseTypeTag("vector<vector<bool>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagBool())));
+    expect(parseTypeTag("vector<vector<address>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagAddress())));
+    expect(parseTypeTag("vector<vector<0x1::string::String>>")).toEqual(
+      new TypeTagVector(new TypeTagVector(new TypeTagStruct(stringStructTag()))),
+    );
+  });
+
+  test("string", () => {
+    expect(parseTypeTag("0x1::string::String")).toEqual(new TypeTagStruct(stringStructTag()));
+  });
+
+  test("object", () => {
+    expect(parseTypeTag("0x1::object::Object<0x1::tag::Tag>")).toEqual(
+      new TypeTagStruct(objectStructTag(structTagType())),
+    );
+    expect(parseTypeTag("0x1::object::Object<0x1::tag::Tag<u8>>")).toEqual(
+      new TypeTagStruct(objectStructTag(structTagType([new TypeTagU8()]))),
+    );
+  });
+
+  test("option", () => {
+    expect(parseTypeTag("0x1::option::Option<0x1::tag::Tag>")).toEqual(
+      new TypeTagStruct(optionStructTag(structTagType())),
+    );
+    expect(parseTypeTag("0x1::option::Option<0x1::tag::Tag<u8>>")).toEqual(
+      new TypeTagStruct(optionStructTag(structTagType([new TypeTagU8()]))),
+    );
+  });
+
+  test("0x1::tag::Tag", () => {
+    expect(parseTypeTag("0x1::tag::Tag")).toEqual(structTagType());
+  });
+
+  test("0x1::tag::Tag<u8>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<u8>")).toEqual(structTagType([new TypeTagU8()]));
+  });
+
+  test("0x1::tag::Tag<u8,u64>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<u8,u64>")).toEqual(structTagType([new TypeTagU8(), new TypeTagU64()]));
+  });
+
+  test("0x1::tag::Tag<u8,  u8>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<u8,  u8>")).toEqual(structTagType([new TypeTagU8(), new TypeTagU8()]));
+  });
+
+  test("0x1::tag::Tag<  u8,u8>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<  u8,u8>")).toEqual(structTagType([new TypeTagU8(), new TypeTagU8()]));
+  });
+
+  test("0x1::tag::Tag<u8,u8  >", () => {
+    expect(parseTypeTag("0x1::tag::Tag<u8,u8  >")).toEqual(structTagType([new TypeTagU8(), new TypeTagU8()]));
+  });
+
+  test("0x1::tag::Tag<0x1::tag::Tag<u8>>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<0x1::tag::Tag<u8>>")).toEqual(structTagType([structTagType([new TypeTagU8()])]));
+  });
+
+  test("0x1::tag::Tag<0x1::tag::Tag<u8, u8>>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<0x1::tag::Tag<u8, u8>>")).toEqual(
+      structTagType([structTagType([new TypeTagU8(), new TypeTagU8()])]),
+    );
+  });
+
+  test("0x1::tag::Tag<u8, 0x1::tag::Tag<u8>>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<u8, 0x1::tag::Tag<u8>>")).toEqual(
+      structTagType([new TypeTagU8(), structTagType([new TypeTagU8()])]),
+    );
+  });
+
+  test("0x1::tag::Tag<0x1::tag::Tag<u8>, u8>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<0x1::tag::Tag<u8>, u8>")).toEqual(
+      structTagType([structTagType([new TypeTagU8()]), new TypeTagU8()]),
+    );
+  });
+
+  test("0x1::tag::Tag<0x1::tag::Tag<0x1::tag::Tag<u8>>, u8>", () => {
+    expect(parseTypeTag("0x1::tag::Tag<0x1::tag::Tag<0x1::tag::Tag<u8>>, u8>")).toEqual(
+      structTagType([structTagType([structTagType([new TypeTagU8()])]), new TypeTagU8()]),
+    );
+  });
+
+  /* These are debatable on whether they are valid or not */
+  test.skip("edge case invalid types", () => {
+    // TODO: Do we care about this one?
+
+    expect(() => parseTypeTag("0x1::tag::Tag< , u8>")).toThrow();
+    expect(() => parseTypeTag("0x1::tag::Tag<,u8>")).toThrow();
+  });
+
+  /* These need to be supported for ABI parsing */
+  test.skip("struct with generic", () => {
+    expect(parseTypeTag("0x1::tag::Tag<T1>")).toEqual(structTagType());
+  });
+});


### PR DESCRIPTION
### Description
The typetag parser will need to be adjusted for generics and other special cases in an upcoming pull request.

This adds a much simpler parser and has comments for every choice made.

### Test Plan
I've put a pretty comprehensive set of tests, including some that are disabled that aren't properly handled in either parser (it can probably be updated in the new one).

Additionally, replaced structTag parsing with this implementation for now.
### Related Links
<!-- Please link to any relevant issues or pull requests! -->