### PR TITLE
[Easy] Fix MoveStructType address format

### DIFF
--- a/tests/e2e/transaction/signTransaction.test.ts
+++ b/tests/e2e/transaction/signTransaction.test.ts
@@ -54,7 +54,7 @@ describe("sign transaction", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -72,7 +72,7 @@ describe("sign transaction", () => {
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -108,7 +108,7 @@ describe("sign transaction", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -126,7 +126,7 @@ describe("sign transaction", () => {
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -162,7 +162,7 @@ describe("sign transaction", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -180,7 +180,7 @@ describe("sign transaction", () => {
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -63,7 +63,7 @@ describe("transaction builder", () => {
       const payload = await generateTransactionPayload({
         aptosConfig: config,
         multisigAddress: Account.generate().accountAddress,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [200, "0x1"],
       });
       expect(payload instanceof TransactionPayloadMultisig).toBeTruthy();
@@ -71,7 +71,7 @@ describe("transaction builder", () => {
     test("it generates an entry function transaction payload", async () => {
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [200, "0x1"],
       });
       expect(payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
@@ -79,7 +79,7 @@ describe("transaction builder", () => {
     test("it generates an entry function transaction payload with encoded inputs", async () => {
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(100), AccountAddress.ONE],
       });
       expect(payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
@@ -87,13 +87,13 @@ describe("transaction builder", () => {
     test("it generates an entry function transaction payload with mixed arguments", async () => {
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: ["0x2", AccountAddress.ONE],
       });
       expect(payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
       const payload2 = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(10), "0x1"],
       });
       expect(payload2 instanceof TransactionPayloadEntryFunction).toBeTruthy();
@@ -109,7 +109,7 @@ describe("transaction builder", () => {
       const payload = generateTransactionPayloadWithABI(
         {
           multisigAddress: Account.generate().accountAddress,
-          function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+          function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
           functionArguments: ["0x1", "0x1"],
         },
         functionAbi,
@@ -119,7 +119,7 @@ describe("transaction builder", () => {
     test("it generates an entry function transaction payload", async () => {
       const payload = generateTransactionPayloadWithABI(
         {
-          function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+          function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
           functionArguments: ["0x1", "0x1"],
         },
         functionAbi,
@@ -129,7 +129,7 @@ describe("transaction builder", () => {
     test("it generates an entry function transaction payload with mixed arguments", async () => {
       const payload = generateTransactionPayloadWithABI(
         {
-          function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+          function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
           functionArguments: [AccountAddress.ONE, "0x1"],
         },
         functionAbi,
@@ -137,7 +137,7 @@ describe("transaction builder", () => {
       expect(payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
       const payload2 = generateTransactionPayloadWithABI(
         {
-          function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+          function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
           functionArguments: ["0x1", AccountAddress.ONE],
         },
         functionAbi,
@@ -175,7 +175,7 @@ describe("transaction builder", () => {
       const payload = await generateTransactionPayload({
         aptosConfig: config,
         multisigAddress: bob.accountAddress,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const rawTxn = await generateRawTransaction({
@@ -193,7 +193,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const rawTxn = await generateRawTransaction({
@@ -235,7 +235,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const secondarySignerAddress = Account.generate();
@@ -260,7 +260,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const feePayer = Account.generate();
@@ -284,7 +284,7 @@ describe("transaction builder", () => {
         const bob = Account.generate();
         const payload = await generateTransactionPayload({
           aptosConfig: config,
-          function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+          function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
           functionArguments: [new U64(1), bob.accountAddress],
         });
         const feePayer = Account.generate();
@@ -374,7 +374,7 @@ describe("transaction builder", () => {
       const payload = await generateTransactionPayload({
         aptosConfig: config,
         multisigAddress: bob.accountAddress,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const transaction = await buildTransaction({
@@ -459,7 +459,7 @@ describe("transaction builder", () => {
       const bob = await Account.generate();
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const transaction = await buildTransaction({
@@ -492,7 +492,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const transaction = await buildTransaction({
@@ -526,7 +526,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const transaction = await buildTransaction({
@@ -544,7 +544,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const transaction = await buildTransaction({
@@ -564,7 +564,7 @@ describe("transaction builder", () => {
       const bob = Account.generate();
       const payload = await generateTransactionPayload({
         aptosConfig: config,
-        function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
         functionArguments: [new U64(1), bob.accountAddress],
       });
       const transaction = await buildTransaction({

--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -44,7 +44,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -59,7 +59,7 @@ describe("transaction simulation", () => {
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -102,7 +102,7 @@ describe("transaction simulation", () => {
             sender: singleSignerED25519SenderAccount.accountAddress.toString(),
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
-              function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+              function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
               functionArguments: [
                 new U64(100),
                 new U64(200),
@@ -146,7 +146,7 @@ describe("transaction simulation", () => {
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -163,7 +163,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -181,7 +181,7 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
               new U64(100),
               new U64(200),
@@ -222,7 +222,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -237,7 +237,7 @@ describe("transaction simulation", () => {
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -280,7 +280,7 @@ describe("transaction simulation", () => {
             sender: singleSignerSecp256k1Account.accountAddress.toString(),
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
-              function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+              function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
               functionArguments: [
                 new U64(100),
                 new U64(200),
@@ -324,7 +324,7 @@ describe("transaction simulation", () => {
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -341,7 +341,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -359,7 +359,7 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
               new U64(100),
               new U64(200),
@@ -400,7 +400,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -415,7 +415,7 @@ describe("transaction simulation", () => {
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -458,7 +458,7 @@ describe("transaction simulation", () => {
             sender: legacyED25519SenderAccount.accountAddress.toString(),
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
-              function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+              function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
               functionArguments: [
                 new U64(100),
                 new U64(200),
@@ -502,7 +502,7 @@ describe("transaction simulation", () => {
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -519,7 +519,7 @@ describe("transaction simulation", () => {
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
@@ -537,7 +537,7 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
               new U64(100),
               new U64(200),

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -55,7 +55,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -110,7 +110,7 @@ describe("transaction submission", () => {
             sender: singleSignerED25519SenderAccount.accountAddress.toString(),
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
-              function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+              function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
               functionArguments: [
                 new U64(100),
                 new U64(200),
@@ -170,7 +170,7 @@ describe("transaction submission", () => {
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -195,7 +195,7 @@ describe("transaction submission", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
               new U64(100),
               new U64(200),
@@ -251,7 +251,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -306,7 +306,7 @@ describe("transaction submission", () => {
             sender: singleSignerSecp256k1Account.accountAddress.toString(),
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
-              function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+              function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
               functionArguments: [
                 new U64(100),
                 new U64(200),
@@ -366,7 +366,7 @@ describe("transaction submission", () => {
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -391,7 +391,7 @@ describe("transaction submission", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
               new U64(100),
               new U64(200),
@@ -447,7 +447,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -502,7 +502,7 @@ describe("transaction submission", () => {
             sender: legacyED25519SenderAccount.accountAddress.toString(),
             secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
             data: {
-              function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+              function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
               functionArguments: [
                 new U64(100),
                 new U64(200),
@@ -562,7 +562,7 @@ describe("transaction submission", () => {
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::transfer`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
@@ -587,7 +587,7 @@ describe("transaction submission", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
           data: {
-            function: `0x${contractPublisherAccount.accountAddress.toStringWithoutPrefix()}::transfer::two_by_two`,
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
               new U64(100),
               new U64(200),


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

Since we loosen the type of MoveStructType, we do not need to specify the `0x` prefix. `toString()` of the address class should include the prefix already.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

pnpm test

### Related Links
<!-- Please link to any relevant issues or pull requests! -->