### PR TITLE
[account] Add ability for custom typed resource calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Fix client config not being added to the request
 - Support to config a custom client instance
 - Changed all Regex based inputs requiring a `0x` to be optional. This is to allow for easier copy/pasting of addresses and keys.
+- Change GetAccountResource to take in a generic output type that matches the struct
 
 ## 0.0.0 (2023-10-18)
 

--- a/examples/typescript/multi_agent_transfer.ts
+++ b/examples/typescript/multi_agent_transfer.ts
@@ -20,8 +20,12 @@ const TRANSFER_AMOUNT = 10;
  *
  */
 const balance = async (aptos: Aptos, name: string, address: AccountAddress) => {
-  let resource = await aptos.getAccountResource({ accountAddress: address.toUint8Array(), resourceType: COIN_STORE });
-  let amount = Number((resource.data as { coin: { value: string } }).coin.value);
+  type Coin = { coin: { value: string } };
+  let resource = await aptos.getAccountResource<Coin>({
+    accountAddress: address.toUint8Array(),
+    resourceType: COIN_STORE,
+  });
+  let amount = Number(resource.coin.value);
 
   console.log(`${name}'s balance is: ${amount}`);
   return amount;

--- a/examples/typescript/simple_transfer.ts
+++ b/examples/typescript/simple_transfer.ts
@@ -20,8 +20,12 @@ const TRANSFER_AMOUNT = 100;
  *
  */
 const balance = async (aptos: Aptos, name: string, address: AccountAddress) => {
-  let resource = await aptos.getAccountResource({ accountAddress: address.toUint8Array(), resourceType: COIN_STORE });
-  let amount = Number((resource.data as { coin: { value: string } }).coin.value);
+  type Coin = { coin: { value: string } };
+  let resource = await aptos.getAccountResource<Coin>({
+    accountAddress: address.toUint8Array(),
+    resourceType: COIN_STORE,
+  });
+  let amount = Number(resource.coin.value);
 
   console.log(`${name}'s balance is: ${amount}`);
   return amount;

--- a/examples/typescript/transfer_coin.ts
+++ b/examples/typescript/transfer_coin.ts
@@ -19,8 +19,12 @@ const TRANSFER_AMOUNT = 1_000_000;
  *
  */
 const balance = async (aptos: Aptos, name: string, address: AccountAddress) => {
-  let resource = await aptos.getAccountResource({ accountAddress: address.toUint8Array(), resourceType: COIN_STORE });
-  let amount = Number((resource.data as { coin: { value: string } }).coin.value);
+  type Coin = { coin: { value: string } };
+  let resource = await aptos.getAccountResource<Coin>({
+    accountAddress: address.toUint8Array(),
+    resourceType: COIN_STORE,
+  });
+  let amount = Number(resource.coin.value);
 
   console.log(`${name}'s balance is: ${amount}`);
   return amount;

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -155,8 +155,10 @@ export class Account {
   }
 
   /**
-   * Queries a specific account resource given account address and resource type
+   * Queries a specific account resource given account address and resource type. Note that the default is `any` in order
+   * to allow for ease of accessing properties of the object.
    *
+   * @type The typed output of the resource
    * @param args.accountAddress Aptos account address
    * @param args.resourceType String representation of an on-chain Move struct type, i.e "0x1::aptos_coin::AptosCoin"
    * @param args.options.ledgerVersion The ledger version to query, if not provided it will get the latest version
@@ -166,17 +168,16 @@ export class Account {
    * @example An example of an account resource
    * ```
    * {
-   *    type: "0x1::aptos_coin::AptosCoin",
    *    data: { value: 6 }
    * }
    * ```
    */
-  async getAccountResource(args: {
+  async getAccountResource<T extends {} = any>(args: {
     accountAddress: HexInput;
     resourceType: MoveResourceType;
     options?: LedgerVersion;
-  }): Promise<MoveResource> {
-    return getResource({ aptosConfig: this.config, ...args });
+  }): Promise<T> {
+    return getResource<T>({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/tests/e2e/api/faucet.test.ts
+++ b/tests/e2e/api/faucet.test.ts
@@ -14,11 +14,12 @@ describe("Faucet", () => {
     await aptos.fundAccount({ accountAddress: testAccount.accountAddress.toString(), amount: FUND_AMOUNT });
 
     // Check the balance
-    const resource = await aptos.getAccountResource({
+    type Coin = { coin: { value: string } };
+    const resource = await aptos.getAccountResource<Coin>({
       accountAddress: testAccount.accountAddress.toString(),
       resourceType: "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>",
     });
-    const amount = Number((resource.data as { coin: { value: string } }).coin.value);
+    const amount = Number(resource.coin.value);
     expect(amount).toBe(FUND_AMOUNT);
   });
 });

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -65,7 +65,7 @@ describe("general api", () => {
           },
         ],
       },
-    } = resource.data as any;
+    } = resource as any;
 
     const supply = await aptos.getTableItem({
       handle,


### PR DESCRIPTION
### Description
Add ability for direct typed resource calls from the API without having to do conversion.

This should let you read Move resources directly, without having to have your own conversion code.  This also should allow for general type safety, keeping in mind that the underlying resource could possibly not match if it's not correct.

I'm debating how useful this is without something that generates types ahead of time from the ABI, but it also should be pretty easy to generate those.

### Test Plan
I added a test that does a direct comparison of the output objects of `getAccountResource` and the typed one, and they are the same, though now there is proper typing to handle it

### Related Links
<!-- Please link to any relevant issues or pull requests! -->