### PR TITLE
Include client config override and set version for metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,10 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+
 - [`Breaking`] Changed all instances of `arguments` to `functionArguments` to avoid the reserved keyword in `strict` mode.
 - Support publish move module API function
+- Fix client config not being added to the request
 
 ## 0.0.0 (2023-10-18)
 

--- a/src/client/get.ts
+++ b/src/client/get.ts
@@ -61,7 +61,7 @@ export async function get<Req, Res>(options: GetRequestOptions): Promise<AptosRe
       acceptType: acceptType?.valueOf(),
       params,
       overrides: {
-        ...aptosConfig,
+        ...aptosConfig.clientConfig,
         ...overrides,
       },
     },

--- a/src/client/post.ts
+++ b/src/client/post.ts
@@ -69,7 +69,7 @@ export async function post<Req, Res>(options: PostRequestOptions): Promise<Aptos
       acceptType: acceptType?.valueOf(),
       params,
       overrides: {
-        ...aptosConfig,
+        ...aptosConfig.clientConfig,
         ...overrides,
       },
     },

--- a/src/version.ts
+++ b/src/version.ts
@@ -6,4 +6,4 @@
  *
  * hardcoded for now, we would want to have it injected dynamically
  */
-export const VERSION = "0.0.0";
+export const VERSION = "2.0.0";


### PR DESCRIPTION
### Description
- Add clientConfig to header client config override
- Set metric version to 2.0.0 to distinguish between sdk v1 and v2

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->