### PR TITLE
[TypeTag] Adding explicit return types for TypeTag types, fix vectors `toString()` function, add aptosCoinStructTag

### DIFF
--- a/src/transactions/typeTag/index.ts
+++ b/src/transactions/typeTag/index.ts
@@ -9,6 +9,7 @@ import { Serializable, Serializer } from "../../bcs/serializer";
 import { AccountAddress } from "../../core";
 import { Identifier } from "../instances/identifier";
 import { TypeTagVariants } from "../../types";
+import { APTOS_COIN } from "../../utils/const";
 
 export abstract class TypeTag extends Serializable {
   abstract serialize(serializer: Serializer): void;
@@ -224,7 +225,7 @@ export class TypeTagSigner extends TypeTag {
 }
 
 export class TypeTagReference extends TypeTag {
-  toString(): string {
+  toString(): `&${string}` {
     return `&${this.value.toString()}`;
   }
 
@@ -248,7 +249,7 @@ export class TypeTagReference extends TypeTag {
  * used as a type directly.
  */
 export class TypeTagGeneric extends TypeTag {
-  toString(): string {
+  toString(): `T${number}` {
     return `T${this.value}`;
   }
 
@@ -268,8 +269,8 @@ export class TypeTagGeneric extends TypeTag {
 }
 
 export class TypeTagVector extends TypeTag {
-  toString(): string {
-    return `vector${this.value.toString()}`;
+  toString(): `vector<${string}>` {
+    return `vector<${this.value.toString()}>`;
   }
 
   constructor(public readonly value: TypeTag) {
@@ -288,7 +289,7 @@ export class TypeTagVector extends TypeTag {
 }
 
 export class TypeTagStruct extends TypeTag {
-  toString(): string {
+  toString(): `0x${string}::${string}::${string}${string}` {
     // Collect type args and add it if there are any
     let typePredicate = "";
     if (this.value.type_args.length > 0) {
@@ -368,8 +369,13 @@ export class StructTag extends Serializable {
   }
 }
 
-export const stringStructTag = () =>
-  new StructTag(AccountAddress.ONE, new Identifier("string"), new Identifier("String"), []);
+export function aptosCoinStructTag(): StructTag {
+  return new StructTag(AccountAddress.ONE, new Identifier("aptos_coin"), new Identifier("AptosCoin"), []);
+}
+
+export function stringStructTag(): StructTag {
+  return new StructTag(AccountAddress.ONE, new Identifier("string"), new Identifier("String"), []);
+}
 
 export function optionStructTag(typeArg: TypeTag): StructTag {
   return new StructTag(AccountAddress.ONE, new Identifier("option"), new Identifier("Option"), [typeArg]);

--- a/src/transactions/typeTag/index.ts
+++ b/src/transactions/typeTag/index.ts
@@ -289,7 +289,7 @@ export class TypeTagVector extends TypeTag {
 }
 
 export class TypeTagStruct extends TypeTag {
-  toString(): `0x${string}::${string}::${string}${string}` {
+  toString(): `0x${string}::${string}::${string}` {
     // Collect type args and add it if there are any
     let typePredicate = "";
     if (this.value.type_args.length > 0) {

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -165,7 +165,7 @@ describe("TypeTagParser", () => {
   });
 
   test("aptos coin", () => {
-    const aptosCoin = new TypeTagStruct(aptosCoinStructTag())
+    const aptosCoin = new TypeTagStruct(aptosCoinStructTag());
     expect(parseTypeTag("0x1::aptos_coin::AptosCoin")).toEqual(aptosCoin);
     expect(parseTypeTag(APTOS_COIN)).toEqual(aptosCoin);
   });

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -24,8 +24,10 @@ import {
   TypeTagParserError,
   TypeTagParserErrorType,
   TypeTagReference,
+  aptosCoinStructTag,
 } from "../../src";
 import { Identifier } from "../../src/transactions/instances";
+import { APTOS_COIN } from "../../src/utils/const";
 
 const MODULE_NAME = new Identifier("tag");
 const STRUCT_NAME = new Identifier("Tag");
@@ -160,6 +162,12 @@ describe("TypeTagParser", () => {
     expect(parseTypeTag("vector<vector<0x1::string::String>>")).toEqual(
       new TypeTagVector(new TypeTagVector(new TypeTagStruct(stringStructTag()))),
     );
+  });
+
+  test("aptos coin", () => {
+    const aptosCoin = new TypeTagStruct(aptosCoinStructTag())
+    expect(parseTypeTag("0x1::aptos_coin::AptosCoin")).toEqual(aptosCoin);
+    expect(parseTypeTag(APTOS_COIN)).toEqual(aptosCoin);
   });
 
   test("string", () => {


### PR DESCRIPTION
### Description
1. Adding more explicit return types to facilitate using pattern matching types
2. The `TypeTagVector.toString()` function was returning `vectoru64` instead of `vector<u64>`
3. added `aptosCoinStructTag()` because it's so commonly used
4. changed `stringStructTag()` to be `async function` instead of `const ... async()` to match the others

### Test Plan
```typescript
pnpm jest
```
