### PR TITLE
[Naming] Unifying type names so they reflect the rust enums more accurately

### DIFF
--- a/src/transactions/authenticator/transaction.ts
+++ b/src/transactions/authenticator/transaction.ts
@@ -24,8 +24,8 @@ export abstract class TransactionAuthenticator extends Serializable {
         return TransactionAuthenticatorMultiAgent.load(deserializer);
       case TransactionAuthenticatorVariant.FeePayer:
         return TransactionAuthenticatorFeePayer.load(deserializer);
-      case TransactionAuthenticatorVariant.SingleSenderTransactionAuthenticator:
-        return SingleSenderTransactionAuthenticator.load(deserializer);
+      case TransactionAuthenticatorVariant.SingleSender:
+        return TransactionAuthenticatorSingleSender.load(deserializer);
       default:
         throw new Error(`Unknown variant index for TransactionAuthenticator: ${index}`);
     }
@@ -195,7 +195,7 @@ export class TransactionAuthenticatorFeePayer extends TransactionAuthenticator {
  *
  * @param sender AccountAuthenticator
  */
-export class SingleSenderTransactionAuthenticator extends TransactionAuthenticator {
+export class TransactionAuthenticatorSingleSender extends TransactionAuthenticator {
   public readonly sender: AccountAuthenticator;
 
   constructor(sender: AccountAuthenticator) {
@@ -204,12 +204,12 @@ export class SingleSenderTransactionAuthenticator extends TransactionAuthenticat
   }
 
   serialize(serializer: Serializer): void {
-    serializer.serializeU32AsUleb128(TransactionAuthenticatorVariant.SingleSenderTransactionAuthenticator);
+    serializer.serializeU32AsUleb128(TransactionAuthenticatorVariant.SingleSender);
     this.sender.serialize(serializer);
   }
 
-  static load(deserializer: Deserializer): SingleSenderTransactionAuthenticator {
+  static load(deserializer: Deserializer): TransactionAuthenticatorSingleSender {
     const sender = AccountAuthenticator.deserialize(deserializer);
-    return new SingleSenderTransactionAuthenticator(sender);
+    return new TransactionAuthenticatorSingleSender(sender);
   }
 }

--- a/src/transactions/instances/transactionPayload.ts
+++ b/src/transactions/instances/transactionPayload.ts
@@ -334,7 +334,7 @@ export class Script {
 export class MultiSig {
   public readonly multisig_address: AccountAddress;
 
-  public readonly transaction_payload?: TransactionPayloadMultiSig;
+  public readonly transaction_payload?: MultisigTransactionPayload;
 
   /**
    * Contains the payload to run a multi-sig account transaction.
@@ -344,7 +344,7 @@ export class MultiSig {
    * @param transaction_payload The payload of the multi-sig transaction. This is optional when executing a multi-sig
    *  transaction whose payload is already stored on chain.
    */
-  constructor(multisig_address: AccountAddress, transaction_payload?: TransactionPayloadMultiSig) {
+  constructor(multisig_address: AccountAddress, transaction_payload?: MultisigTransactionPayload) {
     this.multisig_address = multisig_address;
     this.transaction_payload = transaction_payload;
   }
@@ -366,16 +366,21 @@ export class MultiSig {
     const payloadPresent = deserializer.deserializeBool();
     let transaction_payload;
     if (payloadPresent) {
-      transaction_payload = TransactionPayloadMultiSig.deserialize(deserializer);
+      transaction_payload = MultisigTransactionPayload.deserialize(deserializer);
     }
     return new MultiSig(multisig_address, transaction_payload);
   }
 }
 
 /**
- * Representation of a MultiSig Transaction Payload that can serialized and deserialized
+ * Representation of a MultiSig Transaction Payload from `multisig_account.move`
+ * that can be serialized and deserialized
+
+ * This class exists right now to represent an extensible transaction payload class for
+ * transactions used in `multisig_account.move`. Eventually, this class will be able to
+ * support script payloads when the `multisig_account.move` module supports them.
  */
-export class TransactionPayloadMultiSig {
+export class MultisigTransactionPayload {
   public readonly transaction_payload: EntryFunction;
 
   /**
@@ -399,9 +404,9 @@ export class TransactionPayloadMultiSig {
     this.transaction_payload.serialize(serializer);
   }
 
-  static deserialize(deserializer: Deserializer): TransactionPayloadMultiSig {
+  static deserialize(deserializer: Deserializer): MultisigTransactionPayload {
     // This is the enum value indicating which type of payload the multi-sig transaction contains.
     deserializer.deserializeUleb128AsU32();
-    return new TransactionPayloadMultiSig(EntryFunction.deserialize(deserializer));
+    return new MultisigTransactionPayload(EntryFunction.deserialize(deserializer));
   }
 }

--- a/src/transactions/instances/transactionPayload.ts
+++ b/src/transactions/instances/transactionPayload.ts
@@ -334,7 +334,7 @@ export class Script {
 export class MultiSig {
   public readonly multisig_address: AccountAddress;
 
-  public readonly transaction_payload?: MultiSigTransactionPayload;
+  public readonly transaction_payload?: TransactionPayloadMultiSig;
 
   /**
    * Contains the payload to run a multi-sig account transaction.
@@ -344,7 +344,7 @@ export class MultiSig {
    * @param transaction_payload The payload of the multi-sig transaction. This is optional when executing a multi-sig
    *  transaction whose payload is already stored on chain.
    */
-  constructor(multisig_address: AccountAddress, transaction_payload?: MultiSigTransactionPayload) {
+  constructor(multisig_address: AccountAddress, transaction_payload?: TransactionPayloadMultiSig) {
     this.multisig_address = multisig_address;
     this.transaction_payload = transaction_payload;
   }
@@ -366,7 +366,7 @@ export class MultiSig {
     const payloadPresent = deserializer.deserializeBool();
     let transaction_payload;
     if (payloadPresent) {
-      transaction_payload = MultiSigTransactionPayload.deserialize(deserializer);
+      transaction_payload = TransactionPayloadMultiSig.deserialize(deserializer);
     }
     return new MultiSig(multisig_address, transaction_payload);
   }
@@ -375,7 +375,7 @@ export class MultiSig {
 /**
  * Representation of a MultiSig Transaction Payload that can serialized and deserialized
  */
-export class MultiSigTransactionPayload {
+export class TransactionPayloadMultiSig {
   public readonly transaction_payload: EntryFunction;
 
   /**
@@ -399,9 +399,9 @@ export class MultiSigTransactionPayload {
     this.transaction_payload.serialize(serializer);
   }
 
-  static deserialize(deserializer: Deserializer): MultiSigTransactionPayload {
+  static deserialize(deserializer: Deserializer): TransactionPayloadMultiSig {
     // This is the enum value indicating which type of payload the multi-sig transaction contains.
     deserializer.deserializeUleb128AsU32();
-    return new MultiSigTransactionPayload(EntryFunction.deserialize(deserializer));
+    return new TransactionPayloadMultiSig(EntryFunction.deserialize(deserializer));
   }
 }

--- a/src/transactions/transaction_builder/transaction_builder.ts
+++ b/src/transactions/transaction_builder/transaction_builder.ts
@@ -42,7 +42,7 @@ import {
   FeePayerRawTransaction,
   MultiAgentRawTransaction,
   MultiSig,
-  TransactionPayloadMultiSig,
+  MultisigTransactionPayload,
   RawTransaction,
   Script,
   TransactionPayloadEntryFunction,
@@ -189,7 +189,7 @@ export function generateTransactionPayloadWithABI(
       multisigAddress = args.multisigAddress;
     }
     return new TransactionPayloadMultisig(
-      new MultiSig(multisigAddress, new MultiSigTransactionPayload(entryFunctionPayload)),
+      new MultiSig(multisigAddress, new MultisigTransactionPayload(entryFunctionPayload)),
     );
   }
 

--- a/src/transactions/transaction_builder/transaction_builder.ts
+++ b/src/transactions/transaction_builder/transaction_builder.ts
@@ -34,7 +34,7 @@ import {
   TransactionAuthenticatorEd25519,
   TransactionAuthenticatorFeePayer,
   TransactionAuthenticatorMultiAgent,
-  SingleSenderTransactionAuthenticator,
+  TransactionAuthenticatorSingleSender,
 } from "../authenticator/transaction";
 import {
   ChainId,
@@ -42,7 +42,7 @@ import {
   FeePayerRawTransaction,
   MultiAgentRawTransaction,
   MultiSig,
-  MultiSigTransactionPayload,
+  TransactionPayloadMultiSig,
   RawTransaction,
   Script,
   TransactionPayloadEntryFunction,
@@ -399,7 +399,7 @@ export function generateSignedTransactionForSimulation(args: SimulateTransaction
       accountAuthenticator.signature,
     );
   } else if (accountAuthenticator instanceof AccountAuthenticatorSingleKey) {
-    transactionAuthenticator = new SingleSenderTransactionAuthenticator(accountAuthenticator);
+    transactionAuthenticator = new TransactionAuthenticatorSingleSender(accountAuthenticator);
   } else {
     throw new Error("Invalid public key");
   }
@@ -504,7 +504,7 @@ export function generateSignedTransaction(args: {
   }
 
   if (accountAuthenticator instanceof AccountAuthenticatorSingleKey) {
-    const transactionAuthenticator = new SingleSenderTransactionAuthenticator(accountAuthenticator);
+    const transactionAuthenticator = new TransactionAuthenticatorSingleSender(accountAuthenticator);
     // return signed transaction
     return new SignedTransaction(transactionToSubmit as RawTransaction, transactionAuthenticator).bcsToBytes();
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,7 +89,7 @@ export enum TransactionAuthenticatorVariant {
   MultiEd25519 = 1,
   MultiAgent = 2,
   FeePayer = 3,
-  SingleSenderTransactionAuthenticator = 4,
+  SingleSender = 4,
 }
 
 /**


### PR DESCRIPTION
### Description
As I'm exporting types for the wallet adapter stuff, I'm coming across inconsistent type names, so I'm trying to make sure they make sense.

### Test Plan
```typescript
pnpm jest
```