### PR TITLE
Implement `MultiKey` authentication key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Rename publishModuleTransaction to publishPackageTransaction and fix functionality accordingly
 - Added toString() for type tags, and reference placeholder type
 - Add ability to generate transactions with known ABI and remote ABI
+- Fix verify signature logic
+- Implement `MultiKey`support for multi authentication key
 
 ## 0.0.2 (2023-10-25)
 

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -62,8 +62,8 @@ export class Account {
    *
    * @param args.privateKey PrivateKey - private key of the account
    * @param args.address AccountAddress - address of the account
-   * @param args.legacy optional. If set to true, the keypair generated is a Legacy keypair. Defaults
-   * to generating a Unified keypair
+   * @param args.legacy optional. If set to true, the keypair authentication keys will be derived with a Legacy scheme.
+   * Defaults to deriving an authentication key with a Unified scheme
    *
    * This method is private because it should only be called by the factory static methods.
    * @returns Account
@@ -129,7 +129,6 @@ export class Account {
       case SigningSchemeInput.Secp256k1Ecdsa:
         privateKey = Secp256k1PrivateKey.generate();
         break;
-      // TODO: Add support for MultiEd25519 as AnyMultiKey
       default:
         privateKey = Ed25519PrivateKey.generate();
     }
@@ -141,7 +140,7 @@ export class Account {
 
     const address = new AccountAddress({
       data: Account.authKey({
-        publicKey, // TODO support AnyMultiKey
+        publicKey,
       }).toUint8Array(),
     });
     return new Account({ privateKey, address, legacy: args?.legacy });
@@ -153,8 +152,8 @@ export class Account {
    *
    * @param privateKey PrivateKey - private key of the account
    * @param address The account address
-   * @param args.legacy optional. If set to true, the keypair generated is a Legacy keypair. Defaults
-   * to generating a Unified keypair
+   * @param args.legacy optional. If set to true, the keypair authentication keys will be derived with a Legacy scheme.
+   * Defaults to deriving an authentication key with a Unified scheme
    *
    * @returns Account
    */

--- a/src/core/authenticationKey.ts
+++ b/src/core/authenticationKey.ts
@@ -9,6 +9,7 @@ import { MultiEd25519PublicKey } from "./crypto/multiEd25519";
 import { Hex } from "./hex";
 import { AuthenticationKeyScheme, HexInput, SigningScheme } from "../types";
 import { AnyPublicKey } from "./crypto/anyPublicKey";
+import { MultiKey } from "./crypto/multiKey";
 
 /**
  * Each account stores an authentication key. Authentication key enables account owners to rotate
@@ -57,13 +58,14 @@ export class AuthenticationKey {
     const { publicKey, scheme } = args;
     let authKeyBytes: Uint8Array;
 
-    // TODO - support multied25519 key and MultiKey
     switch (scheme) {
+      case SigningScheme.MultiKey:
       case SigningScheme.SingleKey: {
         const singleKeyBytes = publicKey.bcsToBytes();
         authKeyBytes = new Uint8Array([...singleKeyBytes, scheme]);
         break;
       }
+
       case SigningScheme.Ed25519:
       case SigningScheme.MultiEd25519: {
         const ed25519PublicKeyBytes = publicKey.toUint8Array();
@@ -71,6 +73,7 @@ export class AuthenticationKey {
         authKeyBytes = new Uint8Array([...inputBytes, scheme]);
         break;
       }
+
       default:
         throw new Error(`Scheme ${scheme} is not supported`);
     }
@@ -99,6 +102,8 @@ export class AuthenticationKey {
       scheme = SigningScheme.MultiEd25519.valueOf();
     } else if (publicKey instanceof AnyPublicKey) {
       scheme = SigningScheme.SingleKey.valueOf();
+    } else if (publicKey instanceof MultiKey) {
+      scheme = SigningScheme.MultiKey.valueOf();
     } else {
       throw new Error("No supported authentication scheme for public key");
     }

--- a/src/core/crypto/anyPublicKey.ts
+++ b/src/core/crypto/anyPublicKey.ts
@@ -2,10 +2,21 @@ import { Serializer, Deserializer } from "../../bcs";
 import { AnyPublicKeyVariant, HexInput } from "../../types";
 import { AnySignature } from "./anySignature";
 import { PublicKey } from "./asymmetricCrypto";
-import { Ed25519PublicKey, Ed25519Signature } from "./ed25519";
-import { Secp256k1PublicKey, Secp256k1Signature } from "./secp256k1";
+import { Ed25519PublicKey } from "./ed25519";
+import { Secp256k1PublicKey } from "./secp256k1";
 
+/**
+ * Represents any public key supported by Aptos.
+ *
+ * Since [AIP-55](https://github.com/aptos-foundation/AIPs/pull/263) Aptos supports
+ * `Legacy` and `Unified` authentication keys.
+ *
+ * Any unified authentication key is represented in the SDK as `AnyPublicKey`.
+ */
 export class AnyPublicKey extends PublicKey {
+  /**
+   * Reference to the inner public key
+   */
   public readonly publicKey: PublicKey;
 
   constructor(publicKey: PublicKey) {
@@ -40,22 +51,7 @@ export class AnyPublicKey extends PublicKey {
    */
   verifySignature(args: { message: HexInput; signature: AnySignature }): boolean {
     const { message, signature } = args;
-    if (this.isED25519Signature(signature)) {
-      return this.publicKey.verifySignature({ message, signature: signature.signature });
-      // eslint-disable-next-line no-else-return
-    } else if (this.isSecp256k1Signature(signature)) {
-      return this.publicKey.verifySignature({ message, signature: signature.signature });
-    } else {
-      throw new Error("Unknown public key type");
-    }
-  }
-
-  isED25519Signature(signature: AnySignature): boolean {
-    return this.publicKey instanceof Ed25519PublicKey && signature.signature instanceof Ed25519Signature;
-  }
-
-  isSecp256k1Signature(signature: AnySignature): boolean {
-    return this.publicKey instanceof Secp256k1PublicKey && signature.signature instanceof Secp256k1Signature;
+    return this.publicKey.verifySignature({ message, signature });
   }
 
   serialize(serializer: Serializer): void {

--- a/src/core/crypto/ed25519.ts
+++ b/src/core/crypto/ed25519.ts
@@ -10,6 +10,12 @@ import { HexInput } from "../../types";
 
 /**
  * Represents the public key of an Ed25519 key pair.
+ *
+ * Since [AIP-55](https://github.com/aptos-foundation/AIPs/pull/263) Aptos supports
+ * `Legacy` and `Unified` authentication keys.
+ *
+ * Ed25519 scheme is represented in the SDK as `Legacy authentication key` and also
+ * as `AnyPublicKey` that represents any `Unified authentication key`
  */
 export class Ed25519PublicKey extends PublicKey {
   /**

--- a/src/core/crypto/index.ts
+++ b/src/core/crypto/index.ts
@@ -5,3 +5,4 @@ export * from "./asymmetricCrypto";
 export * from "./ed25519";
 export * from "./multiEd25519";
 export * from "./secp256k1";
+export * from "./multiKey";

--- a/src/core/crypto/multiKey.ts
+++ b/src/core/crypto/multiKey.ts
@@ -1,0 +1,122 @@
+import { Hex } from "../hex";
+import { HexInput } from "../../types";
+import { Deserializer } from "../../bcs/deserializer";
+import { Serializer } from "../../bcs/serializer";
+import { AnyPublicKey } from "./anyPublicKey";
+import { AnySignature } from "./anySignature";
+import { PublicKey } from "./asymmetricCrypto";
+
+export class MultiKey extends PublicKey {
+  /**
+   * List of any public keys
+   */
+  public readonly publicKeys: AnyPublicKey[];
+
+  /**
+   * The minimum number of valid signatures required, for the number of public keys specified
+   */
+  public readonly signaturesRequired: number;
+
+  constructor(args: { publicKeys: PublicKey[]; signaturesRequired: number }) {
+    super();
+    const { publicKeys, signaturesRequired } = args;
+
+    // Validate number of public keys is greater than signature required
+    if (signaturesRequired < 0) {
+      throw new Error("The number of required signatures needs to be greater then 0");
+    }
+
+    // Validate number of public keys is greater than signature required
+    if (publicKeys.length < signaturesRequired) {
+      throw new Error(
+        `Provided ${publicKeys.length} public keys is smaller than the ${signaturesRequired} required signatures`,
+      );
+    }
+
+    const keys: AnyPublicKey[] = [];
+    publicKeys.forEach((publicKey) => {
+      if (publicKey instanceof AnyPublicKey) {
+        keys.push(publicKey);
+      } else {
+        // if public key is instance of a legacy authentication key, i.e
+        // Legacy Ed25519, convert it into AnyPublicKey
+        keys.push(new AnyPublicKey(publicKey));
+      }
+    });
+
+    this.publicKeys = keys;
+    this.signaturesRequired = signaturesRequired;
+  }
+
+  toUint8Array(): Uint8Array {
+    return this.bcsToBytes();
+  }
+
+  /**
+   * Create a bitmap that holds the mapping from the original public keys
+   * to the signatures passed in
+   *
+   * @param args.bits array of the index mapping to the matching public keys
+   * @returns Uint8array bit map
+   */
+  createBitmap(args: { bits: number[] }): Uint8Array {
+    const { bits } = args;
+    // Bits are read from left to right. e.g. 0b10000000 represents the first bit is set in one byte.
+    // The decimal value of 0b10000000 is 128.
+    const firstBitInByte = 128;
+    const bitmap = new Uint8Array([0, 0, 0, 0]);
+
+    // Check if duplicates exist in bits
+    const dupCheckSet = new Set();
+
+    bits.forEach((bit: number, idx: number) => {
+      if (idx + 1 > this.publicKeys.length) {
+        throw new Error(`Signature index ${idx + 1} is out of public keys range, ${this.publicKeys.length}.`);
+      }
+
+      if (dupCheckSet.has(bit)) {
+        throw new Error(`Duplicate bit ${bit} detected.`);
+      }
+
+      dupCheckSet.add(bit);
+
+      const byteOffset = Math.floor(bit / 8);
+
+      let byte = bitmap[byteOffset];
+
+      // eslint-disable-next-line no-bitwise
+      byte |= firstBitInByte >> bit % 8;
+
+      bitmap[byteOffset] = byte;
+    });
+
+    return bitmap;
+  }
+
+  /**
+   * Hex string representationog the multi key bytes
+   *
+   * @returns string
+   */
+  toString(): string {
+    return Hex.fromHexInput(this.toUint8Array()).toString();
+  }
+
+  // TODO
+  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+  verifySignature(args: { message: HexInput; signature: AnySignature }): boolean {
+    throw new Error("not implemented");
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serializeVector(this.publicKeys);
+    serializer.serializeU8(this.signaturesRequired);
+  }
+
+  static deserialize(deserializer: Deserializer): MultiKey {
+    const keys = deserializer.deserializeVector(AnyPublicKey);
+    const signaturesRequired = deserializer.deserializeU8();
+
+    return new MultiKey({ publicKeys: keys, signaturesRequired });
+  }
+}

--- a/src/core/crypto/multiKey.ts
+++ b/src/core/crypto/multiKey.ts
@@ -22,7 +22,7 @@ export class MultiKey extends PublicKey {
     const { publicKeys, signaturesRequired } = args;
 
     // Validate number of public keys is greater than signature required
-    if (signaturesRequired < 0) {
+    if (signaturesRequired < 1) {
       throw new Error("The number of required signatures needs to be greater then 0");
     }
 

--- a/src/core/crypto/multiKey.ts
+++ b/src/core/crypto/multiKey.ts
@@ -94,7 +94,7 @@ export class MultiKey extends PublicKey {
   }
 
   /**
-   * Hex string representationog the multi key bytes
+   * Hex string representation the multi key bytes
    *
    * @returns string
    */

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -10,6 +10,8 @@ import { HexInput } from "../../types";
 
 /**
  * Represents the Secp256k1 ecdsa public key
+ *
+ * Secp256k1 authentication key is represented in the SDK as `AnyPublicKey`.
  */
 export class Secp256k1PublicKey extends PublicKey {
   // Secp256k1 ecdsa public keys contain a prefix indicating compression and two 32-byte coordinates.

--- a/src/transactions/transaction_builder/transaction_builder.ts
+++ b/src/transactions/transaction_builder/transaction_builder.ts
@@ -28,6 +28,7 @@ import {
 import {
   AccountAuthenticator,
   AccountAuthenticatorEd25519,
+  AccountAuthenticatorMultiKey,
   AccountAuthenticatorSingleKey,
 } from "../authenticator/account";
 import {
@@ -490,27 +491,25 @@ export function generateSignedTransaction(args: {
 
   // submit single signer transaction
 
-  // deserialize the senderAuthenticator
-  const deserializer = new Deserializer(senderAuthenticator.bcsToBytes());
-  const accountAuthenticator = AccountAuthenticator.deserialize(deserializer);
   // check what instance is accountAuthenticator
-  if (accountAuthenticator instanceof AccountAuthenticatorEd25519) {
+  if (senderAuthenticator instanceof AccountAuthenticatorEd25519) {
     const transactionAuthenticator = new TransactionAuthenticatorEd25519(
-      accountAuthenticator.public_key,
-      accountAuthenticator.signature,
+      senderAuthenticator.public_key,
+      senderAuthenticator.signature,
     );
-    // return signed transaction
     return new SignedTransaction(transactionToSubmit as RawTransaction, transactionAuthenticator).bcsToBytes();
   }
 
-  if (accountAuthenticator instanceof AccountAuthenticatorSingleKey) {
-    const transactionAuthenticator = new TransactionAuthenticatorSingleSender(accountAuthenticator);
-    // return signed transaction
+  if (
+    senderAuthenticator instanceof AccountAuthenticatorSingleKey ||
+    senderAuthenticator instanceof AccountAuthenticatorMultiKey
+  ) {
+    const transactionAuthenticator = new TransactionAuthenticatorSingleSender(senderAuthenticator);
     return new SignedTransaction(transactionToSubmit as RawTransaction, transactionAuthenticator).bcsToBytes();
   }
 
   throw new Error(
-    `Cannot generate a signed transaction, ${accountAuthenticator} is not a supported account authentication scheme`,
+    `Cannot generate a signed transaction, ${senderAuthenticator} is not a supported account authentication scheme`,
   );
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -948,6 +948,8 @@ export enum SigningScheme {
    * For SingleKey ecdsa
    */
   SingleKey = 2,
+
+  MultiKey = 3,
 }
 
 export enum SigningSchemeInput {
@@ -955,10 +957,6 @@ export enum SigningSchemeInput {
    * For Ed25519PublicKey
    */
   Ed25519 = 0,
-  /**
-   * For MultiEd25519PublicKey
-   */
-  MultiEd25519 = 1,
   /**
    * For Secp256k1Ecdsa
    */
@@ -991,6 +989,9 @@ export enum DeriveScheme {
   DeriveResourceAccountAddress = 255,
 }
 
+/**
+ * Option properties to pass for waitForTransaction() function
+ */
 export type WaitForTransactionOptions = {
   timeoutSecs?: number;
   checkSuccess?: boolean;
@@ -1003,7 +1004,7 @@ export type WaitForTransactionOptions = {
  * In this case `legacy` is always true
  */
 export type GenerateAccountWithLegacyKey = {
-  scheme?: SigningSchemeInput.Ed25519 | SigningSchemeInput.MultiEd25519;
+  scheme?: SigningSchemeInput.Ed25519;
   legacy: true;
 };
 

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -99,33 +99,33 @@ describe("Account", () => {
 
   describe("sign and verify", () => {
     it("signs a message with Secp256k1 scheme and verifies succefully", () => {
-      const { privateKey: privateKeyBytes, address, signatureHex } = secp256k1TestObject;
+      const { privateKey: privateKeyBytes, address, signatureHex, messageEncoded } = secp256k1TestObject;
       const privateKey = new Secp256k1PrivateKey(privateKeyBytes);
       const accountAddress = AccountAddress.fromHexInput(address);
-      const secpAccount = Account.fromPrivateKey({ privateKey, address: accountAddress });
-      const signature = secpAccount.sign("68656c6c6f20776f726c64");
+      const secpAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress });
+      const signature = secpAccount.sign(messageEncoded);
       expect(signature.toString()).toEqual(signatureHex);
-      expect(secpAccount.verifySignature({ message: "68656c6c6f20776f726c64", signature })).toBeTruthy();
+      expect(secpAccount.verifySignature({ message: messageEncoded, signature })).toBeTruthy();
     });
 
     it("signs a message with ed25519 scheme and verifies succefully", () => {
-      const { privateKey: privateKeyBytes, address, signatureHex } = singleSignerED25519;
+      const { privateKey: privateKeyBytes, address, signatureHex, messageEncoded } = singleSignerED25519;
       const privateKey = new Ed25519PrivateKey(privateKeyBytes);
       const accountAddress = AccountAddress.fromHexInput(address);
-      const edAccount = Account.fromPrivateKey({ privateKey, address: accountAddress });
-      const signature = edAccount.sign("68656c6c6f20776f726c64");
+      const edAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress });
+      const signature = edAccount.sign(messageEncoded);
       expect(signature.toString()).toEqual(signatureHex);
-      expect(edAccount.verifySignature({ message: "68656c6c6f20776f726c64", signature })).toBeTruthy();
+      expect(edAccount.verifySignature({ message: messageEncoded, signature })).toBeTruthy();
     });
 
     it("derives the correct account from a legacy ed25519 private key", () => {
-      const { privateKey: privateKeyBytes, address, signedMessage } = ed25519;
+      const { privateKey: privateKeyBytes, address, signedMessage, message } = ed25519;
       const privateKey = new Ed25519PrivateKey(privateKeyBytes);
       const accountAddress = AccountAddress.fromHexInput(address);
-      const legacyEdAccount = Account.fromPrivateKey({ privateKey, address: accountAddress, legacy: true });
-      const signature = legacyEdAccount.sign("0x7777");
+      const legacyEdAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress, legacy: true });
+      const signature = legacyEdAccount.sign(message);
       expect(signature.toString()).toEqual(signedMessage);
-      expect(legacyEdAccount.verifySignature({ message: "0x7777", signature })).toBeTruthy();
+      expect(legacyEdAccount.verifySignature({ message, signature })).toBeTruthy();
     });
   });
 

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -97,6 +97,38 @@ describe("Account", () => {
     });
   });
 
+  describe("sign and verify", () => {
+    it("signs a message with Secp256k1 scheme and verifies succefully", () => {
+      const { privateKey: privateKeyBytes, address, signatureHex } = secp256k1TestObject;
+      const privateKey = new Secp256k1PrivateKey(privateKeyBytes);
+      const accountAddress = AccountAddress.fromHexInput(address);
+      const secpAccount = Account.fromPrivateKey({ privateKey, address: accountAddress });
+      const signature = secpAccount.sign("68656c6c6f20776f726c64");
+      expect(signature.toString()).toEqual(signatureHex);
+      expect(secpAccount.verifySignature({ message: "68656c6c6f20776f726c64", signature })).toBeTruthy();
+    });
+
+    it("signs a message with ed25519 scheme and verifies succefully", () => {
+      const { privateKey: privateKeyBytes, address, signatureHex } = singleSignerED25519;
+      const privateKey = new Ed25519PrivateKey(privateKeyBytes);
+      const accountAddress = AccountAddress.fromHexInput(address);
+      const edAccount = Account.fromPrivateKey({ privateKey, address: accountAddress });
+      const signature = edAccount.sign("68656c6c6f20776f726c64");
+      expect(signature.toString()).toEqual(signatureHex);
+      expect(edAccount.verifySignature({ message: "68656c6c6f20776f726c64", signature })).toBeTruthy();
+    });
+
+    it("derives the correct account from a legacy ed25519 private key", () => {
+      const { privateKey: privateKeyBytes, address, signedMessage } = ed25519;
+      const privateKey = new Ed25519PrivateKey(privateKeyBytes);
+      const accountAddress = AccountAddress.fromHexInput(address);
+      const legacyEdAccount = Account.fromPrivateKey({ privateKey, address: accountAddress, legacy: true });
+      const signature = legacyEdAccount.sign("0x7777");
+      expect(signature.toString()).toEqual(signedMessage);
+      expect(legacyEdAccount.verifySignature({ message: "0x7777", signature })).toBeTruthy();
+    });
+  });
+
   it("should return the authentication key for a public key", () => {
     const { publicKey: publicKeyBytes, address } = ed25519;
     const publicKey = new Ed25519PublicKey(publicKeyBytes);

--- a/tests/unit/helper.ts
+++ b/tests/unit/helper.ts
@@ -62,6 +62,25 @@ export const singleSignerED25519 = {
   address: "0x5bdf77d5bf826c8c04273d4e7323f7bc4a85ee7ee34b37bd7458b7aed3639dd3",
   authKey: "0x5bdf77d5bf826c8c04273d4e7323f7bc4a85ee7ee34b37bd7458b7aed3639dd3",
   messageEncoded: "68656c6c6f20776f726c64", // "hello world"
+  signatureHex:
+    "0xc6f50f4e0cb1961f6f7b28be1a1d80e3ece240dfbb7bd8a8b03cc26bfd144fc176295d7c322c5bf3d9669d2ad49d8bdbfe77254b4a6393d8c49da04b40cee600",
+};
+
+export const multiKeyTestObject = {
+  publicKeys: [
+    // secp256k1
+    "0x049a6f7caddff8064a7dd5800e4fb512bf1ff91daee965409385dfa040e3e63008ab7ef566f4377c2de5aeb2948208a01bcee2050c1c8578ce5fa6e0c3c507cca2",
+    // ed25519
+    "0x7a73df1afd028e75e7f9e23b2187a37d092a6ccebcb3edff6e02f93185cbde86",
+    // ed25519
+    "0x17fe89a825969c1c0e5f5e80b95f563a6cb6240f88c4246c19cb39c9535a1486",
+  ],
+  signaturesReuired: 2,
+  address: "0x738a998ac1f69db4a91fc5a0152f792c98ad87354c65a2a842a118d7a17109b1",
+  authKey: "0x738a998ac1f69db4a91fc5a0152f792c98ad87354c65a2a842a118d7a17109b1",
+  bitmap: [160, 0, 0, 0],
+  stringBytes:
+    "0x030141049a6f7caddff8064a7dd5800e4fb512bf1ff91daee965409385dfa040e3e63008ab7ef566f4377c2de5aeb2948208a01bcee2050c1c8578ce5fa6e0c3c507cca200207a73df1afd028e75e7f9e23b2187a37d092a6ccebcb3edff6e02f93185cbde86002017fe89a825969c1c0e5f5e80b95f563a6cb6240f88c4246c19cb39c9535a148602",
 };
 
 export const longTestTimeout = 120 * 1000;

--- a/tests/unit/multiKey.test.ts
+++ b/tests/unit/multiKey.test.ts
@@ -1,0 +1,92 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Deserializer, Ed25519PublicKey, Secp256k1PublicKey, MultiKey } from "../../src";
+import { multiKeyTestObject } from "./helper";
+
+describe("MultiKey", () => {
+  it("should convert to Uint8Array correctly", async () => {
+    const multiKey = new MultiKey({
+      publicKeys: [
+        new Secp256k1PublicKey(multiKeyTestObject.publicKeys[0]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[1]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[2]),
+      ],
+      signaturesRequired: 2,
+    });
+
+    const expected = new Uint8Array([
+      3, 1, 65, 4, 154, 111, 124, 173, 223, 248, 6, 74, 125, 213, 128, 14, 79, 181, 18, 191, 31, 249, 29, 174, 233, 101,
+      64, 147, 133, 223, 160, 64, 227, 230, 48, 8, 171, 126, 245, 102, 244, 55, 124, 45, 229, 174, 178, 148, 130, 8,
+      160, 27, 206, 226, 5, 12, 28, 133, 120, 206, 95, 166, 224, 195, 197, 7, 204, 162, 0, 32, 122, 115, 223, 26, 253,
+      2, 142, 117, 231, 249, 226, 59, 33, 135, 163, 125, 9, 42, 108, 206, 188, 179, 237, 255, 110, 2, 249, 49, 133, 203,
+      222, 134, 0, 32, 23, 254, 137, 168, 37, 150, 156, 28, 14, 95, 94, 128, 185, 95, 86, 58, 108, 182, 36, 15, 136,
+      196, 36, 108, 25, 203, 57, 201, 83, 90, 20, 134, 2,
+    ]);
+    expect(multiKey.toUint8Array()).toEqual(expected);
+  });
+
+  it("should serializes to bytes correctly", async () => {
+    const multiKey = new MultiKey({
+      publicKeys: [
+        new Secp256k1PublicKey(multiKeyTestObject.publicKeys[0]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[1]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[2]),
+      ],
+      signaturesRequired: 2,
+    });
+
+    expect(multiKey.toString()).toEqual(multiKeyTestObject.stringBytes);
+  });
+
+  it("should deserializes from bytes correctly", async () => {
+    const multiKey = new MultiKey({
+      publicKeys: [
+        new Secp256k1PublicKey(multiKeyTestObject.publicKeys[0]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[1]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[2]),
+      ],
+      signaturesRequired: 2,
+    });
+
+    const deserialize = new Deserializer(multiKey.toUint8Array());
+    expect(multiKey).toEqual(MultiKey.deserialize(deserialize));
+  });
+
+  it("should throw when signatures in bitmap greater than public keys amount", () => {
+    const multiKey = new MultiKey({
+      publicKeys: [
+        new Secp256k1PublicKey(multiKeyTestObject.publicKeys[0]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[1]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[2]),
+      ],
+      signaturesRequired: 2,
+    });
+    expect(() => multiKey.createBitmap({ bits: [0, 1, 2, 3] })).toThrow();
+  });
+
+  it("should throw when there are duplicates in bitmap", () => {
+    const multiKey = new MultiKey({
+      publicKeys: [
+        new Secp256k1PublicKey(multiKeyTestObject.publicKeys[0]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[1]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[2]),
+      ],
+      signaturesRequired: 2,
+    });
+    expect(() => multiKey.createBitmap({ bits: [0, 0] })).toThrow();
+  });
+
+  it("should create bitmap correctly", () => {
+    const multiKey = new MultiKey({
+      publicKeys: [
+        new Secp256k1PublicKey(multiKeyTestObject.publicKeys[0]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[1]),
+        new Ed25519PublicKey(multiKeyTestObject.publicKeys[2]),
+      ],
+      signaturesRequired: 2,
+    });
+    const bitmap = multiKey.createBitmap({ bits: [0, 2] });
+    expect(bitmap).toEqual(new Uint8Array(multiKeyTestObject.bitmap));
+  });
+});

--- a/tests/unit/multiKey.test.ts
+++ b/tests/unit/multiKey.test.ts
@@ -5,6 +5,34 @@ import { Deserializer, Ed25519PublicKey, Secp256k1PublicKey, MultiKey } from "..
 import { multiKeyTestObject } from "./helper";
 
 describe("MultiKey", () => {
+  it("should throw when number of required signatures is less then 1", () => {
+    expect(
+      () =>
+        new MultiKey({
+          publicKeys: [
+            new Secp256k1PublicKey(multiKeyTestObject.publicKeys[0]),
+            new Ed25519PublicKey(multiKeyTestObject.publicKeys[1]),
+            new Ed25519PublicKey(multiKeyTestObject.publicKeys[2]),
+          ],
+          signaturesRequired: 0,
+        }),
+    ).toThrow();
+  });
+
+  it("should throw when number of public keys is less then the number of signatures required", () => {
+    expect(
+      () =>
+        new MultiKey({
+          publicKeys: [
+            new Secp256k1PublicKey(multiKeyTestObject.publicKeys[0]),
+            new Ed25519PublicKey(multiKeyTestObject.publicKeys[1]),
+            new Ed25519PublicKey(multiKeyTestObject.publicKeys[2]),
+          ],
+          signaturesRequired: 4,
+        }),
+    ).toThrow();
+  });
+
   it("should convert to Uint8Array correctly", async () => {
     const multiKey = new MultiKey({
       publicKeys: [


### PR DESCRIPTION
### Description
- Implement `MultiKey` that conforms to [AIP-55](https://github.com/aptos-foundation/AIPs/pull/263).
- Add multiSig example that uses MultiKey class
- Fix verify signature logic on public key module
- Simplify code to use `senderAuthentication` when generating signed transaction as part of the transaction builder flow
- Add clarity and explanations around `Ed25519PublicKey`, `Secp256k1PublicKey` and `AnyPublicKey` classes

Follow up:
- Implement `verifySignature` in `MultiKey` class


### Test Plan
pnpm test

### Related Links
<!-- Please link to any relevant issues or pull requests! -->