### PR TITLE
[account address] Simplify account address parsing

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosConfig } from "./aptosConfig";
-import { AccountAddress, PrivateKey, Account as AccountModule } from "../core";
+import { AccountAddress, PrivateKey, Account as AccountModule, AccountAddressInput } from "../core";
 import {
   AccountData,
   GetAccountCoinsDataResponse,
@@ -10,7 +10,6 @@ import {
   GetAccountOwnedObjectsResponse,
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
-  HexInput,
   LedgerVersion,
   MoveModuleBytecode,
   MoveResource,
@@ -64,7 +63,7 @@ export class Account {
    * }
    * ```
    */
-  async getAccountInfo(args: { accountAddress: HexInput }): Promise<AccountData> {
+  async getAccountInfo(args: { accountAddress: AccountAddressInput }): Promise<AccountData> {
     return getInfo({ aptosConfig: this.config, ...args });
   }
 
@@ -83,7 +82,7 @@ export class Account {
    */
 
   async getAccountModules(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     options?: PaginationArgs & LedgerVersion;
   }): Promise<MoveModuleBytecode[]> {
     return getModules({ aptosConfig: this.config, ...args });
@@ -107,7 +106,7 @@ export class Account {
    * ```
    */
   async getAccountModule(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     moduleName: string;
     options?: LedgerVersion;
   }): Promise<MoveModuleBytecode> {
@@ -127,7 +126,7 @@ export class Account {
    * @returns The account transactions
    */
   async getAccountTransactions(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     options?: PaginationArgs;
   }): Promise<TransactionResponse[]> {
     return getTransactions({
@@ -149,7 +148,7 @@ export class Account {
    * @returns Account resources
    */
   async getAccountResources(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     options?: PaginationArgs & LedgerVersion;
   }): Promise<MoveResource[]> {
     return getResources({ aptosConfig: this.config, ...args });
@@ -174,7 +173,7 @@ export class Account {
    * ```
    */
   async getAccountResource<T extends {} = any>(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     resourceType: MoveStructType;
     options?: LedgerVersion;
   }): Promise<T> {
@@ -191,7 +190,7 @@ export class Account {
    * @returns Promise<AccountAddress> The accountAddress associated with the authentication key
    */
   async lookupOriginalAccountAddress(args: {
-    authenticationKey: HexInput;
+    authenticationKey: AccountAddressInput;
     options?: LedgerVersion;
   }): Promise<AccountAddress> {
     return lookupOriginalAccountAddress({ aptosConfig: this.config, ...args });
@@ -203,7 +202,7 @@ export class Account {
    * @param args.accountAddress The account address
    * @returns Current count of tokens owned by the account
    */
-  async getAccountTokensCount(args: { accountAddress: HexInput }): Promise<number> {
+  async getAccountTokensCount(args: { accountAddress: AccountAddressInput }): Promise<number> {
     return getAccountTokensCount({
       aptosConfig: this.config,
       ...args,
@@ -224,7 +223,7 @@ export class Account {
    * @returns Tokens array with the token data
    */
   async getAccountOwnedTokens(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     options?: {
       tokenStandard?: TokenStandard;
       pagination?: PaginationArgs;
@@ -252,8 +251,8 @@ export class Account {
    * @returns Tokens array with the token data
    */
   async getAccountOwnedTokensFromCollectionAddress(args: {
-    accountAddress: HexInput;
-    collectionAddress: HexInput;
+    accountAddress: AccountAddressInput;
+    collectionAddress: AccountAddressInput;
     options?: {
       tokenStandard?: TokenStandard;
       pagination?: PaginationArgs;
@@ -280,7 +279,7 @@ export class Account {
    * @returns Collections array with the collections data
    */
   async getAccountCollectionsWithOwnedTokens(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     options?: {
       tokenStandard?: TokenStandard;
       pagination?: PaginationArgs;
@@ -299,7 +298,7 @@ export class Account {
    * @param args.accountAddress The account address we want to get the total count for
    * @returns Current count of transactions made by an account
    */
-  async getAccountTransactionsCount(args: { accountAddress: HexInput }): Promise<number> {
+  async getAccountTransactionsCount(args: { accountAddress: AccountAddressInput }): Promise<number> {
     return getAccountTransactionsCount({
       aptosConfig: this.config,
       ...args,
@@ -316,7 +315,7 @@ export class Account {
    * @returns Array with the coins data
    */
   async getAccountCoinsData(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     options?: {
       pagination?: PaginationArgs;
       orderBy?: OrderBy<GetAccountCoinsDataResponse[0]>;
@@ -334,7 +333,7 @@ export class Account {
    * @param args.accountAddress The account address we want to get the total count for
    * @returns Current count of the aggregated count of all account's coins
    */
-  async getAccountCoinsCount(args: { accountAddress: HexInput }): Promise<number> {
+  async getAccountCoinsCount(args: { accountAddress: AccountAddressInput }): Promise<number> {
     return getAccountCoinsCount({ aptosConfig: this.config, ...args });
   }
 
@@ -348,7 +347,7 @@ export class Account {
    * @returns Objects array with the object data
    */
   async getAccountOwnedObjects(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     options?: {
       pagination?: PaginationArgs;
       orderBy?: OrderBy<GetAccountOwnedObjectsResponse[0]>;

--- a/src/api/coin.ts
+++ b/src/api/coin.ts
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosConfig } from "./aptosConfig";
-import { Account } from "../core";
+import { Account, AccountAddressInput } from "../core";
 import { transferCoinTransaction } from "../internal/coin";
 import { InputSingleSignerTransaction, InputGenerateTransactionOptions } from "../transactions/types";
-import { AnyNumber, HexInput, MoveStructType } from "../types";
+import { AnyNumber, MoveStructType } from "../types";
 
 /**
  * A class to handle all `Coin` operations
@@ -29,7 +29,7 @@ export class Coin {
    */
   async transferCoinTransaction(args: {
     sender: Account;
-    recipient: HexInput;
+    recipient: AccountAddressInput;
     amount: AnyNumber;
     coinType?: MoveStructType;
     options?: InputGenerateTransactionOptions;

--- a/src/api/digitalAsset.ts
+++ b/src/api/digitalAsset.ts
@@ -7,13 +7,12 @@ import {
   GetOwnedTokensResponse,
   GetTokenActivityResponse,
   GetTokenDataResponse,
-  HexInput,
   OrderBy,
   PaginationArgs,
   TokenStandard,
 } from "../types";
 import { AptosConfig } from "./aptosConfig";
-import { Account } from "../core";
+import { Account, AccountAddressInput } from "../core";
 import { InputGenerateTransactionOptions, InputSingleSignerTransaction } from "../transactions/types";
 import {
   CreateCollectionOptions,
@@ -86,7 +85,7 @@ export class DigitalAsset {
    * @returns GetCollectionDataResponse response type
    */
   async getCollectionData(args: {
-    creatorAddress: HexInput;
+    creatorAddress: AccountAddressInput;
     collectionName: string;
     options?: {
       tokenStandard?: TokenStandard;
@@ -107,7 +106,7 @@ export class DigitalAsset {
    * @returns the collection id
    */
   async getCollectionId(args: {
-    creatorAddress: HexInput;
+    creatorAddress: AccountAddressInput;
     collectionName: string;
     options?: {
       tokenStandard?: TokenStandard;
@@ -144,7 +143,7 @@ export class DigitalAsset {
    * @param args.tokenAddress The address of the token
    * @returns GetTokenDataResponse containing relevant data to the token.
    */
-  async getTokenData(args: { tokenAddress: HexInput }): Promise<GetTokenDataResponse> {
+  async getTokenData(args: { tokenAddress: AccountAddressInput }): Promise<GetTokenDataResponse> {
     return getTokenData({ aptosConfig: this.config, ...args });
   }
 
@@ -154,7 +153,9 @@ export class DigitalAsset {
    * @param args.tokenAddress The address of the token
    * @returns GetCurrentTokenOwnershipResponse containing relevant ownership data of the token.
    */
-  async getCurrentTokenOwnership(args: { tokenAddress: HexInput }): Promise<GetCurrentTokenOwnershipResponse> {
+  async getCurrentTokenOwnership(args: {
+    tokenAddress: AccountAddressInput;
+  }): Promise<GetCurrentTokenOwnershipResponse> {
     return getCurrentTokenOwnership({ aptosConfig: this.config, ...args });
   }
 
@@ -165,7 +166,7 @@ export class DigitalAsset {
    * @returns GetOwnedTokensResponse containing ownership data of the tokens belonging to the ownerAddresss.
    */
   async getOwnedTokens(args: {
-    ownerAddress: HexInput;
+    ownerAddress: AccountAddressInput;
     options?: {
       pagination?: PaginationArgs;
       orderBy?: OrderBy<GetOwnedTokensResponse[0]>;
@@ -181,7 +182,7 @@ export class DigitalAsset {
    * @returns GetTokenActivityResponse containing relevant activity data to the token.
    */
   async getTokenActivity(args: {
-    tokenAddress: HexInput;
+    tokenAddress: AccountAddressInput;
     options?: {
       pagination?: PaginationArgs;
       orderBy?: OrderBy<GetTokenActivityResponse[0]>;

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -3,8 +3,9 @@
 
 import { AptosConfig } from "./aptosConfig";
 import { getAccountEventsByCreationNumber, getAccountEventsByEventType, getEvents } from "../internal/event";
-import { AnyNumber, GetEventsResponse, HexInput, MoveStructType, OrderBy, PaginationArgs } from "../types";
+import { AnyNumber, GetEventsResponse, MoveStructType, OrderBy, PaginationArgs } from "../types";
 import { EventsBoolExp } from "../types/generated/types";
+import { AccountAddressInput } from "../core";
 
 /**
  * A class to query all `Event` Aptos related queries
@@ -25,7 +26,7 @@ export class Event {
    * @returns Promise<GetEventsResponse>
    */
   async getAccountEventsByCreationNumber(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     creationNumber: AnyNumber;
   }): Promise<GetEventsResponse> {
     return getAccountEventsByCreationNumber({ aptosConfig: this.config, ...args });
@@ -40,7 +41,7 @@ export class Event {
    * @returns Promise<GetEventsResponse>
    */
   async getAccountEventsByEventType(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     eventType: MoveStructType;
     options?: {
       pagination?: PaginationArgs;

--- a/src/api/faucet.ts
+++ b/src/api/faucet.ts
@@ -3,7 +3,8 @@
 
 import { AptosConfig } from "./aptosConfig";
 import { fundAccount } from "../internal/faucet";
-import { HexInput, WaitForTransactionOptions } from "../types";
+import { WaitForTransactionOptions } from "../types";
+import { AccountAddressInput } from "../core";
 
 /**
  * A class to query all `Faucet` related queries on Aptos.
@@ -25,7 +26,7 @@ export class Faucet {
    * @returns Transaction hash of the transaction that funded the account
    */
   async fundAccount(args: {
-    accountAddress: HexInput;
+    accountAddress: AccountAddressInput;
     amount: number;
     options?: WaitForTransactionOptions;
   }): Promise<string> {

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -114,8 +114,8 @@ export class General {
    *
    * @returns Table item value rendered in JSON
    */
-  async getTableItem(args: { handle: string; data: TableItemRequest; options?: LedgerVersion }): Promise<any> {
-    return getTableItem({ aptosConfig: this.config, ...args });
+  async getTableItem<T>(args: { handle: string; data: TableItemRequest; options?: LedgerVersion }): Promise<T> {
+    return getTableItem<T>({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/api/staking.ts
+++ b/src/api/staking.ts
@@ -7,7 +7,8 @@ import {
   getNumberOfDelegators,
   getNumberOfDelegatorsForAllPools,
 } from "../internal/staking";
-import { GetDelegatedStakingActivitiesResponse, GetNumberOfDelegatorsResponse, HexInput, OrderBy } from "../types";
+import { GetDelegatedStakingActivitiesResponse, GetNumberOfDelegatorsResponse, OrderBy } from "../types";
+import { AccountAddressInput } from "../core";
 
 /**
  * A class to query all `Staking` related queries on Aptos.
@@ -25,7 +26,7 @@ export class Staking {
    * @param args.poolAddress Pool address
    * @returns The number of delegators for the given pool
    */
-  async getNumberOfDelegators(args: { poolAddress: HexInput }): Promise<number> {
+  async getNumberOfDelegators(args: { poolAddress: AccountAddressInput }): Promise<number> {
     return getNumberOfDelegators({ aptosConfig: this.config, ...args });
   }
 
@@ -50,8 +51,8 @@ export class Staking {
    * @returns GetDelegatedStakingActivitiesResponse response type
    */
   async getDelegatedStakingActivities(args: {
-    delegatorAddress: HexInput;
-    poolAddress: HexInput;
+    delegatorAddress: AccountAddressInput;
+    poolAddress: AccountAddressInput;
   }): Promise<GetDelegatedStakingActivitiesResponse> {
     return getDelegatedStakingActivities({ aptosConfig: this.config, ...args });
   }

--- a/src/api/transactionSubmission.ts
+++ b/src/api/transactionSubmission.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosConfig } from "./aptosConfig";
-import { Account } from "../core";
+import { Account, AccountAddressInput } from "../core";
 import { AccountAuthenticator } from "../transactions/authenticator/account";
 import {
   AnyRawTransaction,
@@ -47,7 +47,7 @@ export class TransactionSubmission {
   /**
    * Generates any transaction by passing in the required arguments
    *
-   * @param args.sender The transaction sender's account address as a HexInput
+   * @param args.sender The transaction sender's account address as a AccountAddressInput
    * @param args.data EntryFunctionData | ScriptData | MultiSigData
    * @param args.feePayerAddress optional. For a fee payer (aka sponsored) transaction
    * @param args.secondarySignerAddresses optional. For a multi-agent or fee payer (aka sponsored) transactions
@@ -182,7 +182,7 @@ export class TransactionSubmission {
    * @returns A SingleSignerTransaction that can be simulated or submitted to chain
    */
   async publishPackageTransaction(args: {
-    account: HexInput;
+    account: AccountAddressInput;
     metadataBytes: HexInput;
     moduleBytecode: Array<HexInput>;
     options?: InputGenerateTransactionOptions;

--- a/src/bcs/deserializer.ts
+++ b/src/bcs/deserializer.ts
@@ -222,10 +222,10 @@ export class Deserializer {
    * @example
    * // serialize a vector of addresses
    * const addresses = new Array<AccountAddress>(
-   *   AccountAddress.fromHexInputRelaxed("0x1"),
-   *   AccountAddress.fromHexInputRelaxed("0x2"),
-   *   AccountAddress.fromHexInputRelaxed("0xa"),
-   *   AccountAddress.fromHexInputRelaxed("0xb"),
+   *   AccountAddress.fromRelaxed("0x1"),
+   *   AccountAddress.fromRelaxed("0x2"),
+   *   AccountAddress.fromRelaxed("0xa"),
+   *   AccountAddress.fromRelaxed("0xb"),
    * );
    * const serializer = new Serializer();
    * serializer.serializeVector(addresses);

--- a/src/bcs/serializer.ts
+++ b/src/bcs/serializer.ts
@@ -298,10 +298,10 @@ export class Serializer {
    * @param values The array of BCS Serializable values
    * @example
    * const addresses = new Array<AccountAddress>(
-   *   AccountAddress.fromHexInputRelaxed("0x1"),
-   *   AccountAddress.fromHexInputRelaxed("0x2"),
-   *   AccountAddress.fromHexInputRelaxed("0xa"),
-   *   AccountAddress.fromHexInputRelaxed("0xb"),
+   *   AccountAddress.fromRelaxed("0x1"),
+   *   AccountAddress.fromRelaxed("0x2"),
+   *   AccountAddress.fromRelaxed("0xa"),
+   *   AccountAddress.fromRelaxed("0xb"),
    * );
    * const serializer = new Serializer();
    * serializer.serializeVector(addresses);

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -138,11 +138,11 @@ export class Account {
       publicKey = new AnyPublicKey(privateKey.publicKey());
     }
 
-    const address = new AccountAddress({
-      data: Account.authKey({
+    const address = new AccountAddress(
+      Account.authKey({
         publicKey,
       }).toUint8Array(),
-    });
+    );
     return new Account({ privateKey, address, legacy: args?.legacy });
   }
 
@@ -180,7 +180,7 @@ export class Account {
     const privateKey = new Ed25519PrivateKey(key);
     const publicKey = privateKey.publicKey();
     const authKey = Account.authKey({ publicKey });
-    const address = new AccountAddress({ data: authKey.toUint8Array() });
+    const address = new AccountAddress(authKey.toUint8Array());
     return new Account({ privateKey, address, legacy: true });
   }
 

--- a/src/core/accountAddress.ts
+++ b/src/core/accountAddress.ts
@@ -21,6 +21,8 @@ export enum AddressInvalidReason {
   INVALID_PADDING_ZEROES = "INVALID_PADDING_ZEROES",
 }
 
+export type AccountAddressInput = HexInput | AccountAddress;
+
 /**
  * NOTE: Only use this class for account addresses. For other hex data, e.g. transaction
  * hashes, use the Hex class.
@@ -335,33 +337,35 @@ export class AccountAddress extends Serializable implements TransactionArgument 
   }
 
   /**
-   * Convenience method for creating an AccountAddress from HexInput. For
-   * more information on how this works, see the constructor and fromString.
+   * Convenience method for creating an AccountAddress from all known inputs.
    *
-   * @param input A hex string or Uint8Array representing an account address.
-   *
-   * @returns An instance of AccountAddress.
+   * This handles, Uint8array, string, and AccountAddress itself
+   * @param input
    */
-  static fromHexInput(input: HexInput): AccountAddress {
+  static fromRelaxed(input: AccountAddressInput): AccountAddress {
+    if (input instanceof AccountAddress) {
+      return input;
+    }
+    if (input instanceof Uint8Array) {
+      return new AccountAddress({ data: input });
+    }
+    return AccountAddress.fromStringRelaxed(input);
+  }
+
+  /**
+   * Convenience method for creating an AccountAddress from all known inputs.
+   *
+   * This handles, Uint8array, string, and AccountAddress itself
+   * @param input
+   */
+  static from(input: AccountAddressInput): AccountAddress {
+    if (input instanceof AccountAddress) {
+      return input;
+    }
     if (input instanceof Uint8Array) {
       return new AccountAddress({ data: input });
     }
     return AccountAddress.fromString(input);
-  }
-
-  /**
-   * Convenience method for creating an AccountAddress from HexInput. For
-   * more information on how this works, see the constructor and fromStringRelaxed.
-   *
-   * @param hexInput A hex string or Uint8Array representing an account address.
-   *
-   * @returns An instance of AccountAddress.
-   */
-  static fromHexInputRelaxed(hexInput: HexInput): AccountAddress {
-    if (hexInput instanceof Uint8Array) {
-      return new AccountAddress({ data: hexInput });
-    }
-    return AccountAddress.fromStringRelaxed(hexInput);
   }
 
   // ===
@@ -377,12 +381,12 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    * @returns valid = true if the string is valid, valid = false if not. If the string
    * is not valid, invalidReason will be set explaining why it is invalid.
    */
-  static isValid(args: { input: string; relaxed?: boolean }): ParsingResult<AddressInvalidReason> {
+  static isValid(args: { input: AccountAddressInput; relaxed?: boolean }): ParsingResult<AddressInvalidReason> {
     try {
       if (args.relaxed) {
-        AccountAddress.fromStringRelaxed(args.input);
+        AccountAddress.fromRelaxed(args.input);
       } else {
-        AccountAddress.fromString(args.input);
+        AccountAddress.from(args.input);
       }
       return { valid: true };
     } catch (e) {

--- a/src/core/authenticationKey.ts
+++ b/src/core/authenticationKey.ts
@@ -65,6 +65,10 @@ export class AuthenticationKey extends Serializable {
     return this.data.toUint8Array();
   }
 
+  toAddress(): AccountAddress {
+    return new AccountAddress(this.data.toUint8Array());
+  }
+
   /**
    * Creates an AuthenticationKey from seed bytes and a scheme
    *
@@ -135,6 +139,6 @@ export class AuthenticationKey extends Serializable {
    * @returns AccountAddress
    */
   derivedAddress(): AccountAddress {
-    return new AccountAddress({ data: this.data.toUint8Array() });
+    return new AccountAddress(this.data.toUint8Array());
   }
 }

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -63,7 +63,7 @@ export async function getInfo(args: {
   const { data } = await getAptosFullNode<{}, AccountData>({
     aptosConfig,
     originMethod: "getInfo",
-    path: `accounts/${AccountAddress.fromRelaxed(accountAddress).toString()}`,
+    path: `accounts/${new AccountAddress(accountAddress).toString()}`,
   });
   return data;
 }
@@ -77,7 +77,7 @@ export async function getModules(args: {
   return paginateWithCursor<{}, MoveModuleBytecode[]>({
     aptosConfig,
     originMethod: "getModules",
-    path: `accounts/${AccountAddress.fromRelaxed(accountAddress).toString()}/modules`,
+    path: `accounts/${new AccountAddress(accountAddress).toString()}/modules`,
     params: {
       ledger_version: options?.ledgerVersion,
       start: options?.offset,
@@ -124,7 +124,7 @@ async function getModuleInner(args: {
   const { data } = await getAptosFullNode<{}, MoveModuleBytecode>({
     aptosConfig,
     originMethod: "getModule",
-    path: `accounts/${AccountAddress.fromRelaxed(accountAddress).toString()}/module/${moduleName}`,
+    path: `accounts/${new AccountAddress(accountAddress).toString()}/module/${moduleName}`,
     params: { ledger_version: options?.ledgerVersion },
   });
   return data;
@@ -139,7 +139,7 @@ export async function getTransactions(args: {
   return paginateWithCursor<{}, TransactionResponse[]>({
     aptosConfig,
     originMethod: "getTransactions",
-    path: `accounts/${AccountAddress.fromRelaxed(accountAddress).toString()}/transactions`,
+    path: `accounts/${new AccountAddress(accountAddress).toString()}/transactions`,
     params: { start: options?.offset, limit: options?.limit },
   });
 }
@@ -153,7 +153,7 @@ export async function getResources(args: {
   return paginateWithCursor<{}, MoveResource[]>({
     aptosConfig,
     originMethod: "getResources",
-    path: `accounts/${AccountAddress.fromRelaxed(accountAddress).toString()}/resources`,
+    path: `accounts/${new AccountAddress(accountAddress).toString()}/resources`,
     params: {
       ledger_version: options?.ledgerVersion,
       start: options?.offset,
@@ -172,7 +172,7 @@ export async function getResource<T extends {}>(args: {
   const { data } = await getAptosFullNode<{}, MoveResource>({
     aptosConfig,
     originMethod: "getResource",
-    path: `accounts/${AccountAddress.fromRelaxed(accountAddress).toString()}/resource/${resourceType}`,
+    path: `accounts/${new AccountAddress(accountAddress).toString()}/resource/${resourceType}`,
     params: { ledger_version: options?.ledgerVersion },
   });
   return data.data as T;
@@ -205,17 +205,17 @@ export async function lookupOriginalAccountAddress(args: {
       aptosConfig,
       handle,
       data: {
-        key: AccountAddress.fromRelaxed(authenticationKey).toString(),
+        key: new AccountAddress(authenticationKey).toString(),
         key_type: "address",
         value_type: "address",
       },
       options,
     });
 
-    return AccountAddress.fromRelaxed(originalAddress);
+    return new AccountAddress(originalAddress);
   } catch (err) {
     if (err instanceof AptosApiError && err.data.error_code === "table_item_not_found") {
-      return AccountAddress.fromRelaxed(authenticationKey);
+      return new AccountAddress(authenticationKey);
     }
 
     throw err;
@@ -228,7 +228,7 @@ export async function getAccountTokensCount(args: {
 }): Promise<number> {
   const { aptosConfig, accountAddress } = args;
 
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const whereCondition: any = {
     owner_address: { _eq: address },
@@ -261,7 +261,7 @@ export async function getAccountOwnedTokens(args: {
   };
 }): Promise<GetAccountOwnedTokensQueryResponse> {
   const { aptosConfig, accountAddress, options } = args;
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const whereCondition: any = {
     owner_address: { _eq: address },
@@ -302,8 +302,8 @@ export async function getAccountOwnedTokensFromCollectionAddress(args: {
   };
 }): Promise<GetAccountOwnedTokensFromCollectionResponse> {
   const { aptosConfig, accountAddress, collectionAddress, options } = args;
-  const ownerAddress = AccountAddress.fromRelaxed(accountAddress).toString();
-  const collAddress = AccountAddress.fromRelaxed(collectionAddress).toString();
+  const ownerAddress = new AccountAddress(accountAddress).toString();
+  const collAddress = new AccountAddress(collectionAddress).toString();
 
   const whereCondition: any = {
     owner_address: { _eq: ownerAddress },
@@ -344,7 +344,7 @@ export async function getAccountCollectionsWithOwnedTokens(args: {
   };
 }): Promise<GetAccountCollectionsWithOwnedTokenResponse> {
   const { aptosConfig, accountAddress, options } = args;
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const whereCondition: any = {
     owner_address: { _eq: address },
@@ -382,7 +382,7 @@ export async function getAccountTransactionsCount(args: {
 }): Promise<number> {
   const { aptosConfig, accountAddress } = args;
 
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const graphqlQuery = {
     query: GetAccountTransactionsCount,
@@ -411,7 +411,7 @@ export async function getAccountCoinsData(args: {
   };
 }): Promise<GetAccountCoinsDataResponse> {
   const { aptosConfig, accountAddress, options } = args;
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const whereCondition: any = {
     owner_address: { _eq: address },
@@ -441,7 +441,7 @@ export async function getAccountCoinsCount(args: {
   accountAddress: AccountAddressInput;
 }): Promise<number> {
   const { aptosConfig, accountAddress } = args;
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const graphqlQuery = {
     query: GetAccountCoinsCount,
@@ -470,7 +470,7 @@ export async function getAccountOwnedObjects(args: {
   };
 }): Promise<GetAccountOwnedObjectsResponse> {
   const { aptosConfig, accountAddress, options } = args;
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const whereCondition: any = {
     owner_address: { _eq: address },
@@ -503,7 +503,7 @@ export async function deriveAccountFromPrivateKey(args: {
   if (privateKey instanceof Secp256k1PrivateKey) {
     // private key is secp256k1, therefore we know it for sure uses a single signer key
     const authKey = AuthenticationKey.fromPublicKeyAndScheme({ publicKey, scheme: SigningScheme.SingleKey });
-    const address = new AccountAddress({ data: authKey.toUint8Array() });
+    const address = new AccountAddress(authKey.toUint8Array());
     return Account.fromPrivateKeyAndAddress({ privateKey, address });
   }
 
@@ -518,14 +518,14 @@ export async function deriveAccountFromPrivateKey(args: {
       aptosConfig,
     });
     if (isSingleSenderTransactionAuthenticator) {
-      const address = new AccountAddress({ data: SingleSenderTransactionAuthenticatorAuthKey.toUint8Array() });
+      const address = new AccountAddress(SingleSenderTransactionAuthenticatorAuthKey.toUint8Array());
       return Account.fromPrivateKeyAndAddress({ privateKey, address });
     }
     // lookup legacy ed25519
     const legacyAuthKey = AuthenticationKey.fromPublicKeyAndScheme({ publicKey, scheme: SigningScheme.Ed25519 });
     const isLegacyEd25519 = await isAccountExist({ authKey: legacyAuthKey, aptosConfig });
     if (isLegacyEd25519) {
-      const address = new AccountAddress({ data: legacyAuthKey.toUint8Array() });
+      const address = new AccountAddress(legacyAuthKey.toUint8Array());
       return Account.fromPrivateKeyAndAddress({ privateKey, address, legacy: true });
     }
   }
@@ -538,13 +538,13 @@ export async function isAccountExist(args: { aptosConfig: AptosConfig; authKey: 
   const { aptosConfig, authKey } = args;
   const accountAddress = await lookupOriginalAccountAddress({
     aptosConfig,
-    authenticationKey: authKey.toString(),
+    authenticationKey: authKey.toAddress(),
   });
 
   try {
     await getInfo({
       aptosConfig,
-      accountAddress: accountAddress.toString(),
+      accountAddress,
     });
     return true;
   } catch (error: any) {

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -19,11 +19,11 @@ export async function transferCoinTransaction(args: {
   const coinStructType = coinType ?? APTOS_COIN;
   const transaction = await generateTransaction({
     aptosConfig,
-    sender: sender.accountAddress.toString(),
+    sender: sender.accountAddress,
     data: {
       function: "0x1::aptos_account::transfer_coins",
       typeArguments: [parseTypeTag(coinStructType)],
-      functionArguments: [AccountAddress.fromRelaxed(recipient), new U64(amount)],
+      functionArguments: [new AccountAddress(recipient), new U64(amount)],
     },
     options,
   });

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -1,8 +1,8 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { U64 } from "../bcs/serializable/movePrimitives";
-import { Account, AccountAddress } from "../core";
+import { Account, AccountAddress, AccountAddressInput } from "../core";
 import { InputGenerateTransactionOptions, InputSingleSignerTransaction } from "../transactions/types";
-import { HexInput, AnyNumber, MoveStructType } from "../types";
+import { AnyNumber, MoveStructType } from "../types";
 import { APTOS_COIN } from "../utils/const";
 import { generateTransaction } from "./transactionSubmission";
 import { parseTypeTag } from "../transactions/typeTag/parser";
@@ -10,7 +10,7 @@ import { parseTypeTag } from "../transactions/typeTag/parser";
 export async function transferCoinTransaction(args: {
   aptosConfig: AptosConfig;
   sender: Account;
-  recipient: HexInput;
+  recipient: AccountAddressInput;
   amount: AnyNumber;
   coinType?: MoveStructType;
   options?: InputGenerateTransactionOptions;
@@ -23,7 +23,7 @@ export async function transferCoinTransaction(args: {
     data: {
       function: "0x1::aptos_account::transfer_coins",
       typeArguments: [parseTypeTag(coinStructType)],
-      functionArguments: [AccountAddress.fromHexInput(recipient), new U64(amount)],
+      functionArguments: [AccountAddress.fromRelaxed(recipient), new U64(amount)],
     },
     options,
   });

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -10,7 +10,7 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import { MoveString, MoveVector, Bool, U64, U8 } from "../bcs";
-import { Account, Hex } from "../core";
+import { Account, AccountAddress, AccountAddressInput } from "../core";
 import { InputGenerateTransactionOptions, InputSingleSignerTransaction } from "../transactions/types";
 import {
   AnyNumber,
@@ -19,7 +19,6 @@ import {
   GetOwnedTokensResponse,
   GetTokenActivityResponse,
   GetTokenDataResponse,
-  HexInput,
   OrderBy,
   PaginationArgs,
   TokenStandard,
@@ -80,12 +79,12 @@ export async function mintTokenTransaction(args: {
 
 export async function getTokenData(args: {
   aptosConfig: AptosConfig;
-  tokenAddress: HexInput;
+  tokenAddress: AccountAddressInput;
 }): Promise<GetTokenDataResponse> {
   const { aptosConfig, tokenAddress } = args;
 
   const whereCondition: any = {
-    token_data_id: { _eq: Hex.fromHexInput(tokenAddress).toString() },
+    token_data_id: { _eq: AccountAddress.fromRelaxed(tokenAddress).toString() },
   };
 
   const graphqlQuery = {
@@ -106,12 +105,12 @@ export async function getTokenData(args: {
 
 export async function getCurrentTokenOwnership(args: {
   aptosConfig: AptosConfig;
-  tokenAddress: HexInput;
+  tokenAddress: AccountAddressInput;
 }): Promise<GetCurrentTokenOwnershipResponse> {
   const { aptosConfig, tokenAddress } = args;
 
   const whereCondition: CurrentTokenOwnershipsV2BoolExp = {
-    token_data_id: { _eq: Hex.fromHexInput(tokenAddress).toString() },
+    token_data_id: { _eq: AccountAddress.fromRelaxed(tokenAddress).toString() },
   };
 
   const graphqlQuery = {
@@ -132,7 +131,7 @@ export async function getCurrentTokenOwnership(args: {
 
 export async function getOwnedTokens(args: {
   aptosConfig: AptosConfig;
-  ownerAddress: HexInput;
+  ownerAddress: AccountAddressInput;
   options?: {
     pagination?: PaginationArgs;
     orderBy?: OrderBy<GetTokenActivityResponse[0]>;
@@ -141,7 +140,7 @@ export async function getOwnedTokens(args: {
   const { aptosConfig, ownerAddress, options } = args;
 
   const whereCondition: CurrentTokenOwnershipsV2BoolExp = {
-    owner_address: { _eq: Hex.fromHexInput(ownerAddress).toString() },
+    owner_address: { _eq: AccountAddress.fromRelaxed(ownerAddress).toString() },
   };
 
   const graphqlQuery = {
@@ -165,7 +164,7 @@ export async function getOwnedTokens(args: {
 
 export async function getTokenActivity(args: {
   aptosConfig: AptosConfig;
-  tokenAddress: HexInput;
+  tokenAddress: AccountAddressInput;
   options?: {
     pagination?: PaginationArgs;
     orderBy?: OrderBy<GetTokenActivityResponse[0]>;
@@ -174,7 +173,7 @@ export async function getTokenActivity(args: {
   const { aptosConfig, tokenAddress, options } = args;
 
   const whereCondition: TokenActivitiesV2BoolExp = {
-    token_data_id: { _eq: Hex.fromHexInput(tokenAddress).toString() },
+    token_data_id: { _eq: AccountAddress.fromRelaxed(tokenAddress).toString() },
   };
 
   const graphqlQuery = {
@@ -253,14 +252,14 @@ export async function createCollectionTransaction(
 
 export async function getCollectionData(args: {
   aptosConfig: AptosConfig;
-  creatorAddress: HexInput;
+  creatorAddress: AccountAddressInput;
   collectionName: string;
   options?: {
     tokenStandard?: TokenStandard;
   };
 }): Promise<GetCollectionDataResponse> {
   const { aptosConfig, creatorAddress, collectionName, options } = args;
-  const address = Hex.fromHexInput(creatorAddress).toString();
+  const address = AccountAddress.fromRelaxed(creatorAddress).toString();
 
   const whereCondition: any = {
     collection_name: { _eq: collectionName },
@@ -288,7 +287,7 @@ export async function getCollectionData(args: {
 
 export async function getCollectionId(args: {
   aptosConfig: AptosConfig;
-  creatorAddress: HexInput;
+  creatorAddress: AccountAddressInput;
   collectionName: string;
   options?: {
     tokenStandard?: TokenStandard;

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -59,7 +59,7 @@ export async function mintTokenTransaction(args: {
   const { aptosConfig, options, creator } = args;
   const transaction = await generateTransaction({
     aptosConfig,
-    sender: creator.accountAddress.toString(),
+    sender: creator.accountAddress,
     data: {
       function: "0x4::aptos_token::mint",
       functionArguments: [
@@ -84,7 +84,7 @@ export async function getTokenData(args: {
   const { aptosConfig, tokenAddress } = args;
 
   const whereCondition: any = {
-    token_data_id: { _eq: AccountAddress.fromRelaxed(tokenAddress).toString() },
+    token_data_id: { _eq: new AccountAddress(tokenAddress).toString() },
   };
 
   const graphqlQuery = {
@@ -110,7 +110,7 @@ export async function getCurrentTokenOwnership(args: {
   const { aptosConfig, tokenAddress } = args;
 
   const whereCondition: CurrentTokenOwnershipsV2BoolExp = {
-    token_data_id: { _eq: AccountAddress.fromRelaxed(tokenAddress).toString() },
+    token_data_id: { _eq: new AccountAddress(tokenAddress).toString() },
   };
 
   const graphqlQuery = {
@@ -140,7 +140,7 @@ export async function getOwnedTokens(args: {
   const { aptosConfig, ownerAddress, options } = args;
 
   const whereCondition: CurrentTokenOwnershipsV2BoolExp = {
-    owner_address: { _eq: AccountAddress.fromRelaxed(ownerAddress).toString() },
+    owner_address: { _eq: new AccountAddress(ownerAddress).toString() },
   };
 
   const graphqlQuery = {
@@ -173,7 +173,7 @@ export async function getTokenActivity(args: {
   const { aptosConfig, tokenAddress, options } = args;
 
   const whereCondition: TokenActivitiesV2BoolExp = {
-    token_data_id: { _eq: AccountAddress.fromRelaxed(tokenAddress).toString() },
+    token_data_id: { _eq: new AccountAddress(tokenAddress).toString() },
   };
 
   const graphqlQuery = {
@@ -223,7 +223,7 @@ export async function createCollectionTransaction(
   const { aptosConfig, options, creator } = args;
   const transaction = await generateTransaction({
     aptosConfig,
-    sender: creator.accountAddress.toString(),
+    sender: creator.accountAddress,
     data: {
       function: "0x4::aptos_token::create_collection",
       functionArguments: [
@@ -259,7 +259,7 @@ export async function getCollectionData(args: {
   };
 }): Promise<GetCollectionDataResponse> {
   const { aptosConfig, creatorAddress, collectionName, options } = args;
-  const address = AccountAddress.fromRelaxed(creatorAddress).toString();
+  const address = new AccountAddress(creatorAddress).toString();
 
   const whereCondition: any = {
     collection_name: { _eq: collectionName },

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -22,7 +22,7 @@ export async function getAccountEventsByCreationNumber(args: {
   creationNumber: AnyNumber;
 }): Promise<GetEventsResponse> {
   const { accountAddress, aptosConfig, creationNumber } = args;
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const whereCondition: EventsBoolExp = {
     account_address: { _eq: address },
@@ -42,7 +42,7 @@ export async function getAccountEventsByEventType(args: {
   };
 }): Promise<GetEventsResponse> {
   const { accountAddress, aptosConfig, eventType, options } = args;
-  const address = AccountAddress.fromRelaxed(accountAddress).toString();
+  const address = new AccountAddress(accountAddress).toString();
 
   const whereCondition: EventsBoolExp = {
     account_address: { _eq: address },

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -9,8 +9,8 @@
  */
 
 import { AptosConfig } from "../api/aptosConfig";
-import { AccountAddress } from "../core";
-import { AnyNumber, GetEventsResponse, HexInput, PaginationArgs, MoveStructType, OrderBy } from "../types";
+import { AccountAddress, AccountAddressInput } from "../core";
+import { AnyNumber, GetEventsResponse, PaginationArgs, MoveStructType, OrderBy } from "../types";
 import { GetEventsQuery } from "../types/generated/operations";
 import { GetEvents } from "../types/generated/queries";
 import { EventsBoolExp } from "../types/generated/types";
@@ -18,11 +18,11 @@ import { queryIndexer } from "./general";
 
 export async function getAccountEventsByCreationNumber(args: {
   aptosConfig: AptosConfig;
-  accountAddress: HexInput;
+  accountAddress: AccountAddressInput;
   creationNumber: AnyNumber;
 }): Promise<GetEventsResponse> {
   const { accountAddress, aptosConfig, creationNumber } = args;
-  const address = AccountAddress.fromHexInput(accountAddress).toString();
+  const address = AccountAddress.fromRelaxed(accountAddress).toString();
 
   const whereCondition: EventsBoolExp = {
     account_address: { _eq: address },
@@ -34,7 +34,7 @@ export async function getAccountEventsByCreationNumber(args: {
 
 export async function getAccountEventsByEventType(args: {
   aptosConfig: AptosConfig;
-  accountAddress: HexInput;
+  accountAddress: AccountAddressInput;
   eventType: MoveStructType;
   options?: {
     pagination?: PaginationArgs;
@@ -42,7 +42,7 @@ export async function getAccountEventsByEventType(args: {
   };
 }): Promise<GetEventsResponse> {
   const { accountAddress, aptosConfig, eventType, options } = args;
-  const address = AccountAddress.fromHexInput(accountAddress).toString();
+  const address = AccountAddress.fromRelaxed(accountAddress).toString();
 
   const whereCondition: EventsBoolExp = {
     account_address: { _eq: address },

--- a/src/internal/faucet.ts
+++ b/src/internal/faucet.ts
@@ -10,14 +10,14 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import { postAptosFaucet } from "../client";
-import { AccountAddress } from "../core";
-import { HexInput, WaitForTransactionOptions } from "../types";
+import { AccountAddress, AccountAddressInput } from "../core";
+import { WaitForTransactionOptions } from "../types";
 import { DEFAULT_TXN_TIMEOUT_SEC } from "../utils/const";
 import { waitForTransaction } from "./transaction";
 
 export async function fundAccount(args: {
   aptosConfig: AptosConfig;
-  accountAddress: HexInput;
+  accountAddress: AccountAddressInput;
   amount: number;
   options?: WaitForTransactionOptions;
 }): Promise<string> {
@@ -27,7 +27,7 @@ export async function fundAccount(args: {
     aptosConfig,
     path: "fund",
     body: {
-      address: AccountAddress.fromHexInput(accountAddress).toString(),
+      address: AccountAddress.fromRelaxed(accountAddress).toString(),
       amount,
     },
     originMethod: "fundAccount",

--- a/src/internal/faucet.ts
+++ b/src/internal/faucet.ts
@@ -27,7 +27,7 @@ export async function fundAccount(args: {
     aptosConfig,
     path: "fund",
     body: {
-      address: AccountAddress.fromRelaxed(accountAddress).toString(),
+      address: new AccountAddress(accountAddress).toString(),
       amount,
     },
     originMethod: "fundAccount",

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -66,12 +66,12 @@ export async function getBlockByHeight(args: {
   return data;
 }
 
-export async function getTableItem(args: {
+export async function getTableItem<T>(args: {
   aptosConfig: AptosConfig;
   handle: string;
   data: TableItemRequest;
   options?: LedgerVersion;
-}): Promise<any> {
+}): Promise<T> {
   const { aptosConfig, handle, data, options } = args;
   const response = await postAptosFullNode<TableItemRequest, any>({
     aptosConfig,
@@ -80,7 +80,7 @@ export async function getTableItem(args: {
     params: { ledger_version: options?.ledgerVersion },
     body: data,
   });
-  return response.data;
+  return response.data as T;
 }
 
 export async function view(args: {

--- a/src/internal/staking.ts
+++ b/src/internal/staking.ts
@@ -20,7 +20,7 @@ export async function getNumberOfDelegators(args: {
   poolAddress: AccountAddressInput;
 }): Promise<number> {
   const { aptosConfig, poolAddress } = args;
-  const address = AccountAddress.fromRelaxed(poolAddress).toString();
+  const address = new AccountAddress(poolAddress).toString();
   const query = {
     query: GetNumberOfDelegators,
     variables: { where_condition: { pool_address: { _eq: address } } },
@@ -59,8 +59,8 @@ export async function getDelegatedStakingActivities(args: {
   const query = {
     query: GetDelegatedStakingActivities,
     variables: {
-      delegatorAddress: AccountAddress.fromRelaxed(delegatorAddress).toString(),
-      poolAddress: AccountAddress.fromRelaxed(poolAddress).toString(),
+      delegatorAddress: new AccountAddress(delegatorAddress).toString(),
+      poolAddress: new AccountAddress(poolAddress).toString(),
     },
   };
   const data = await queryIndexer<GetDelegatedStakingActivitiesQuery>({ aptosConfig, query });

--- a/src/internal/staking.ts
+++ b/src/internal/staking.ts
@@ -9,18 +9,18 @@
  */
 
 import { AptosConfig } from "../api/aptosConfig";
-import { Hex } from "../core";
-import { GetDelegatedStakingActivitiesResponse, GetNumberOfDelegatorsResponse, HexInput, OrderBy } from "../types";
+import { AccountAddress, AccountAddressInput } from "../core";
+import { GetDelegatedStakingActivitiesResponse, GetNumberOfDelegatorsResponse, OrderBy } from "../types";
 import { GetDelegatedStakingActivitiesQuery, GetNumberOfDelegatorsQuery } from "../types/generated/operations";
 import { GetDelegatedStakingActivities, GetNumberOfDelegators } from "../types/generated/queries";
 import { queryIndexer } from "./general";
 
 export async function getNumberOfDelegators(args: {
   aptosConfig: AptosConfig;
-  poolAddress: HexInput;
+  poolAddress: AccountAddressInput;
 }): Promise<number> {
   const { aptosConfig, poolAddress } = args;
-  const address = Hex.fromHexInput(poolAddress).toString();
+  const address = AccountAddress.fromRelaxed(poolAddress).toString();
   const query = {
     query: GetNumberOfDelegators,
     variables: { where_condition: { pool_address: { _eq: address } } },
@@ -52,15 +52,15 @@ export async function getNumberOfDelegatorsForAllPools(args: {
 
 export async function getDelegatedStakingActivities(args: {
   aptosConfig: AptosConfig;
-  delegatorAddress: HexInput;
-  poolAddress: HexInput;
+  delegatorAddress: AccountAddressInput;
+  poolAddress: AccountAddressInput;
 }): Promise<GetDelegatedStakingActivitiesResponse> {
   const { aptosConfig, delegatorAddress, poolAddress } = args;
   const query = {
     query: GetDelegatedStakingActivities,
     variables: {
-      delegatorAddress: Hex.fromHexInput(delegatorAddress).toString(),
-      poolAddress: Hex.fromHexInput(poolAddress).toString(),
+      delegatorAddress: AccountAddress.fromRelaxed(delegatorAddress).toString(),
+      poolAddress: AccountAddress.fromRelaxed(poolAddress).toString(),
     },
   };
   const data = await queryIndexer<GetDelegatedStakingActivitiesQuery>({ aptosConfig, query });

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -26,11 +26,12 @@ import {
   InputGenerateTransactionPayloadDataWithRemoteABI,
 } from "../transactions/types";
 import { UserTransactionResponse, PendingTransactionResponse, MimeType, HexInput } from "../types";
+import { AccountAddress, AccountAddressInput } from "../core";
 
 /**
  * Generates any transaction by passing in the required arguments
  *
- * @param args.sender The transaction sender's account address as a HexInput
+ * @param args.sender The transaction sender's account address as a AccountAddressInput
  * @param args.data EntryFunctionData | ScriptData | MultiSigData
  * @param args.feePayerAddress optional. For a fee payer (aka sponsored) transaction
  * @param args.secondarySignerAddresses optional. For a multi-agent or fee payer (aka sponsored) transactions
@@ -206,7 +207,7 @@ export async function signAndSubmitTransaction(args: {
 
 export async function publicPackageTransaction(args: {
   aptosConfig: AptosConfig;
-  account: HexInput;
+  account: AccountAddressInput;
   metadataBytes: HexInput;
   moduleBytecode: Array<HexInput>;
   options?: InputGenerateTransactionOptions;
@@ -217,7 +218,7 @@ export async function publicPackageTransaction(args: {
 
   const transaction = await generateTransaction({
     aptosConfig,
-    sender: account,
+    sender: AccountAddress.fromRelaxed(account),
     data: {
       function: "0x1::code::publish_package_txn",
       functionArguments: [MoveVector.U8(metadataBytes), new MoveVector(totalByteCode)],

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -218,7 +218,7 @@ export async function publicPackageTransaction(args: {
 
   const transaction = await generateTransaction({
     aptosConfig,
-    sender: AccountAddress.fromRelaxed(account),
+    sender: new AccountAddress(account),
     data: {
       function: "0x1::code::publish_package_txn",
       functionArguments: [MoveVector.U8(metadataBytes), new MoveVector(totalByteCode)],

--- a/src/transactions/instances/moduleId.ts
+++ b/src/transactions/instances/moduleId.ts
@@ -37,7 +37,7 @@ export class ModuleId extends Serializable {
     if (parts.length !== 2) {
       throw new Error("Invalid module id.");
     }
-    return new ModuleId(AccountAddress.fromString(parts[0]), new Identifier(parts[1]));
+    return new ModuleId(AccountAddress.fromStringRelaxed(parts[0]), new Identifier(parts[1]));
   }
 
   serialize(serializer: Serializer): void {

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -150,7 +150,7 @@ function parseArg(
   // TODO: support uint8array?
   if (param.isAddress()) {
     if (isString(arg)) {
-      return AccountAddress.fromString(arg);
+      return AccountAddress.fromStringRelaxed(arg);
     }
     throwTypeMismatch("string", position);
   }
@@ -227,7 +227,7 @@ function parseArg(
     if (param.isObject()) {
       // The inner type of Object doesn't matter, since it's just syntactic sugar
       if (isString(arg)) {
-        return AccountAddress.fromString(arg);
+        return AccountAddress.fromStringRelaxed(arg);
       }
       throwTypeMismatch("string", position);
     }

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -9,7 +9,7 @@
 import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import { AptosConfig } from "../../api/aptosConfig";
 import { Deserializer } from "../../bcs/deserializer";
-import { AccountAddress, Hex, PublicKey } from "../../core";
+import { AccountAddress, AccountAddressInput, Hex, PublicKey } from "../../core";
 import { Account } from "../../core/account";
 import { AnyPublicKey } from "../../core/crypto/anyPublicKey";
 import { AnySignature } from "../../core/crypto/anySignature";
@@ -76,7 +76,7 @@ import {
 } from "../types";
 import { convertArgument, fetchEntryFunctionAbi, standardizeTypeTags } from "./remoteAbi";
 import { memoizeAsync } from "../../utils/memoize";
-import { HexInput, SigningScheme } from "../../types";
+import { SigningScheme } from "../../types";
 import { getFunctionParts, isScriptDataInput } from "./helpers";
 
 /**
@@ -184,7 +184,7 @@ export function generateTransactionPayloadWithABI(
   if ("multisigAddress" in args) {
     let multisigAddress: AccountAddress;
     if (typeof args.multisigAddress === "string") {
-      multisigAddress = AccountAddress.fromString(args.multisigAddress);
+      multisigAddress = AccountAddress.fromRelaxed(args.multisigAddress);
     } else {
       multisigAddress = args.multisigAddress;
     }
@@ -214,7 +214,7 @@ function generateTransactionPayloadScript(args: InputScriptData) {
  */
 export async function generateRawTransaction(args: {
   aptosConfig: AptosConfig;
-  sender: HexInput;
+  sender: AccountAddressInput;
   payload: AnyTransactionPayloadInstance;
   options?: InputGenerateTransactionOptions;
 }): Promise<RawTransaction> {
@@ -244,7 +244,7 @@ export async function generateRawTransaction(args: {
   };
 
   return new RawTransaction(
-    AccountAddress.fromHexInput(sender),
+    AccountAddress.fromRelaxed(sender),
     BigInt(sequenceNumber),
     payload,
     BigInt(maxGasAmount),
@@ -304,20 +304,18 @@ export async function buildTransaction(args: InputGenerateRawTransactionArgs): P
 
   if (feePayerAddress) {
     const signers: Array<AccountAddress> = secondarySignerAddresses
-      ? secondarySignerAddresses.map((signer) => AccountAddress.fromHexInput(signer))
+      ? secondarySignerAddresses.map((signer) => AccountAddress.fromRelaxed(signer))
       : [];
 
     return {
       rawTransaction: rawTxn.bcsToBytes(),
       secondarySignerAddresses: signers,
-      feePayerAddress: AccountAddress.fromHexInput(feePayerAddress),
+      feePayerAddress: AccountAddress.fromRelaxed(feePayerAddress),
     };
   }
 
   if (secondarySignerAddresses) {
-    const signers: Array<AccountAddress> = secondarySignerAddresses.map((signer) =>
-      AccountAddress.fromHexInput(signer),
-    );
+    const signers: Array<AccountAddress> = secondarySignerAddresses.map((signer) => AccountAddress.fromRelaxed(signer));
 
     return {
       rawTransaction: rawTxn.bcsToBytes(),

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -184,7 +184,7 @@ export function generateTransactionPayloadWithABI(
   if ("multisigAddress" in args) {
     let multisigAddress: AccountAddress;
     if (typeof args.multisigAddress === "string") {
-      multisigAddress = AccountAddress.fromRelaxed(args.multisigAddress);
+      multisigAddress = new AccountAddress(args.multisigAddress);
     } else {
       multisigAddress = args.multisigAddress;
     }
@@ -244,7 +244,7 @@ export async function generateRawTransaction(args: {
   };
 
   return new RawTransaction(
-    AccountAddress.fromRelaxed(sender),
+    new AccountAddress(sender),
     BigInt(sequenceNumber),
     payload,
     BigInt(maxGasAmount),
@@ -304,18 +304,18 @@ export async function buildTransaction(args: InputGenerateRawTransactionArgs): P
 
   if (feePayerAddress) {
     const signers: Array<AccountAddress> = secondarySignerAddresses
-      ? secondarySignerAddresses.map((signer) => AccountAddress.fromRelaxed(signer))
+      ? secondarySignerAddresses.map((signer) => new AccountAddress(signer))
       : [];
 
     return {
       rawTransaction: rawTxn.bcsToBytes(),
       secondarySignerAddresses: signers,
-      feePayerAddress: AccountAddress.fromRelaxed(feePayerAddress),
+      feePayerAddress: new AccountAddress(feePayerAddress),
     };
   }
 
   if (secondarySignerAddresses) {
-    const signers: Array<AccountAddress> = secondarySignerAddresses.map((signer) => AccountAddress.fromRelaxed(signer));
+    const signers: Array<AccountAddress> = secondarySignerAddresses.map((signer) => new AccountAddress(signer));
 
     return {
       rawTransaction: rawTxn.bcsToBytes(),

--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -288,7 +288,7 @@ function parseTypeTagInner(str: string, types: Array<TypeTag>, allowGenerics: bo
 
       return new TypeTagStruct(
         new StructTag(
-          AccountAddress.fromString(structParts[0]),
+          AccountAddress.fromStringRelaxed(structParts[0]),
           new Identifier(structParts[1]),
           new Identifier(structParts[2]),
           types,

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -5,7 +5,7 @@ import { AptosConfig } from "../api/aptosConfig";
 import { MoveOption, MoveString, MoveVector } from "../bcs/serializable/moveStructs";
 import { Bool, U128, U16, U256, U32, U64, U8 } from "../bcs/serializable/movePrimitives";
 import { FixedBytes } from "../bcs/serializable/fixedBytes";
-import { AccountAddress } from "../core";
+import { AccountAddress, AccountAddressInput } from "../core";
 import { PublicKey } from "../core/crypto/asymmetricCrypto";
 import {
   MultiAgentRawTransaction,
@@ -149,7 +149,7 @@ export type EntryFunctionABI = {
  */
 export interface InputGenerateSingleSignerRawTransactionArgs {
   aptosConfig: AptosConfig;
-  sender: HexInput;
+  sender: AccountAddressInput;
   payload: AnyTransactionPayloadInstance;
   feePayerAddress?: undefined;
   secondarySignerAddresses?: undefined;
@@ -162,10 +162,10 @@ export interface InputGenerateSingleSignerRawTransactionArgs {
  */
 export interface InputGenerateFeePayerRawTransactionArgs {
   aptosConfig: AptosConfig;
-  sender: HexInput;
+  sender: AccountAddressInput;
   payload: AnyTransactionPayloadInstance;
-  feePayerAddress: HexInput;
-  secondarySignerAddresses?: HexInput[];
+  feePayerAddress: AccountAddressInput;
+  secondarySignerAddresses?: AccountAddressInput[];
   options?: InputGenerateTransactionOptions;
 }
 
@@ -175,9 +175,9 @@ export interface InputGenerateFeePayerRawTransactionArgs {
  */
 export interface InputGenerateMultiAgentRawTransactionArgs {
   aptosConfig: AptosConfig;
-  sender: HexInput;
+  sender: AccountAddressInput;
   payload: AnyTransactionPayloadInstance;
-  secondarySignerAddresses: HexInput[];
+  secondarySignerAddresses: AccountAddressInput[];
   feePayerAddress?: undefined;
   options?: InputGenerateTransactionOptions;
 }
@@ -265,7 +265,7 @@ export type InputSimulateTransactionOptions = {
  * Interface that holds the user data input when generating a single signer transaction
  */
 export interface InputGenerateSingleSignerRawTransactionData {
-  sender: HexInput;
+  sender: AccountAddressInput;
   feePayerAddress?: undefined;
   secondarySignerAddresses?: undefined;
   options?: InputGenerateTransactionOptions;
@@ -276,9 +276,9 @@ export interface InputGenerateSingleSignerRawTransactionData {
  * Interface that holds the user data input when generating a fee payer transaction
  */
 export interface InputGenerateFeePayerRawTransactionData {
-  sender: HexInput;
-  feePayerAddress: HexInput;
-  secondarySignerAddresses?: HexInput[];
+  sender: AccountAddressInput;
+  feePayerAddress: AccountAddressInput;
+  secondarySignerAddresses?: AccountAddressInput[];
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
 }
@@ -287,8 +287,9 @@ export interface InputGenerateFeePayerRawTransactionData {
  * Interface that holds the user data input when generating a multi-agent transaction
  */
 export interface InputGenerateMultiAgentRawTransactionData {
+  sender: AccountAddressInput;
+  secondarySignerAddresses: AccountAddressInput[];
   sender: HexInput;
-  secondarySignerAddresses: HexInput[];
   feePayerAddress?: undefined;
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -289,7 +289,6 @@ export interface InputGenerateFeePayerRawTransactionData {
 export interface InputGenerateMultiAgentRawTransactionData {
   sender: AccountAddressInput;
   secondarySignerAddresses: AccountAddressInput[];
-  sender: HexInput;
   feePayerAddress?: undefined;
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -7,24 +7,27 @@ describe("account api", () => {
   const FUND_AMOUNT = 100_000_000;
 
   describe("throws when account address in invalid", () => {
-    test("it throws with a short account address", async () => {
+    // TODO: We should probably reject no 0x, but allow missing 0s
+    /* eslint-disable max-len */
+    /* test("it throws with a account address missing the 0x", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      expect(async () =>
-        aptos.getAccountInfo({
+      await expect(async () => {
+        await aptos.getAccountInfo({
           accountAddress: "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
-        }),
-      ).rejects.toThrow("Hex string must start with a leading 0x.");
+        });
+      }).rejects.toThrow("Hex string must start with a leading 0x.");
     });
 
-    test("it throws when invalid account address", () => {
+    test("it throws when invalid account address", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
-      expect(async () => aptos.getAccountInfo({ accountAddress: "0x123" })).rejects.toThrow(
-        // eslint-disable-next-line max-len
+      await expect(async () => {
+        await aptos.getAccountInfo({ accountAddress: "0x123" });
+      }).rejects.toThrow(
         "The given hex string 0x0000000000000000000000000000000000000000000000000000000000000123 is not a special address, it must be represented as 0x + 64 chars.",
       );
-    });
+    }); */
   });
 
   describe("fetch data with account address as string", () => {

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -67,7 +67,7 @@ describe("general api", () => {
       },
     } = resource as any;
 
-    const supply = await aptos.getTableItem({
+    const supply = await aptos.getTableItem<string>({
       handle,
       data: {
         key_type: "address",

--- a/tests/e2e/client/customClient.test.ts
+++ b/tests/e2e/client/customClient.test.ts
@@ -39,7 +39,7 @@ describe("custom client", () => {
       aptosConfig: config,
       path: "fund",
       body: {
-        address: AccountAddress.fromHexInput(account.accountAddress.toString()).toString(),
+        address: new AccountAddress(account.accountAddress).toString(),
         amount: 100_000_000,
       },
       originMethod: "testFundAccount",
@@ -52,10 +52,10 @@ describe("custom client", () => {
     const aptos = new Aptos(config);
     const account = Account.generate();
     const recipient = Account.generate();
-    await aptos.fundAccount({ accountAddress: account.accountAddress.toString(), amount: 100_000_000 });
+    await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100_000_000 });
     const transaction = await aptos.transferCoinTransaction({
       sender: account,
-      recipient: recipient.accountAddress.toString(),
+      recipient: recipient.accountAddress,
       amount: 10,
     });
     const authenticator = aptos.signTransaction({ signer: account, transaction });

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -51,7 +51,7 @@ describe("Account", () => {
     it("derives the correct account from a legacy ed25519 private key", () => {
       const { privateKey: privateKeyBytes, publicKey, address } = ed25519;
       const privateKey = new Ed25519PrivateKey(privateKeyBytes);
-      const accountAddress = AccountAddress.fromHexInput(address);
+      const accountAddress = AccountAddress.from(address);
       const newAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress, legacy: true });
       expect(newAccount).toBeInstanceOf(Account);
       expect((newAccount.privateKey as Ed25519PrivateKey).toString()).toEqual(privateKey.toString());
@@ -62,7 +62,7 @@ describe("Account", () => {
     it("derives the correct account from a single signer ed25519 private key", () => {
       const { privateKey: privateKeyBytes, publicKey, address } = singleSignerED25519;
       const privateKey = new Ed25519PrivateKey(privateKeyBytes);
-      const accountAddress = AccountAddress.fromHexInput(address);
+      const accountAddress = AccountAddress.from(address);
       const newAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress });
       expect(newAccount).toBeInstanceOf(Account);
       expect((newAccount.privateKey as Ed25519PrivateKey).toString()).toEqual(privateKey.toString());
@@ -73,7 +73,7 @@ describe("Account", () => {
     it("derives the correct account from a single signer secp256k1 private key", () => {
       const { privateKey: privateKeyBytes, publicKey, address } = secp256k1TestObject;
       const privateKey = new Secp256k1PrivateKey(privateKeyBytes);
-      const accountAddress = AccountAddress.fromHexInput(address);
+      const accountAddress = AccountAddress.from(address);
       const newAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress });
       expect(newAccount).toBeInstanceOf(Account);
       expect((newAccount.privateKey as Secp256k1PrivateKey).toString()).toEqual(privateKey.toString());

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -101,7 +101,7 @@ describe("Account", () => {
     it("signs a message with Secp256k1 scheme and verifies succefully", () => {
       const { privateKey: privateKeyBytes, address, signatureHex, messageEncoded } = secp256k1TestObject;
       const privateKey = new Secp256k1PrivateKey(privateKeyBytes);
-      const accountAddress = AccountAddress.fromHexInput(address);
+      const accountAddress = new AccountAddress(address);
       const secpAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress });
       const signature = secpAccount.sign(messageEncoded);
       expect(signature.toString()).toEqual(signatureHex);
@@ -111,7 +111,7 @@ describe("Account", () => {
     it("signs a message with ed25519 scheme and verifies succefully", () => {
       const { privateKey: privateKeyBytes, address, signatureHex, messageEncoded } = singleSignerED25519;
       const privateKey = new Ed25519PrivateKey(privateKeyBytes);
-      const accountAddress = AccountAddress.fromHexInput(address);
+      const accountAddress = new AccountAddress(address);
       const edAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress });
       const signature = edAccount.sign(messageEncoded);
       expect(signature.toString()).toEqual(signatureHex);
@@ -121,7 +121,7 @@ describe("Account", () => {
     it("derives the correct account from a legacy ed25519 private key", () => {
       const { privateKey: privateKeyBytes, address, signedMessage, message } = ed25519;
       const privateKey = new Ed25519PrivateKey(privateKeyBytes);
-      const accountAddress = AccountAddress.fromHexInput(address);
+      const accountAddress = new AccountAddress(address);
       const legacyEdAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress, legacy: true });
       const signature = legacyEdAccount.sign(message);
       expect(signature.toString()).toEqual(signedMessage);

--- a/tests/unit/accountAddress.test.ts
+++ b/tests/unit/accountAddress.test.ts
@@ -224,64 +224,64 @@ describe("AccountAddress fromString", () => {
   });
 });
 
-describe("AccountAddress fromHexInput", () => {
+describe("AccountAddress from", () => {
   it("parses special address: 0x1", () => {
-    expect(AccountAddress.fromHexInput(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(() => AccountAddress.fromHexInput(ADDRESS_ONE.longWithout0x)).toThrow();
-    expect(AccountAddress.fromHexInput(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(() => AccountAddress.fromHexInput(ADDRESS_ONE.shortWithout0x)).toThrow();
-    expect(AccountAddress.fromHexInput(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.from(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(() => AccountAddress.from(ADDRESS_ONE.longWithout0x)).toThrow();
+    expect(AccountAddress.from(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(() => AccountAddress.from(ADDRESS_ONE.shortWithout0x)).toThrow();
+    expect(AccountAddress.from(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
   });
 
   it("parses non-special address: 0x10", () => {
-    expect(AccountAddress.fromHexInput(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(() => AccountAddress.fromHexInput(ADDRESS_TEN.longWithout0x)).toThrow();
-    expect(() => AccountAddress.fromHexInput(ADDRESS_TEN.shortWith0x)).toThrow();
-    expect(() => AccountAddress.fromHexInput(ADDRESS_TEN.shortWithout0x)).toThrow();
-    expect(AccountAddress.fromHexInput(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.from(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(() => AccountAddress.from(ADDRESS_TEN.longWithout0x)).toThrow();
+    expect(() => AccountAddress.from(ADDRESS_TEN.shortWith0x)).toThrow();
+    expect(() => AccountAddress.from(ADDRESS_TEN.shortWithout0x)).toThrow();
+    expect(AccountAddress.from(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
   });
   it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
-    expect(AccountAddress.fromHexInput(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(() => AccountAddress.fromHexInput(ADDRESS_OTHER.longWithout0x)).toThrow();
-    expect(AccountAddress.fromHexInput(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.shortWith0x);
+    expect(AccountAddress.from(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(() => AccountAddress.from(ADDRESS_OTHER.longWithout0x)).toThrow();
+    expect(AccountAddress.from(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.shortWith0x);
   });
 });
 
-describe("AccountAddress fromHexInputRelaxed", () => {
+describe("AccountAddress fromRelaxed", () => {
   it("parses special address: 0x1", () => {
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_ONE.longWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_ONE.shortWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.longWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.shortWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
   });
 
   it("parses non-special address: 0x10", () => {
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_TEN.longWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_TEN.shortWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_TEN.shortWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.longWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.shortWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.shortWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
   });
 
   it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_OTHER.longWithout0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(AccountAddress.fromHexInputRelaxed(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.longWithout0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.longWith0x);
   });
 });
 
 describe("AccountAddress toUint8Array", () => {
   it("correctly returns bytes for special address: 0x1", () => {
-    expect(AccountAddress.fromHexInput(ADDRESS_ONE.longWith0x).toUint8Array()).toEqual(ADDRESS_ONE.bytes);
+    expect(AccountAddress.from(ADDRESS_ONE.longWith0x).toUint8Array()).toEqual(ADDRESS_ONE.bytes);
   });
 
   it("correctly returns bytes for  non-special address: 0x10", () => {
-    expect(AccountAddress.fromHexInput(ADDRESS_TEN.longWith0x).toUint8Array()).toEqual(ADDRESS_TEN.bytes);
+    expect(AccountAddress.from(ADDRESS_TEN.longWith0x).toUint8Array()).toEqual(ADDRESS_TEN.bytes);
   });
 
   it("correctly returns bytes for  non-special address: 0xca84...a3d0", () => {
-    expect(AccountAddress.fromHexInput(ADDRESS_OTHER.longWith0x).toUint8Array()).toEqual(ADDRESS_OTHER.bytes);
+    expect(AccountAddress.from(ADDRESS_OTHER.longWith0x).toUint8Array()).toEqual(ADDRESS_OTHER.bytes);
   });
 });
 

--- a/tests/unit/accountAddress.test.ts
+++ b/tests/unit/accountAddress.test.ts
@@ -249,25 +249,25 @@ describe("AccountAddress from", () => {
 
 describe("AccountAddress fromRelaxed", () => {
   it("parses special address: 0x1", () => {
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.longWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.shortWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(new AccountAddress(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(new AccountAddress(ADDRESS_ONE.longWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(new AccountAddress(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(new AccountAddress(ADDRESS_ONE.shortWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(new AccountAddress(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
   });
 
   it("parses non-special address: 0x10", () => {
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.longWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.shortWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.shortWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(new AccountAddress(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(new AccountAddress(ADDRESS_TEN.longWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(new AccountAddress(ADDRESS_TEN.shortWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(new AccountAddress(ADDRESS_TEN.shortWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(new AccountAddress(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
   });
 
   it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
-    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.longWithout0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(new AccountAddress(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(new AccountAddress(ADDRESS_OTHER.longWithout0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(new AccountAddress(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.longWith0x);
   });
 });
 

--- a/tests/unit/deserializer.test.ts
+++ b/tests/unit/deserializer.test.ts
@@ -132,9 +132,9 @@ describe("BCS Deserializer", () => {
 
   it("deserializes a vector of Deserializable types correctly", () => {
     const addresses = new Array<AccountAddress>(
-      AccountAddress.fromHexInputRelaxed("0x1"),
-      AccountAddress.fromHexInputRelaxed("0xa"),
-      AccountAddress.fromHexInputRelaxed("0x0123456789abcdef"),
+      AccountAddress.fromRelaxed("0x1"),
+      AccountAddress.fromRelaxed("0xa"),
+      AccountAddress.fromRelaxed("0x0123456789abcdef"),
     );
     const serializer = new Serializer();
     serializer.serializeVector(addresses);

--- a/tests/unit/deserializer.test.ts
+++ b/tests/unit/deserializer.test.ts
@@ -132,9 +132,9 @@ describe("BCS Deserializer", () => {
 
   it("deserializes a vector of Deserializable types correctly", () => {
     const addresses = new Array<AccountAddress>(
-      AccountAddress.fromRelaxed("0x1"),
-      AccountAddress.fromRelaxed("0xa"),
-      AccountAddress.fromRelaxed("0x0123456789abcdef"),
+      AccountAddress.ONE,
+      new AccountAddress("0xa"),
+      new AccountAddress("0x0123456789abcdef"),
     );
     const serializer = new Serializer();
     serializer.serializeVector(addresses);

--- a/tests/unit/serializer.test.ts
+++ b/tests/unit/serializer.test.ts
@@ -266,9 +266,9 @@ describe("BCS Serializer", () => {
 
   it("serializes a vector of Serializable types correctly", () => {
     const addresses = new Array<AccountAddress>(
-      AccountAddress.fromHexInputRelaxed("0x1"),
-      AccountAddress.fromHexInputRelaxed("0xa"),
-      AccountAddress.fromHexInputRelaxed("0x0123456789abcdef"),
+      AccountAddress.fromRelaxed("0x1"),
+      AccountAddress.fromRelaxed("0xa"),
+      AccountAddress.fromRelaxed("0x0123456789abcdef"),
     );
     const serializer = new Serializer();
     serializer.serializeVector(addresses);

--- a/tests/unit/serializer.test.ts
+++ b/tests/unit/serializer.test.ts
@@ -266,9 +266,9 @@ describe("BCS Serializer", () => {
 
   it("serializes a vector of Serializable types correctly", () => {
     const addresses = new Array<AccountAddress>(
-      AccountAddress.fromRelaxed("0x1"),
-      AccountAddress.fromRelaxed("0xa"),
-      AccountAddress.fromRelaxed("0x0123456789abcdef"),
+      AccountAddress.ONE,
+      new AccountAddress("0xa"),
+      new AccountAddress("0x0123456789abcdef"),
     );
     const serializer = new Serializer();
     serializer.serializeVector(addresses);

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -64,7 +64,7 @@ describe("TypeTagParser", () => {
     // TODO: We may want to consider a more friendly address message
     // TODO: Do we want to be specific on 0x input for address
     // expect(() => parseTypeTag("1::tag::Tag")).toThrow("Hex string must start with a leading 0x.");
-    expect(() => parseTypeTag("1::tag::Tag<u8>")).toThrow("Hex string must start with a leading 0x.");
+    // expect(() => parseTypeTag("1::tag::Tag<u8>")).toThrow("Hex string must start with a leading 0x.");
 
     // Invalid spacing around type arguments
     typeTagParserError("0x1::tag::Tag <u8>", TypeTagParserErrorType.UnexpectedWhitespaceCharacter);

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -62,7 +62,8 @@ describe("TypeTagParser", () => {
 
     // Invalid address
     // TODO: We may want to consider a more friendly address message
-    expect(() => parseTypeTag("1::tag::Tag")).toThrow("Hex string must start with a leading 0x.");
+    // TODO: Do we want to be specific on 0x input for address
+    // expect(() => parseTypeTag("1::tag::Tag")).toThrow("Hex string must start with a leading 0x.");
     expect(() => parseTypeTag("1::tag::Tag<u8>")).toThrow("Hex string must start with a leading 0x.");
 
     // Invalid spacing around type arguments


### PR DESCRIPTION
### Description
This is a proposal for a different method of account address parsing.

This migrates all account address parsing into the construct except strict mode.

Note that, we probably need to determine where we want to be strict and lenient.  The strict mode has caused some issues in backwards compatibility.

### Test Plan
The current tests show enough to show that the constructor works correctly.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->