### PR TITLE
[Rename] Change `arguments` in the transaction builder to `functionArguments`, change references in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
-- Changed all instances of `arguments` to `functionArguments` to avoid the reserved keyword in `strict` mode.
+- [`Breaking`] Changed all instances of `arguments` to `functionArguments` to avoid the reserved keyword in `strict` mode.
 - Support publish move module API function
 
 ## 0.0.0 (2023-10-18)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
-
+- Changed all instances of `arguments` to `functionArguments` to avoid the reserved keyword in `strict` mode.
 - Support publish move module API function
 
 ## 0.0.0 (2023-10-18)

--- a/examples/typescript/multi_agent_transfer.ts
+++ b/examples/typescript/multi_agent_transfer.ts
@@ -75,7 +75,7 @@ const example = async () => {
     sender: alice.accountAddress.toUint8Array(),
     data: {
       bytecode: CREATE_OBJECT_SCRIPT,
-      arguments: [],
+      functionArguments: [],
     },
   });
   const pendingObjectTxn = await aptos.signAndSubmitTransaction({ signer: alice, transaction: createObject });
@@ -93,7 +93,7 @@ const example = async () => {
     data: {
       bytecode: TRANSFER_SCRIPT,
       typeArguments: [new TypeTagStruct(StructTag.fromString(APTOS_COIN))],
-      arguments: [AccountAddress.fromStringRelaxed(objectAddress), new U64(TRANSFER_AMOUNT)],
+      functionArguments: [AccountAddress.fromStringRelaxed(objectAddress), new U64(TRANSFER_AMOUNT)],
     },
   });
 

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -56,7 +56,7 @@ const example = async () => {
     feePayerAddress: sponsorAddress,
     data: {
       function: "0x1::aptos_account::transfer",
-      arguments: [bob.accountAddress, new U64(TRANSFER_AMOUNT)],
+      functionArguments: [bob.accountAddress, new U64(TRANSFER_AMOUNT)],
     },
   });
 

--- a/examples/typescript/simple_transfer.ts
+++ b/examples/typescript/simple_transfer.ts
@@ -71,7 +71,7 @@ const example = async () => {
     data: {
       function: "0x1::coin::transfer",
       typeArguments: [new TypeTagStruct(StructTag.fromString(APTOS_COIN))],
-      arguments: [AccountAddress.fromHexInput(bob.accountAddress.toString()), new U64(TRANSFER_AMOUNT)],
+      functionArguments: [AccountAddress.fromHexInput(bob.accountAddress.toString()), new U64(TRANSFER_AMOUNT)],
     },
   });
 

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -126,8 +126,8 @@ export class General {
    * `
    * const payload: ViewRequest = {
    *  function: "0x1::coin::balance",
-   *  type_arguments: ["0x1::aptos_coin::AptosCoin"],
-   *  arguments: [accountAddress],
+   *  typeArguments: ["0x1::aptos_coin::AptosCoin"],
+   *  functionArguments: [accountAddress],
    * };
    * `
    *

--- a/src/api/transactionSubmission.ts
+++ b/src/api/transactionSubmission.ts
@@ -58,9 +58,9 @@ export class TransactionSubmission {
    * move function name, move function type arguments, move function arguments
    * `
    * data: {
-   *  function:"0x1::aptos_account::transfer",
-   *  type_arguments:[]
-   *  arguments:[receiverAddress,10]
+   *  function: "0x1::aptos_account::transfer",
+   *  typeArguments: []
+   *  functionArguments: [receiverAddress,10]
    * }
    * `
    *
@@ -69,9 +69,9 @@ export class TransactionSubmission {
    * module bytecode, move function type arguments, move function arguments
    * ```
    * data: {
-   *  bytecode:"0x001234567",
-   *  type_arguments:[],
-   *  arguments:[receiverAddress,10]
+   *  bytecode: "0x001234567",
+   *  typeArguments: [],
+   *  functionArguments: [receiverAddress,10]
    * }
    * ```
    *

--- a/src/bcs/serializable/fixedBytes.ts
+++ b/src/bcs/serializable/fixedBytes.ts
@@ -26,7 +26,7 @@ import { TransactionArgument } from "../../transactions/instances/transactionArg
  *  const fixedBytes = new FixedBytes(yourCustomSerializedBytes);
  *  const payload = generateTransactionPayload({
  *    function: "0xbeefcafe::your_module::your_function_that_requires_custom_serialization",
- *    arguments: [yourCustomBytes],
+ *    functionArguments: [yourCustomBytes],
  *  });
  *
  *  For example, if you store each of the 32 bytes for an address as a U8 in a MoveVector<U8>, when you

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -23,7 +23,7 @@ export async function transferCoinTransaction(args: {
     data: {
       function: "0x1::aptos_account::transfer_coins",
       typeArguments: [new TypeTagStruct(StructTag.fromString(coinStructType))],
-      arguments: [AccountAddress.fromHexInput(recipient), new U64(amount)],
+      functionArguments: [AccountAddress.fromHexInput(recipient), new U64(amount)],
     },
     options,
   });

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -63,7 +63,7 @@ export async function mintTokenTransaction(args: {
     sender: creator.accountAddress.toString(),
     data: {
       function: "0x4::aptos_token::mint",
-      arguments: [
+      functionArguments: [
         new MoveString(args.collection),
         new MoveString(args.description),
         new MoveString(args.name),
@@ -227,7 +227,7 @@ export async function createCollectionTransaction(
     sender: creator.accountAddress.toString(),
     data: {
       function: "0x4::aptos_token::create_collection",
-      arguments: [
+      functionArguments: [
         // Do not change the order
         new MoveString(args.description),
         new U64(args.maxSupply ?? MAX_U64_BIG_INT),

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -97,7 +97,7 @@ export async function view(args: {
     body: {
       function: payload.function,
       type_arguments: payload.typeArguments ?? [],
-      arguments: payload.arguments ?? [],
+      arguments: payload.functionArguments ?? [],
     },
   });
   return data;

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -41,8 +41,8 @@ import { UserTransactionResponse, PendingTransactionResponse, MimeType, HexInput
  * `
  * data: {
  *  function:"0x1::aptos_account::transfer",
- *  type_arguments:[]
- *  arguments:[receiverAddress,10]
+ *  typeArguments:[]
+ *  functionArguments :[receiverAddress,10]
  * }
  * `
  *
@@ -52,8 +52,8 @@ import { UserTransactionResponse, PendingTransactionResponse, MimeType, HexInput
  * ```
  * data: {
  *  bytecode:"0x001234567",
- *  type_arguments:[],
- *  arguments:[receiverAddress,10]
+ *  typeArguments:[],
+ *  functionArguments :[receiverAddress,10]
  * }
  * ```
  *
@@ -195,7 +195,7 @@ export async function publishModuleTransaction(args: {
     sender: account,
     data: {
       function: "0x1::code::publish_package_txn",
-      arguments: [MoveVector.U8(metadataBytes), new MoveVector([MoveVector.U8(byteCode)])],
+      functionArguments: [MoveVector.U8(metadataBytes), new MoveVector([MoveVector.U8(byteCode)])],
     },
     options,
   });

--- a/src/transactions/transaction_builder/transaction_builder.ts
+++ b/src/transactions/transaction_builder/transaction_builder.ts
@@ -90,7 +90,7 @@ export function generateTransactionPayload(args: GenerateTransactionPayloadData)
   // generate script payload
   if ("bytecode" in args) {
     return new TransactionPayloadScript(
-      new Script(Hex.fromHexInput(args.bytecode).toUint8Array(), args.typeArguments ?? [], args.arguments),
+      new Script(Hex.fromHexInput(args.bytecode).toUint8Array(), args.typeArguments ?? [], args.functionArguments),
     );
   }
 
@@ -105,7 +105,7 @@ export function generateTransactionPayload(args: GenerateTransactionPayloadData)
             `${funcNameParts[0]}::${funcNameParts[1]}`,
             funcNameParts[2],
             args.typeArguments ?? [],
-            args.arguments,
+            args.functionArguments,
           ),
         ),
       ),
@@ -119,7 +119,7 @@ export function generateTransactionPayload(args: GenerateTransactionPayloadData)
       `${funcNameParts[0]}::${funcNameParts[1]}`,
       funcNameParts[2],
       args.typeArguments ?? [],
-      args.arguments,
+      args.functionArguments,
     ),
   );
 }

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -83,7 +83,7 @@ export type GenerateTransactionPayloadData = EntryFunctionData | ScriptData | Mu
 export type EntryFunctionData = {
   function: MoveStructType;
   typeArguments?: Array<TypeTag>;
-  arguments: Array<EntryFunctionArgumentTypes>;
+  functionArguments: Array<EntryFunctionArgumentTypes>;
 };
 
 /**
@@ -99,7 +99,7 @@ export type MultiSigData = {
 export type ScriptData = {
   bytecode: HexInput;
   typeArguments?: Array<TypeTag>;
-  arguments: Array<ScriptFunctionArgumentTypes>;
+  functionArguments: Array<ScriptFunctionArgumentTypes>;
 };
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -856,7 +856,7 @@ export type Block = {
 export type ViewRequestData = {
   function: MoveStructType;
   typeArguments?: Array<MoveResourceType>;
-  arguments?: Array<MoveValue>;
+  functionArguments?: Array<MoveValue>;
 };
 
 // REQUEST TYPES
@@ -875,7 +875,7 @@ export type ViewRequest = {
   /**
    * Arguments of the function
    */
-  arguments: Array<MoveValue>;
+  functionArguments: Array<MoveValue>;
 };
 
 /**

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -89,7 +89,7 @@ describe("account api", () => {
         sender: senderAccount.accountAddress.toString(),
         data: {
           function: "0x1::aptos_account::transfer",
-          arguments: [bob.accountAddress, new U64(10)],
+          functionArguments: [bob.accountAddress, new U64(10)],
         },
       });
       const authenticator = aptos.signTransaction({

--- a/tests/e2e/api/transaction.test.ts
+++ b/tests/e2e/api/transaction.test.ts
@@ -24,7 +24,7 @@ describe("transaction api", () => {
       sender: senderAccount.accountAddress.toString(),
       data: {
         function: "0x1::aptos_account::transfer",
-        arguments: [bob.accountAddress, new U64(10)],
+        functionArguments: [bob.accountAddress, new U64(10)],
       },
     });
     const authenticator = aptos.signTransaction({
@@ -49,7 +49,7 @@ describe("transaction api", () => {
         sender: senderAccount.accountAddress.toString(),
         data: {
           function: "0x1::aptos_account::transfer",
-          arguments: [bob.accountAddress, new U64(10)],
+          functionArguments: [bob.accountAddress, new U64(10)],
         },
       });
       const authenticator = aptos.signTransaction({

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -24,13 +24,13 @@ describe("aptos request", () => {
       async () => {
         const aptos = new Aptos(config);
         const sender = Account.generate();
-        const recieverAccounts = Account.generate();
+        const receiverAccounts = Account.generate();
         await aptos.fundAccount({ accountAddress: sender.accountAddress.toString(), amount: 100_000_000 });
         const transaction = await aptos.generateTransaction({
           sender: sender.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            arguments: [new U64(1), recieverAccounts.accountAddress],
+            functionArguments: [new U64(1), receiverAccounts.accountAddress],
           },
         });
         const authenticator = aptos.signTransaction({

--- a/tests/e2e/transaction/generateTransaction.test.ts
+++ b/tests/e2e/transaction/generateTransaction.test.ts
@@ -25,7 +25,7 @@ describe("generate transaction", () => {
         sender: senderAccount.accountAddress.toString(),
         data: {
           bytecode: singleSignerScriptBytecode,
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
@@ -42,7 +42,7 @@ describe("generate transaction", () => {
         data: {
           multisigAddress: secondarySignerAccount.accountAddress,
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
@@ -59,7 +59,7 @@ describe("generate transaction", () => {
         sender: senderAccount.accountAddress.toString(),
         data: {
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
@@ -79,7 +79,7 @@ describe("generate transaction", () => {
         secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
         data: {
           bytecode: singleSignerScriptBytecode,
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
@@ -97,7 +97,7 @@ describe("generate transaction", () => {
         secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
         data: {
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
@@ -117,7 +117,7 @@ describe("generate transaction", () => {
         feePayerAddress: feePayerAccount.accountAddress.toString(),
         data: {
           bytecode: singleSignerScriptBytecode,
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
@@ -136,7 +136,7 @@ describe("generate transaction", () => {
         data: {
           multisigAddress: secondarySignerAccount.accountAddress,
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
@@ -154,7 +154,7 @@ describe("generate transaction", () => {
         feePayerAddress: feePayerAccount.accountAddress.toString(),
         data: {
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
@@ -173,7 +173,7 @@ describe("generate transaction", () => {
         feePayerAddress: feePayerAccount.accountAddress.toString(),
         data: {
           function: "0x0000000000000000000000000000000000000000000000000000000000000123::module::name",
-          arguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -25,7 +25,7 @@ export async function publishModule(
     sender: senderAccount.accountAddress.toString(),
     data: {
       function: "0x1::code::publish_package_txn",
-      arguments: [MoveVector.U8(metadataBytes), new MoveVector([MoveVector.U8(codeBytes)])],
+      functionArguments: [MoveVector.U8(metadataBytes), new MoveVector([MoveVector.U8(codeBytes)])],
     },
   });
   const signedTxn = await aptos.signTransaction({
@@ -61,7 +61,7 @@ export async function rawTransactionHelper(
     data: {
       function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::tx_args_module::${functionName}`,
       typeArguments: typeArgs,
-      arguments: args,
+      functionArguments: args,
     },
   });
   const senderAuthenticator = await aptos.signTransaction({
@@ -94,8 +94,8 @@ export const rawTransactionMultiAgentHelper = async (
     sender: senderAccount.accountAddress.toString(),
     data: {
       function: `${senderAccount.accountAddress.toString()}::tx_args_module::${functionName}`,
-      type_arguments: typeArgs,
-      arguments: args,
+      typeArguments: typeArgs,
+      functionArguments: args,
     },
   };
   const generatedTransaction = await (async () => {

--- a/tests/e2e/transaction/signTransaction.test.ts
+++ b/tests/e2e/transaction/signTransaction.test.ts
@@ -33,7 +33,7 @@ describe("sign transaction", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const accountAuthenticator = aptos.signTransaction({
@@ -50,7 +50,7 @@ describe("sign transaction", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const accountAuthenticator = aptos.signTransaction({
@@ -68,7 +68,7 @@ describe("sign transaction", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const accountAuthenticator = aptos.signTransaction({
@@ -88,7 +88,7 @@ describe("sign transaction", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const accountAuthenticator = aptos.signTransaction({
@@ -105,7 +105,7 @@ describe("sign transaction", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const accountAuthenticator = aptos.signTransaction({
@@ -123,7 +123,7 @@ describe("sign transaction", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const accountAuthenticator = aptos.signTransaction({

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -31,7 +31,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        arguments: [
+        functionArguments: [
           new U64(100),
           new U64(200),
           new MoveObject(Account.generate().accountAddress),
@@ -45,14 +45,14 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         multisigAddress: Account.generate().accountAddress,
         function: "0x1::aptos_account::transfer",
-        arguments: [],
+        functionArguments: [],
       });
       expect(payload instanceof TransactionPayloadMultisig).toBeTruthy();
     });
     test("it generates an entry function transaction payload", async () => {
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [],
+        functionArguments: [],
       });
       expect(payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
     });
@@ -66,7 +66,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        arguments: [
+        functionArguments: [
           new U64(100),
           new U64(200),
           Account.generate().accountAddress,
@@ -92,7 +92,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         multisigAddress: bob.accountAddress,
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const rawTxn = await generateRawTransaction({
         aptosConfig: config,
@@ -111,7 +111,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const rawTxn = await generateRawTransaction({
         aptosConfig: config,
@@ -131,7 +131,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        arguments: [
+        functionArguments: [
           new U64(100),
           new U64(200),
           Account.generate().accountAddress,
@@ -157,7 +157,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const secondarySignerAddress = Account.generate();
       const transaction = await buildTransaction({
@@ -183,7 +183,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const feePayer = Account.generate();
       const transaction = await buildTransaction({
@@ -209,7 +209,7 @@ describe("transaction builder", () => {
         const payload = generateTransactionPayload({
           function: "0x1::aptos_account::transfer",
           typeArguments: [],
-          arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+          functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
         });
         const feePayer = Account.generate();
         const secondarySignerAddress = Account.generate();
@@ -241,7 +241,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        arguments: [
+        functionArguments: [
           new U64(100),
           new U64(200),
           Account.generate().accountAddress,
@@ -274,7 +274,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        arguments: [
+        functionArguments: [
           new U64(100),
           new U64(200),
           Account.generate().accountAddress,
@@ -306,7 +306,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         multisigAddress: bob.accountAddress,
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
         aptosConfig: config,
@@ -333,7 +333,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        arguments: [
+        functionArguments: [
           new U64(100),
           new U64(200),
           Account.generate().accountAddress,
@@ -366,7 +366,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayload({
         bytecode:
           "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-        arguments: [
+        functionArguments: [
           new U64(100),
           new U64(200),
           Account.generate().accountAddress,
@@ -400,7 +400,7 @@ describe("transaction builder", () => {
       );
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
         aptosConfig: config,
@@ -434,7 +434,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
         aptosConfig: config,
@@ -469,7 +469,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
         aptosConfig: config,
@@ -488,7 +488,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
         aptosConfig: config,
@@ -509,7 +509,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = generateTransactionPayload({
         function: "0x1::aptos_account::transfer",
-        arguments: [new MoveObject(bob.accountAddress), new U64(1)],
+        functionArguments: [new MoveObject(bob.accountAddress), new U64(1)],
       });
       const transaction = await buildTransaction({
         aptosConfig: config,

--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -27,7 +27,7 @@ describe("transaction simulation", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.simulateTransaction({
@@ -41,7 +41,7 @@ describe("transaction simulation", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.simulateTransaction({
@@ -56,7 +56,7 @@ describe("transaction simulation", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.simulateTransaction({
@@ -73,7 +73,7 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           data: {
             bytecode: multiSignerScriptBytecode,
-            arguments: [
+            functionArguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
               recieverAccounts[0].accountAddress,
@@ -99,7 +99,7 @@ describe("transaction simulation", () => {
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
               function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
-              arguments: [
+              functionArguments: [
                 new U64(100),
                 new U64(200),
                 recieverAccounts[0].accountAddress,
@@ -126,7 +126,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
 
@@ -143,7 +143,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.simulateTransaction({
@@ -160,7 +160,7 @@ describe("transaction simulation", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
 
@@ -178,7 +178,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
-            arguments: [
+            functionArguments: [
               new U64(100),
               new U64(200),
               recieverAccounts[0].accountAddress,
@@ -206,7 +206,7 @@ describe("transaction simulation", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.simulateTransaction({
@@ -220,7 +220,7 @@ describe("transaction simulation", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.simulateTransaction({
@@ -235,7 +235,7 @@ describe("transaction simulation", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.simulateTransaction({
@@ -252,7 +252,7 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           data: {
             bytecode: multiSignerScriptBytecode,
-            arguments: [
+            functionArguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
               recieverAccounts[0].accountAddress,
@@ -278,7 +278,7 @@ describe("transaction simulation", () => {
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
               function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
-              arguments: [
+              functionArguments: [
                 new U64(100),
                 new U64(200),
                 recieverAccounts[0].accountAddress,
@@ -305,7 +305,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             bytecode: singleSignerScriptBytecode,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
 
@@ -322,7 +322,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.simulateTransaction({
@@ -339,7 +339,7 @@ describe("transaction simulation", () => {
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
-            arguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
 
@@ -357,7 +357,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
-            arguments: [
+            functionArguments: [
               new U64(100),
               new U64(200),
               recieverAccounts[0].accountAddress,

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -24,7 +24,7 @@ describe("transaction submission", () => {
             bytecode:
               // eslint-disable-next-line max-len
               "a11ceb0b060000000701000402040a030e18042608052e4307713e08af01200000000101020401000100030800010403040100010505060100010607040100010708060100000201020202030207060c060c0303050503030b000108010b000108010b0001080101080102060c03010b0001090002070b000109000b000109000002070b000109000302050b000109000a6170746f735f636f696e04636f696e04436f696e094170746f73436f696e087769746864726177056d657267650765787472616374076465706f73697400000000000000000000000000000000000000000000000000000000000000010000011a0b000a0238000c070b010a0338000c080d070b0838010d070b020b03160b061738020c090b040b0738030b050b09380302",
-            arguments: [
+            functionArguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
               bob.accountAddress,
@@ -63,7 +63,7 @@ describe("transaction submission", () => {
         sender: alice.accountAddress.toString(),
         data: {
           function: "0x1::aptos_account::transfer",
-          arguments: [bob.accountAddress, new U64(1)],
+          functionArguments: [bob.accountAddress, new U64(1)],
         },
       });
       const authenticator = aptos.signTransaction({
@@ -86,7 +86,7 @@ describe("transaction submission", () => {
         sender: alice.accountAddress.toString(),
         data: {
           function: "0x1::aptos_account::transfer",
-          arguments: [bob.accountAddress, new U64(1)],
+          functionArguments: [bob.accountAddress, new U64(1)],
         },
       });
       const authenticator = aptos.signTransaction({


### PR DESCRIPTION
### Description
Because `arguments` is a reserved keyword in typescript, when you try to use the spread operator with it in `strict` mode, it doesn't let you.

For example:
```typescript
const transactionBuilder = async(args: {
    aptos: Aptos,
    sender: Account,
    moduleFunction: string,
    arguments: Array<EntryFunctionArgumentTypes>,
    typeArguments?: TypeTag[],
}): Promise<UserTransactionResponse> => {
    const { aptos, sender, moduleFunction, arguments, typeArguments } = args;
    // ..
```

The compiler won't let you destructure `args` because `arguments` is reserved. You could of course do `arguments: functionArguments`, but perhaps we should just avoid the reserved keyword entirely to avoid issues

I've also changed each instance of `type_arguments` in the docs to `typeArguments`

I also made sure not to change `arguments` to `functionArguments` in API calls where the JSON structure is required

### Test Plan
```shelll
pnpm jest
```