### PR TITLE
[typeTag] Use new typetag parser everywhere, remove old one

### DIFF
--- a/examples/typescript/multi_agent_transfer.ts
+++ b/examples/typescript/multi_agent_transfer.ts
@@ -2,7 +2,7 @@
  * This example shows how to use the Aptos client to create accounts, fund them, and transfer between them.
  */
 
-import { Account, AccountAddress, Aptos, AptosConfig, Network, StructTag, TypeTagStruct, U64 } from "aptos";
+import { Account, AccountAddress, Aptos, AptosConfig, U64, parseTypeTag } from "aptos";
 
 // TODO: There currently isn't a way to use the APTOS_COIN in the COIN_STORE due to a regex
 const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
@@ -96,7 +96,7 @@ const example = async () => {
     secondarySignerAddresses: [bob.accountAddress.toUint8Array()],
     data: {
       bytecode: TRANSFER_SCRIPT,
-      typeArguments: [new TypeTagStruct(StructTag.fromString(APTOS_COIN))],
+      typeArguments: [parseTypeTag(APTOS_COIN)],
       functionArguments: [AccountAddress.fromStringRelaxed(objectAddress), new U64(TRANSFER_AMOUNT)],
     },
   });

--- a/examples/typescript/simple_transfer.ts
+++ b/examples/typescript/simple_transfer.ts
@@ -2,7 +2,7 @@
  * This example shows how to use the Aptos client to create accounts, fund them, and transfer between them.
  */
 
-import { Account, AccountAddress, Aptos, AptosConfig, Network, StructTag, TypeTagStruct, U64 } from "aptos";
+import { Account, AccountAddress, Aptos, AptosConfig, Network, U64, parseTypeTag } from "aptos";
 
 // TODO: There currently isn't a way to use the APTOS_COIN in the COIN_STORE due to a regex
 const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
@@ -74,7 +74,7 @@ const example = async () => {
     sender: alice.accountAddress.toString(),
     data: {
       function: "0x1::coin::transfer",
-      typeArguments: [new TypeTagStruct(StructTag.fromString(APTOS_COIN))],
+      typeArguments: [parseTypeTag(APTOS_COIN)],
       functionArguments: [AccountAddress.fromHexInput(bob.accountAddress.toString()), new U64(TRANSFER_AMOUNT)],
     },
   });

--- a/examples/typescript/transfer_coin.ts
+++ b/examples/typescript/transfer_coin.ts
@@ -3,7 +3,7 @@
  * Similar to ./simple_transfer.ts, but uses transferCoinTransaction to generate the transaction.
  */
 
-import { Account, AccountAddress, Aptos, AptosConfig, Network } from "aptos";
+import { Account, AccountAddress, Aptos, AptosConfig } from "aptos";
 
 const COIN_STORE = `0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>`;
 const ALICE_INITIAL_BALANCE = 100_000_000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export * from "./bcs";
 export * from "./client";
 export * from "./core";
 export * from "./transactions/types";
-export * from "./transactions/typeTag/typeTag";
+export * from "./transactions/typeTag";
 export * from "./types";
 export * from "./utils/apiEndpoints";
 export * from "./utils/hdKey";

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -2,10 +2,10 @@ import { AptosConfig } from "../api/aptosConfig";
 import { U64 } from "../bcs/serializable/movePrimitives";
 import { Account, AccountAddress } from "../core";
 import { GenerateTransactionOptions, SingleSignerTransaction } from "../transactions/types";
-import { StructTag, TypeTagStruct } from "../transactions/typeTag/typeTag";
 import { HexInput, AnyNumber, MoveResourceType } from "../types";
 import { APTOS_COIN } from "../utils/const";
 import { generateTransaction } from "./transactionSubmission";
+import { parseTypeTag } from "../transactions/typeTag/parser";
 
 export async function transferCoinTransaction(args: {
   aptosConfig: AptosConfig;
@@ -22,7 +22,7 @@ export async function transferCoinTransaction(args: {
     sender: sender.accountAddress.toString(),
     data: {
       function: "0x1::aptos_account::transfer_coins",
-      typeArguments: [new TypeTagStruct(StructTag.fromString(coinStructType))],
+      typeArguments: [parseTypeTag(coinStructType)],
       functionArguments: [AccountAddress.fromHexInput(recipient), new U64(amount)],
     },
     options,

--- a/src/transactions/typeTag/index.ts
+++ b/src/transactions/typeTag/index.ts
@@ -1,0 +1,5 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+export * from "./typeTag";
+export * from "./parser";

--- a/src/transactions/typeTag/typeTag.ts
+++ b/src/transactions/typeTag/typeTag.ts
@@ -38,6 +38,9 @@ export abstract class TypeTag extends Serializable {
         return TypeTagU32.load(deserializer);
       case TypeTagVariants.U256:
         return TypeTagU256.load(deserializer);
+      case TypeTagVariants.Generic:
+        // This is only used for ABI representation, and cannot actually be used as a type.
+        return TypeTagGeneric.load(deserializer);
       default:
         throw new Error(`Unknown variant index for TypeTag: ${index}`);
     }
@@ -134,6 +137,27 @@ export class TypeTagSigner extends TypeTag {
   }
 }
 
+/**
+ * Generics are used for type parameters in entry functions.  However,
+ * they are not actually serialized into a real type, so they cannot be
+ * used as a type directly.
+ */
+export class TypeTagGeneric extends TypeTag {
+  constructor(public readonly value: number) {
+    super();
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(TypeTagVariants.Generic);
+    serializer.serializeU32(this.value);
+  }
+
+  static load(deserializer: Deserializer): TypeTagGeneric {
+    const value = deserializer.deserializeU32();
+    return new TypeTagGeneric(value);
+  }
+}
+
 export class TypeTagVector extends TypeTag {
   constructor(public readonly value: TypeTag) {
     super();
@@ -201,25 +225,6 @@ export class StructTag extends Serializable {
     this.type_args = type_args;
   }
 
-  /**
-   * Converts a string literal to a StructTag
-   * @param structTag String literal in format "AccountAddress::module_name::ResourceName",
-   *   e.g. "0x1::aptos_coin::AptosCoin"
-   * @returns
-   */
-  static fromString(structTag: string): StructTag {
-    // Use the TypeTagParser to parse the string literal into a TypeTagStruct
-    const typeTagStruct = new TypeTagParser(structTag).parseTypeTag() as TypeTagStruct;
-
-    // Convert and return as a StructTag
-    return new StructTag(
-      typeTagStruct.value.address,
-      typeTagStruct.value.module_name,
-      typeTagStruct.value.name,
-      typeTagStruct.value.type_args,
-    );
-  }
-
   serialize(serializer: Serializer): void {
     serializer.serialize(this.address);
     serializer.serialize(this.module_name);
@@ -245,243 +250,4 @@ export function optionStructTag(typeArg: TypeTag): StructTag {
 
 export function objectStructTag(typeArg: TypeTag): StructTag {
   return new StructTag(AccountAddress.ONE, new Identifier("object"), new Identifier("Object"), [typeArg]);
-}
-
-/**
- * Parser to parse a type tag string
- */
-export class TypeTagParser {
-  private readonly tokens: Token[];
-
-  private readonly typeTags: string[] = [];
-
-  constructor(tagStr: string, typeTags?: string[]) {
-    this.tokens = tokenize(tagStr);
-    this.typeTags = typeTags || [];
-  }
-
-  private consume(targetToken: string) {
-    const token = this.tokens.shift();
-    if (!token || token[1] !== targetToken) {
-      bail("Invalid type tag.");
-    }
-  }
-
-  /**
-   * Consumes all of an unused generic field, mostly applicable to object
-   *
-   * Note: This is recursive.  it can be problematic if there's bad input
-   * @private
-   */
-  private consumeWholeGeneric() {
-    this.consume("<");
-    while (this.tokens[0][1] !== ">") {
-      // If it is nested, we have to consume another nested generic
-      if (this.tokens[0][1] === "<") {
-        this.consumeWholeGeneric();
-      } else {
-        this.tokens.shift();
-      }
-    }
-    this.consume(">");
-  }
-
-  private parseCommaList(endToken: string, allowTrailingComma: boolean): TypeTag[] {
-    const res: TypeTag[] = [];
-    if (this.tokens.length <= 0) {
-      bail("Invalid type tag.");
-    }
-
-    while (this.tokens[0][1] !== endToken) {
-      res.push(this.parseTypeTag());
-
-      if (this.tokens.length > 0 && this.tokens[0][1] === endToken) {
-        break;
-      }
-
-      this.consume(",");
-      if (this.tokens.length > 0 && this.tokens[0][1] === endToken && allowTrailingComma) {
-        break;
-      }
-
-      if (this.tokens.length <= 0) {
-        bail("Invalid type tag.");
-      }
-    }
-    return res;
-  }
-
-  parseTypeTag(): TypeTag {
-    if (this.tokens.length === 0) {
-      bail("Invalid type tag.");
-    }
-
-    // Pop left most element out
-    const [tokenTy, tokenVal] = this.tokens.shift()!;
-
-    if (tokenVal === "u8") {
-      return new TypeTagU8();
-    }
-    if (tokenVal === "u16") {
-      return new TypeTagU16();
-    }
-    if (tokenVal === "u32") {
-      return new TypeTagU32();
-    }
-    if (tokenVal === "u64") {
-      return new TypeTagU64();
-    }
-    if (tokenVal === "u128") {
-      return new TypeTagU128();
-    }
-    if (tokenVal === "u256") {
-      return new TypeTagU256();
-    }
-    if (tokenVal === "bool") {
-      return new TypeTagBool();
-    }
-    if (tokenVal === "address") {
-      return new TypeTagAddress();
-    }
-    if (tokenVal === "vector") {
-      this.consume("<");
-      const res = this.parseTypeTag();
-      this.consume(">");
-      return new TypeTagVector(res);
-    }
-    if (tokenVal === "string") {
-      return new TypeTagStruct(stringStructTag());
-    }
-    if (tokenTy === "IDENT" && (tokenVal.startsWith("0x") || tokenVal.startsWith("0X"))) {
-      const address = AccountAddress.fromHexInput(tokenVal);
-      this.consume("::");
-      const [moduleTokenTy, module] = this.tokens.shift()!;
-      if (moduleTokenTy !== "IDENT") {
-        bail("Invalid type tag.");
-      }
-      this.consume("::");
-      const [nameTokenTy, name] = this.tokens.shift()!;
-      if (nameTokenTy !== "IDENT") {
-        bail("Invalid type tag.");
-      }
-
-      // Objects can contain either concrete types e.g. 0x1::object::ObjectCore or generics e.g. T
-      // Neither matter as we can't do type checks, so just the address applies, and we consume the entire generic.
-      // TODO: Support parsing structs that don't come from core code address
-      if (AccountAddress.ONE.toString() === address.toString() && module === "object" && name === "Object") {
-        this.consumeWholeGeneric();
-        return new TypeTagAddress();
-      }
-
-      let tyTags: TypeTag[] = [];
-      // Check if the struct has ty args
-      if (this.tokens.length > 0 && this.tokens[0][1] === "<") {
-        this.consume("<");
-        tyTags = this.parseCommaList(">", true);
-        this.consume(">");
-      }
-
-      const structTag = new StructTag(address, new Identifier(module), new Identifier(name), tyTags);
-      return new TypeTagStruct(structTag);
-    }
-    if (tokenTy === "GENERIC") {
-      if (this.typeTags.length === 0) {
-        bail("Can't convert generic type since no typeTags were specified.");
-      }
-      // a generic tokenVal has the format of `T<digit>`, for example `T1`.
-      // The digit (i.e 1) indicates the index of this type in the typeTags array.
-      // For a tokenVal == T1, should be parsed as the type in typeTags[1]
-      const idx = parseInt(tokenVal.substring(1), 10);
-      return new TypeTagParser(this.typeTags[idx]).parseTypeTag();
-    }
-
-    throw new Error("Invalid type tag.");
-  }
-}
-
-export class TypeTagParserError extends Error {
-  constructor(message: string) {
-    super(message);
-    this.name = "TypeTagParserError";
-  }
-}
-
-function tokenize(tagStr: string): Token[] {
-  let pos = 0;
-  const tokens = [];
-  while (pos < tagStr.length) {
-    const [token, size] = nextToken(tagStr, pos);
-    if (token[0] !== "SPACE") {
-      tokens.push(token);
-    }
-    pos += size;
-  }
-  return tokens;
-}
-
-function bail(message: string) {
-  throw new TypeTagParserError(message);
-}
-
-function isWhiteSpace(c: string): boolean {
-  return !!c.match(/\s/);
-}
-
-function isValidAlphabetic(c: string): boolean {
-  return !!c.match(/[_A-Za-z0-9]/g);
-}
-
-// Generic format is T<digits> - for example T1, T2, T10
-function isGeneric(c: string): boolean {
-  return !!c.match(/T\d+/g);
-}
-
-/**
- * Used for parsing a TypeTag, a Token type is two strings: [token type, token value]
- * @example const token: Token = ["COMMA", ","];
- * @see nextToken(...) in typeTagParser.ts
- */
-type Token = [string, string];
-
-// Returns Token and Token byte size
-function nextToken(tagStr: string, pos: number): [Token, number] {
-  const c = tagStr[pos];
-  if (c === ":") {
-    if (tagStr.slice(pos, pos + 2) === "::") {
-      return [["COLON", "::"], 2];
-    }
-    bail("Unrecognized token.");
-  } else if (c === "<") {
-    return [["LT", "<"], 1];
-  } else if (c === ">") {
-    return [["GT", ">"], 1];
-  } else if (c === ",") {
-    return [["COMMA", ","], 1];
-  } else if (isWhiteSpace(c)) {
-    let res = "";
-    for (let i = pos; i < tagStr.length; i += 1) {
-      const char = tagStr[i];
-      if (isWhiteSpace(char)) {
-        res = `${res}${char}`;
-      } else {
-        break;
-      }
-    }
-    return [["SPACE", res], res.length];
-  } else if (isValidAlphabetic(c)) {
-    let res = "";
-    for (let i = pos; i < tagStr.length; i += 1) {
-      const char = tagStr[i];
-      if (isValidAlphabetic(char)) {
-        res = `${res}${char}`;
-      } else {
-        break;
-      }
-    }
-    if (isGeneric(res)) {
-      return [["GENERIC", res], res.length];
-    }
-    return [["IDENT", res], res.length];
-  }
-  throw new Error("Unrecognized token.");
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -41,6 +41,7 @@ export enum TypeTagVariants {
   U16 = 8,
   U32 = 9,
   U256 = 10,
+  Generic = 255, // This is specifically a placeholder and does not represent a real type
 }
 
 /**

--- a/tests/unit/typeTag.test.ts
+++ b/tests/unit/typeTag.test.ts
@@ -2,12 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {
-  objectStructTag,
   StructTag,
   TypeTag,
   TypeTagAddress,
   TypeTagBool,
-  TypeTagParser,
   TypeTagSigner,
   TypeTagStruct,
   TypeTagU128,
@@ -17,12 +15,10 @@ import {
   TypeTagU64,
   TypeTagU8,
   TypeTagVector,
-  AccountAddress,
-  AddressInvalidReason,
   Deserializer,
-  ParsingError,
   Serializer,
 } from "../../src";
+import { parseTypeTag } from "../../src/transactions/typeTag/parser";
 
 const expectedTypeTag = {
   string: "0x1::some_module::SomeResource",
@@ -30,170 +26,6 @@ const expectedTypeTag = {
   module_name: "some_module",
   name: "SomeResource",
 };
-
-describe("StructTag", () => {
-  test("make sure StructTag.fromString works with un-nested type tag", () => {
-    const structTag = StructTag.fromString(expectedTypeTag.string);
-    expect(structTag.address.toString()).toEqual(expectedTypeTag.address);
-    expect(structTag.module_name.identifier).toEqual(expectedTypeTag.module_name);
-    expect(structTag.name.identifier).toEqual(expectedTypeTag.name);
-    expect(structTag.type_args.length).toEqual(0);
-  });
-
-  test("make sure StructTag.fromString works with nested type tag", () => {
-    const structTag = StructTag.fromString(
-      `${expectedTypeTag.string}<${expectedTypeTag.string}, ${expectedTypeTag.string}>`,
-    );
-    expect(structTag.address.toString()).toEqual(expectedTypeTag.address);
-    expect(structTag.module_name.identifier).toEqual(expectedTypeTag.module_name);
-    expect(structTag.name.identifier).toEqual(expectedTypeTag.name);
-    expect(structTag.type_args.length).toEqual(2);
-
-    // make sure the nested type tag is correct
-    // eslint-disable-next-line no-restricted-syntax
-    for (const typeArg of structTag.type_args) {
-      const nestedTypeTag = typeArg as TypeTagStruct;
-      expect(nestedTypeTag.value.address.toString()).toEqual(expectedTypeTag.address);
-      expect(nestedTypeTag.value.module_name.identifier).toEqual(expectedTypeTag.module_name);
-      expect(nestedTypeTag.value.name.identifier).toEqual(expectedTypeTag.name);
-      expect(nestedTypeTag.value.type_args.length).toEqual(0);
-    }
-  });
-
-  test("correctly validates String type tag", () => {
-    const structTag = new TypeTagStruct(StructTag.fromString("0x1::string::String"));
-    expect(new TypeTagParser("0x1::string::String").parseTypeTag().bcsToBytes()).toEqual(structTag.bcsToBytes());
-  });
-});
-
-describe("TypeTagParser", () => {
-  test("make sure parseTypeTag throws ParsingError<AddressInvalidReason> if the address is an invalid format", () => {
-    let typeTag = "0x000";
-    let parser = new TypeTagParser(typeTag);
-
-    try {
-      parser.parseTypeTag();
-    } catch (error) {
-      expect(error).toBeInstanceOf(ParsingError);
-      const typeTagError = error as ParsingError<AddressInvalidReason>;
-      expect(typeTagError.message).toEqual(
-        `The given hex string ${typeTag} is a special address not in LONG form, it must be 0x0 to 0xf without padding zeroes.`,
-      );
-    }
-
-    typeTag = "0x1::some_module::SomeResource<0x1>";
-    parser = new TypeTagParser(typeTag);
-    expect(() => parser.parseTypeTag()).toThrowError("Invalid type tag.");
-  });
-
-  test("make sure parseTypeTag works with un-nested type tag", () => {
-    const parser = new TypeTagParser(expectedTypeTag.string);
-    const result = parser.parseTypeTag() as TypeTagStruct;
-    expect(result.value.address.toString()).toEqual(expectedTypeTag.address);
-    expect(result.value.module_name.identifier).toEqual(expectedTypeTag.module_name);
-    expect(result.value.name.identifier).toEqual(expectedTypeTag.name);
-    expect(result.value.type_args.length).toEqual(0);
-  });
-
-  test("make sure parseTypeTag works with nested type tag", () => {
-    const typeTag = "0x1::some_module::SomeResource<0x1::some_module::SomeResource, 0x1::some_module::SomeResource>";
-    const parser = new TypeTagParser(typeTag);
-    const result = parser.parseTypeTag() as TypeTagStruct;
-    expect(result.value.address.toString()).toEqual(expectedTypeTag.address);
-    expect(result.value.module_name.identifier).toEqual(expectedTypeTag.module_name);
-    expect(result.value.name.identifier).toEqual(expectedTypeTag.name);
-    expect(result.value.type_args.length).toEqual(2);
-
-    // make sure the nested type tag is correct
-    // eslint-disable-next-line no-restricted-syntax
-    for (const typeArg of result.value.type_args) {
-      const nestedTypeTag = typeArg as TypeTagStruct;
-      expect(nestedTypeTag.value.address.toString()).toEqual(expectedTypeTag.address);
-      expect(nestedTypeTag.value.module_name.identifier).toEqual(expectedTypeTag.module_name);
-      expect(nestedTypeTag.value.name.identifier).toEqual(expectedTypeTag.name);
-      expect(nestedTypeTag.value.type_args.length).toEqual(0);
-    }
-  });
-
-  describe("parse Object type", () => {
-    test("TypeTagParser successfully parses an Object type", () => {
-      const typeTag = "0x1::object::Object<T>";
-      const parser = new TypeTagParser(typeTag);
-      const result = parser.parseTypeTag();
-      expect(result instanceof TypeTagAddress).toBeTruthy();
-    });
-
-    test("TypeTagParser successfully parses complex Object types", () => {
-      const typeTag = "0x1::object::Object<T>";
-      const parser = new TypeTagParser(typeTag);
-      const result = parser.parseTypeTag();
-      expect(result instanceof TypeTagAddress).toBeTruthy();
-
-      const typeTag2 = "0x1::object::Object<0x1::coin::Fun<A, B<C>>>";
-      const parser2 = new TypeTagParser(typeTag2);
-      const result2 = parser2.parseTypeTag();
-      expect(result2 instanceof TypeTagAddress).toBeTruthy();
-    });
-
-    test("TypeTagParser does not parse unofficial objects", () => {
-      const address = AccountAddress.fromHexInputRelaxed("0x12345").toString();
-      const typeTag = `${address}::object::Object<T>`;
-      const parser = new TypeTagParser(typeTag);
-      expect(() => parser.parseTypeTag()).toThrowError("Invalid type tag.");
-    });
-
-    test("TypeTagParser successfully parses an Option type", () => {
-      const typeTag = "0x1::option::Option<u8>";
-      const parser = new TypeTagParser(typeTag);
-      const result = parser.parseTypeTag();
-
-      if (result instanceof TypeTagStruct) {
-        expect(result.value === objectStructTag(new TypeTagU8()));
-      } else {
-        fail(`Not an option ${result}`);
-      }
-    });
-
-    test("TypeTagParser successfully parses a struct with a nested Object type", () => {
-      const typeTag = "0x1::some_module::SomeResource<0x1::object::Object<T>>";
-      const parser = new TypeTagParser(typeTag);
-      const result = parser.parseTypeTag() as TypeTagStruct;
-      expect(result.value.address.toString()).toEqual(expectedTypeTag.address);
-      expect(result.value.module_name.identifier).toEqual("some_module");
-      expect(result.value.name.identifier).toEqual("SomeResource");
-      expect(result.value.type_args[0] instanceof TypeTagAddress).toBeTruthy();
-    });
-
-    test("TypeTagParser successfully parses a struct with a nested Object and Struct types", () => {
-      const typeTag = "0x1::some_module::SomeResource<0x1::object::Object<T>, 0x1::some_module::SomeResource>";
-      const parser = new TypeTagParser(typeTag);
-      const result = parser.parseTypeTag() as TypeTagStruct;
-      expect(result.value.address.toString()).toEqual(expectedTypeTag.address);
-      expect(result.value.module_name.identifier).toEqual("some_module");
-      expect(result.value.name.identifier).toEqual("SomeResource");
-      expect(result.value.type_args.length).toEqual(2);
-      expect(result.value.type_args[0] instanceof TypeTagAddress).toBeTruthy();
-      expect(result.value.type_args[1] instanceof TypeTagStruct).toBeTruthy();
-    });
-  });
-
-  describe("supports generic types", () => {
-    test("throws an error when the type to use is not provided", () => {
-      const typeTag = "T0";
-      const parser = new TypeTagParser(typeTag);
-      expect(() => {
-        parser.parseTypeTag();
-      }).toThrow("Can't convert generic type since no typeTags were specified.");
-    });
-
-    test("successfully parses a generic type tag to the provided type", () => {
-      const typeTag = "T0";
-      const parser = new TypeTagParser(typeTag, ["bool"]);
-      const result = parser.parseTypeTag();
-      expect(result instanceof TypeTagBool).toBeTruthy();
-    });
-  });
-});
 
 describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagBool correctly", () => {
@@ -289,7 +121,7 @@ describe("Deserialize TypeTags", () => {
 
   test("deserializes a TypeTagStruct correctly", () => {
     const serializer = new Serializer();
-    const tag = new TypeTagStruct(StructTag.fromString(expectedTypeTag.string));
+    const tag = parseTypeTag(expectedTypeTag.string);
 
     tag.serialize(serializer);
     const deserialized = TypeTag.deserialize(new Deserializer(serializer.toUint8Array())) as TypeTagStruct;


### PR DESCRIPTION

### Description

Use the new TypeTag parser everywhere, with generic support.  This consistency is required for Remote ABI

### Test Plan
Existing tests.  Parser is already covered with separate tests, so duplicates were removed.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->