### PR TITLE
[remoteAbi] Add transaction argument tests for simple args

### DIFF
--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -150,7 +150,7 @@ function parseArg(
   // TODO: support uint8array?
   if (param.isAddress()) {
     if (isString(arg)) {
-      return AccountAddress.fromString(arg);
+      return AccountAddress.fromStringRelaxed(arg);
     }
     throwTypeMismatch("string", position);
   }

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -10,6 +10,7 @@ import {
   EntryFunctionArgumentTypes,
   HexInput,
   InputGenerateTransactionData,
+  SimpleEntryFunctionArgumentTypes,
 } from "../../../src";
 import { FUND_AMOUNT } from "../../unit/helper";
 
@@ -52,7 +53,7 @@ export async function rawTransactionHelper(
   senderAccount: Account,
   functionName: string,
   typeArgs: TypeTag[],
-  args: Array<EntryFunctionArgumentTypes>,
+  args: Array<EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes>,
 ): Promise<UserTransactionResponse> {
   const rawTransaction = await aptos.generateTransaction({
     sender: senderAccount.accountAddress.toString(),
@@ -82,7 +83,7 @@ export const rawTransactionMultiAgentHelper = async (
   senderAccount: Account,
   functionName: string,
   typeArgs: Array<TypeTag>,
-  args: Array<EntryFunctionArgumentTypes>,
+  args: Array<EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes>,
   secondarySignerAccounts: Array<Account>,
   feePayerAccount?: Account,
 ): Promise<UserTransactionResponse> => {

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -253,7 +253,13 @@ describe("TypeTagParser", () => {
   });
 
   /* These need to be supported for ABI parsing */
-  test.skip("struct with generic", () => {
-    expect(parseTypeTag("0x1::tag::Tag<T1>")).toEqual(structTagType());
+  test("struct with generic", () => {
+    expect(parseTypeTag("0x1::tag::Tag<T0>", { allowGenerics: true })).toEqual(structTagType([new TypeTagGeneric(0)]));
+    expect(parseTypeTag("0x1::tag::Tag<T0, T1>", { allowGenerics: true })).toEqual(
+      structTagType([new TypeTagGeneric(0), new TypeTagGeneric(1)]),
+    );
+    expect(parseTypeTag("0x1::tag::Tag<0x1::tag::Tag<T0, T1>, T2>", { allowGenerics: true })).toEqual(
+      structTagType([structTagType([new TypeTagGeneric(0), new TypeTagGeneric(1)]), new TypeTagGeneric(2)]),
+    );
   });
 });


### PR DESCRIPTION
### Description
This mixes simple and non-simple args with the already existing tests to ensure that transactions are handled properly.

This also makes the string parsing for addresses less strict


### Test Plan
This adds tests specifically to test remote ABI inputs to ensure they work properly.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->