### PR TITLE
[Documentation] Update documentation for authentication key/account address derivation

### DIFF
--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -185,10 +185,10 @@ export class Account {
    * Instantiates an account given a private key and a specified account address.
    * This is primarily used to instantiate an `Account` that has had its authentication key rotated.
    *
-   * @param privateKey PrivateKey - private key of the account
-   * @param address The account address
-   * @param args.legacy optional. If set to true, the keypair authentication keys will be derived with a Legacy scheme.
-   * Defaults to deriving an authentication key with a Unified scheme
+   * @param args.privateKey PrivateKey - the underlying private key for the account
+   * @param args.address A specified account address, in case the authentication key has been rotated
+   * @param args.legacy An optional flag to indicate that the authentication key derivation should
+   * use the legacy Ed25519 scheme. Defaults to false
    *
    * @returns Account
    */

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -186,7 +186,7 @@ export class Account {
    * This is primarily used to instantiate an `Account` that has had its authentication key rotated.
    *
    * @param args.privateKey PrivateKey - the underlying private key for the account
-   * @param args.address A specified account address, in case the authentication key has been rotated
+   * @param args.address AccountAddress - The initial account address before the authentication key was rotated
    * @param args.legacy An optional flag to indicate that the authentication key derivation should
    * use the legacy Ed25519 scheme. Defaults to false
    *

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -186,7 +186,7 @@ export class Account {
    * This is primarily used to instantiate an `Account` that has had its authentication key rotated.
    *
    * @param args.privateKey PrivateKey - the underlying private key for the account
-   * @param args.address AccountAddress - The initial account address before the authentication key was rotated
+   * @param args.address AccountAddress - The account address the `Account` will sign for
    * @param args.legacy An optional flag to indicate that the authentication key derivation should
    * use the legacy Ed25519 scheme. Defaults to false
    *

--- a/src/core/authenticationKey.ts
+++ b/src/core/authenticationKey.ts
@@ -68,13 +68,9 @@ export class AuthenticationKey extends Serializable {
   /**
    * Derives an AuthenticationKey from the public key seed bytes and an explicit derivation scheme.
    *
-   * This facilitates explicitly targeting a specific derivation scheme for an authentication key
-   * to use for an account.
+   * This facilitates targeting a specific scheme for deriving an authentication key from a public key.
    *
-   * This is useful for deriving an account address from an account whose address
-   * was derived using a legacy derivation scheme.
-   *
-   * @param args
+   * @param args - the public key and scheme to use for the derivation
    */
   public static fromPublicKeyAndScheme(args: { publicKey: PublicKey; scheme: AuthenticationKeyScheme }) {
     const { publicKey, scheme } = args;

--- a/src/core/authenticationKey.ts
+++ b/src/core/authenticationKey.ts
@@ -18,13 +18,13 @@ import { Deserializer } from "../bcs/deserializer";
  * their private key(s) associated with the account without changing the address that hosts their account.
  * @see {@link https://aptos.dev/concepts/accounts | Account Basics}
  *
- * Note: AuthenticationKey only supports Ed25519 and MultiEd25519 public keys for now.
- *
  * Account addresses can be derived from AuthenticationKey
  */
 export class AuthenticationKey extends Serializable {
   /**
    * An authentication key is always a SHA3-256 hash of data, and is always 32 bytes.
+   *
+   * The data to hash depends on the underlying public key type and the derivation scheme.
    */
   static readonly LENGTH: number = 32;
 
@@ -66,9 +66,14 @@ export class AuthenticationKey extends Serializable {
   }
 
   /**
-   * Creates an AuthenticationKey from seed bytes and a scheme
+   * Derives an AuthenticationKey from the public key seed bytes and an explicit derivation scheme.
    *
-   * This allows for the creation of AuthenticationKeys that are not derived from Public Keys directly
+   * This facilitates explicitly targeting a specific derivation scheme for an authentication key
+   * to use for an account.
+   *
+   * This is useful for deriving an account address from an account whose address
+   * was derived using a legacy derivation scheme.
+   *
    * @param args
    */
   public static fromPublicKeyAndScheme(args: { publicKey: PublicKey; scheme: AuthenticationKeyScheme }) {
@@ -102,7 +107,8 @@ export class AuthenticationKey extends Serializable {
   }
 
   /**
-   * Converts a PublicKey(s) to AuthenticationKey
+   * Converts a PublicKey(s) to an AuthenticationKey, using the derivation scheme inferred from the
+   * instance of the PublicKey type passed in.
    *
    * @param args.publicKey
    * @returns AuthenticationKey
@@ -129,8 +135,8 @@ export class AuthenticationKey extends Serializable {
   }
 
   /**
-   * Derives an account address from AuthenticationKey. Since current AccountAddress is 32 bytes,
-   * AuthenticationKey bytes are directly translated to AccountAddress.
+   * Derives an account address from an AuthenticationKey. Since an AccountAddress is also 32 bytes,
+   * the AuthenticationKey bytes are directly translated to an AccountAddress.
    *
    * @returns AccountAddress
    */


### PR DESCRIPTION
### Description

Trying to make it clearer (and more explicit) what a derivation/signature scheme is used for and how the authentication keys/account addresses are derived, and what the schemes mean.