### PR TITLE
[typeTag] Add signer and &signer to typetag parsing

### DIFF
--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -6,6 +6,7 @@ import {
   TypeTag,
   TypeTagAddress,
   TypeTagBool,
+  TypeTagSigner,
   TypeTagStruct,
   TypeTagU128,
   TypeTagU16,
@@ -200,6 +201,12 @@ export function parseTypeTag(typeStr: string) {
  */
 function parseTypeTagInner(str: string, types: Array<TypeTag>): TypeTag {
   switch (str) {
+    case "&signer":
+    case "signer":
+      if (types.length > 0) {
+        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
+      }
+      return new TypeTagSigner();
     case "bool":
       if (types.length > 0) {
         throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -10,6 +10,7 @@ import {
   TypeTag,
   TypeTagAddress,
   TypeTagBool,
+  TypeTagSigner,
   TypeTagStruct,
   TypeTagU128,
   TypeTagU16,
@@ -101,6 +102,9 @@ describe("TypeTagParser", () => {
   });
 
   test("standard types", () => {
+    expect(parseTypeTag("signer")).toEqual(new TypeTagSigner());
+    // Technically this isn't a specific type tag, but this is a good estimation of it
+    expect(parseTypeTag("&signer")).toEqual(new TypeTagSigner());
     expect(parseTypeTag("u8")).toEqual(new TypeTagU8());
     expect(parseTypeTag("u16")).toEqual(new TypeTagU16());
     expect(parseTypeTag("u32")).toEqual(new TypeTagU32());


### PR DESCRIPTION
### Description
These are required to parse the ABI.  Even though, you can't actually provide them as an input type tag.

### Test Plan
Added an appropriate unit test

### Related Links
<!-- Please link to any relevant issues or pull requests! -->