### PR TITLE
consolidate move struct and resource type

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -14,7 +14,7 @@ import {
   LedgerVersion,
   MoveModuleBytecode,
   MoveResource,
-  MoveResourceType,
+  MoveStructType,
   OrderBy,
   PaginationArgs,
   TokenStandard,
@@ -175,7 +175,7 @@ export class Account {
    */
   async getAccountResource<T extends {} = any>(args: {
     accountAddress: HexInput;
-    resourceType: MoveResourceType;
+    resourceType: MoveStructType;
     options?: LedgerVersion;
   }): Promise<T> {
     return getResource<T>({ aptosConfig: this.config, ...args });

--- a/src/api/coin.ts
+++ b/src/api/coin.ts
@@ -5,7 +5,7 @@ import { AptosConfig } from "./aptosConfig";
 import { Account } from "../core";
 import { transferCoinTransaction } from "../internal/coin";
 import { SingleSignerTransaction, GenerateTransactionOptions } from "../transactions/types";
-import { AnyNumber, HexInput, MoveResourceType } from "../types";
+import { AnyNumber, HexInput, MoveStructType } from "../types";
 
 /**
  * A class to handle all `Coin` operations
@@ -31,7 +31,7 @@ export class Coin {
     sender: Account;
     recipient: HexInput;
     amount: AnyNumber;
-    coinType?: MoveResourceType;
+    coinType?: MoveStructType;
     options?: GenerateTransactionOptions;
   }): Promise<SingleSignerTransaction> {
     return transferCoinTransaction({ aptosConfig: this.config, ...args });

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -3,7 +3,7 @@
 
 import { AptosConfig } from "./aptosConfig";
 import { getAccountEventsByCreationNumber, getAccountEventsByEventType, getEvents } from "../internal/event";
-import { AnyNumber, GetEventsResponse, HexInput, MoveResourceType, OrderBy, PaginationArgs } from "../types";
+import { AnyNumber, GetEventsResponse, HexInput, MoveStructType, OrderBy, PaginationArgs } from "../types";
 import { EventsBoolExp } from "../types/generated/types";
 
 /**
@@ -41,7 +41,7 @@ export class Event {
    */
   async getAccountEventsByEventType(args: {
     accountAddress: HexInput;
-    eventType: MoveResourceType;
+    eventType: MoveStructType;
     options?: {
       pagination?: PaginationArgs;
       orderBy?: OrderBy<GetEventsResponse[0]>;

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -26,7 +26,7 @@ import {
   LedgerVersion,
   MoveModuleBytecode,
   MoveResource,
-  MoveResourceType,
+  MoveStructType,
   OrderBy,
   PaginationArgs,
   SigningScheme,
@@ -164,7 +164,7 @@ export async function getResources(args: {
 export async function getResource<T extends {}>(args: {
   aptosConfig: AptosConfig;
   accountAddress: HexInput;
-  resourceType: MoveResourceType;
+  resourceType: MoveStructType;
   options?: LedgerVersion;
 }): Promise<T> {
   const { aptosConfig, accountAddress, resourceType, options } = args;

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -2,7 +2,7 @@ import { AptosConfig } from "../api/aptosConfig";
 import { U64 } from "../bcs/serializable/movePrimitives";
 import { Account, AccountAddress } from "../core";
 import { GenerateTransactionOptions, SingleSignerTransaction } from "../transactions/types";
-import { HexInput, AnyNumber, MoveResourceType } from "../types";
+import { HexInput, AnyNumber, MoveStructType } from "../types";
 import { APTOS_COIN } from "../utils/const";
 import { generateTransaction } from "./transactionSubmission";
 import { parseTypeTag } from "../transactions/typeTag/parser";
@@ -12,7 +12,7 @@ export async function transferCoinTransaction(args: {
   sender: Account;
   recipient: HexInput;
   amount: AnyNumber;
-  coinType?: MoveResourceType;
+  coinType?: MoveStructType;
   options?: GenerateTransactionOptions;
 }): Promise<SingleSignerTransaction> {
   const { aptosConfig, sender, recipient, amount, coinType, options } = args;

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -10,7 +10,7 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import { AccountAddress } from "../core";
-import { AnyNumber, GetEventsResponse, HexInput, PaginationArgs, MoveResourceType, OrderBy } from "../types";
+import { AnyNumber, GetEventsResponse, HexInput, PaginationArgs, MoveStructType, OrderBy } from "../types";
 import { GetEventsQuery } from "../types/generated/operations";
 import { GetEvents } from "../types/generated/queries";
 import { EventsBoolExp } from "../types/generated/types";
@@ -35,7 +35,7 @@ export async function getAccountEventsByCreationNumber(args: {
 export async function getAccountEventsByEventType(args: {
   aptosConfig: AptosConfig;
   accountAddress: HexInput;
-  eventType: MoveResourceType;
+  eventType: MoveStructType;
   options?: {
     pagination?: PaginationArgs;
     orderBy?: OrderBy<GetEventsResponse[0]>;

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -15,7 +15,7 @@ import {
   TransactionPayloadMultisig,
   TransactionPayloadScript,
 } from "./instances";
-import { AnyNumber, HexInput, MoveStructType } from "../types";
+import { AnyNumber, HexInput, MoveResourceType } from "../types";
 import { TypeTag } from "./typeTag/typeTag";
 
 export type EntryFunctionArgumentTypes =
@@ -79,7 +79,7 @@ export type GenerateTransactionPayloadData = EntryFunctionData | ScriptData | Mu
  * The data needed to generate an Entry Function payload
  */
 export type EntryFunctionData = {
-  function: MoveStructType;
+  function: MoveResourceType;
   typeArguments?: Array<TypeTag>;
   functionArguments: Array<EntryFunctionArgumentTypes>;
 };

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -15,7 +15,7 @@ import {
   TransactionPayloadMultisig,
   TransactionPayloadScript,
 } from "./instances";
-import { AnyNumber, HexInput, MoveResourceType } from "../types";
+import { AnyNumber, HexInput, MoveStructType } from "../types";
 import { TypeTag } from "./typeTag/typeTag";
 
 export type EntryFunctionArgumentTypes =
@@ -79,7 +79,7 @@ export type GenerateTransactionPayloadData = EntryFunctionData | ScriptData | Mu
  * The data needed to generate an Entry Function payload
  */
 export type EntryFunctionData = {
-  function: MoveResourceType;
+  function: MoveStructType;
   typeArguments?: Array<TypeTag>;
   functionArguments: Array<EntryFunctionArgumentTypes>;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -249,7 +249,7 @@ export type GasEstimation = {
 };
 
 export type MoveResource = {
-  type: MoveResourceType;
+  type: MoveStructType;
   data: {};
 };
 
@@ -518,7 +518,7 @@ export type TransactionPayloadResponse = EntryFunctionPayloadResponse | ScriptPa
 
 export type EntryFunctionPayloadResponse = {
   type: string;
-  function: MoveResourceType;
+  function: MoveStructType;
   /**
    * Type arguments of the function
    */
@@ -683,7 +683,7 @@ export type MoveOptionType = MoveType | null | undefined;
 /**
  * String representation of a on-chain Move struct type.
  */
-export type MoveResourceType = `${string}::${string}::${string}`;
+export type MoveStructType = `${string}::${string}::${string}`;
 
 export type MoveType =
   | boolean
@@ -696,7 +696,7 @@ export type MoveType =
   | MoveUint256Type
   | MoveAddressType
   | MoveObjectType
-  | MoveResourceType
+  | MoveStructType
   | Array<MoveType>;
 
 /**
@@ -733,7 +733,7 @@ export type MoveValue =
   | MoveUint256Type
   | MoveAddressType
   | MoveObjectType
-  | MoveResourceType
+  | MoveStructType
   | MoveOptionType
   | Array<MoveValue>;
 
@@ -891,8 +891,8 @@ export type Block = {
  * The data needed to generate a View Request payload
  */
 export type ViewRequestData = {
-  function: MoveResourceType;
-  typeArguments?: Array<MoveResourceType>;
+  function: MoveStructType;
+  typeArguments?: Array<MoveStructType>;
   functionArguments?: Array<MoveValue>;
 };
 
@@ -901,14 +901,14 @@ export type ViewRequestData = {
 /**
  * View request for the Move view function API
  *
- * `type MoveResourceType = ${string}::${string}::${string}`;
+ * `type MoveStructType = ${string}::${string}::${string}`;
  */
 export type ViewRequest = {
-  function: MoveResourceType;
+  function: MoveStructType;
   /**
    * Type arguments of the function
    */
-  type_arguments: Array<MoveResourceType>;
+  type_arguments: Array<MoveStructType>;
   /**
    * Arguments of the function
    */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -679,7 +679,6 @@ export type MoveUint128Type = string;
 export type MoveUint256Type = string;
 export type MoveAddressType = string;
 export type MoveObjectType = string;
-export type MoveStructType = `${string}::${string}::${string}`;
 export type MoveOptionType = MoveType | null | undefined;
 /**
  * String representation of a on-chain Move struct type.
@@ -697,7 +696,7 @@ export type MoveType =
   | MoveUint256Type
   | MoveAddressType
   | MoveObjectType
-  | MoveStructType
+  | MoveResourceType
   | Array<MoveType>;
 
 /**
@@ -734,7 +733,7 @@ export type MoveValue =
   | MoveUint256Type
   | MoveAddressType
   | MoveObjectType
-  | MoveStructType
+  | MoveResourceType
   | MoveOptionType
   | Array<MoveValue>;
 
@@ -892,7 +891,7 @@ export type Block = {
  * The data needed to generate a View Request payload
  */
 export type ViewRequestData = {
-  function: MoveStructType;
+  function: MoveResourceType;
   typeArguments?: Array<MoveResourceType>;
   functionArguments?: Array<MoveValue>;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -681,7 +681,7 @@ export type MoveAddressType = string;
 export type MoveObjectType = string;
 export type MoveOptionType = MoveType | null | undefined;
 /**
- * String representation of a on-chain Move struct type.
+ * This is the format for a fully qualified struct, resource, or entry function in Move.
  */
 export type MoveStructType = `${string}::${string}::${string}`;
 


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

resolve #117 

Removing the MoveStructType and consolidate into MoveResourceType. 

We could keep both, and assign one to another. i.e 

```
export type MoveStructType = MoveResourceType;
export type MoveResourceType = `${string}::${string}::${string}`;
```

But I feel like it would just confuse the user. 

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

pnpm fmt

### Related Links
<!-- Please link to any relevant issues or pull requests! -->