### PR TITLE
[types] Remove requirement on 0x for input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Changed all Regex based inputs requiring a `0x` to be optional. This is to allow for easier copy/pasting of addresses and keys.
 - [`Breaking`] Changed all instances of `arguments` to `functionArguments` to avoid the reserved keyword in `strict` mode.
 - Support publish move module API function
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -639,9 +639,9 @@ export type MoveUint32Type = number;
 export type MoveUint64Type = string;
 export type MoveUint128Type = string;
 export type MoveUint256Type = string;
-export type MoveAddressType = `0x${string}`;
-export type MoveObjectType = `0x${string}`;
-export type MoveStructType = `0x${string}::${string}::${string}`;
+export type MoveAddressType = string;
+export type MoveObjectType = string;
+export type MoveStructType = `${string}::${string}::${string}`;
 export type MoveOptionType = MoveType | null | undefined;
 /**
  * String representation of a on-chain Move struct type.
@@ -840,7 +840,7 @@ export type LedgerInfo = {
  */
 export type Block = {
   block_height: string;
-  block_hash: `0x${string}`;
+  block_hash: string;
   block_timestamp: string;
   first_version: string;
   last_version: string;

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -59,7 +59,7 @@ export async function rawTransactionHelper(
   const rawTransaction = await aptos.generateTransaction({
     sender: senderAccount.accountAddress.toString(),
     data: {
-      function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::tx_args_module::${functionName}`,
+      function: `${senderAccount.accountAddress.toString()}::tx_args_module::${functionName}`,
       typeArguments: typeArgs,
       functionArguments: args,
     },

--- a/tests/e2e/transaction/signTransaction.test.ts
+++ b/tests/e2e/transaction/signTransaction.test.ts
@@ -49,7 +49,7 @@ describe("sign transaction", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: senderAccount.accountAddress.toString(),
           data: {
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -67,7 +67,7 @@ describe("sign transaction", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -104,7 +104,7 @@ describe("sign transaction", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -122,7 +122,7 @@ describe("sign transaction", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });

--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -40,7 +40,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: senderAccount.accountAddress.toString(),
           data: {
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -55,7 +55,7 @@ describe("transaction simulation", () => {
           sender: senderAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -98,7 +98,7 @@ describe("transaction simulation", () => {
             sender: senderAccount.accountAddress.toString(),
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
-              function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+              function: `${senderAccount.accountAddress.toString()}::transfer::two_by_two`,
               functionArguments: [
                 new U64(100),
                 new U64(200),
@@ -142,7 +142,7 @@ describe("transaction simulation", () => {
           sender: senderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -159,7 +159,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -177,7 +177,7 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
               new U64(100),
               new U64(200),
@@ -219,7 +219,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -234,7 +234,7 @@ describe("transaction simulation", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -277,7 +277,7 @@ describe("transaction simulation", () => {
             sender: senderSecp256k1Account.accountAddress.toString(),
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
-              function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+              function: `${senderAccount.accountAddress.toString()}::transfer::two_by_two`,
               functionArguments: [
                 new U64(100),
                 new U64(200),
@@ -321,7 +321,7 @@ describe("transaction simulation", () => {
           sender: senderSecp256k1Account.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -338,7 +338,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -356,7 +356,7 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${senderAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+            function: `${senderAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
               new U64(100),
               new U64(200),


### PR DESCRIPTION
### Description
This removes needing to do silliness like:

`0x${HexInput.toStringWithoutPrefix()}...`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->