### PR TITLE
[Documentation] Fixing typos in documentation

### DIFF
--- a/src/bcs/serializable/moveStructs.ts
+++ b/src/bcs/serializable/moveStructs.ts
@@ -205,24 +205,6 @@ export class MoveVector<T extends Serializable & EntryFunctionArgument>
     return new MoveVector<AccountAddress>(accountAddresses);
   }
 
-  /**
-   * Factory method to generate a MoveVector of MoveObjects
-   *
-   * @example
-   * const v = MoveVector.MoveObject(["hello", "world"]);
-   * @params values: an array of `HexInput | MoveObject`
-   * @returns a `MoveVector<MoveObject>`
-   */
-  static MoveObject(values: Array<HexInput | AccountAddress | MoveObject>): MoveVector<MoveObject> {
-    const accountAddresses = values.map((v) => {
-      if (v instanceof MoveObject) {
-        return v;
-      }
-      return new MoveObject(v);
-    });
-    return new MoveVector<MoveObject>(accountAddresses);
-  }
-
   serialize(serializer: Serializer): void {
     serializer.serializeVector(this.values);
   }

--- a/src/bcs/serializable/moveStructs.ts
+++ b/src/bcs/serializable/moveStructs.ts
@@ -7,7 +7,6 @@ import { Deserializable, Deserializer } from "../deserializer";
 import { AnyNumber, HexInput, ScriptTransactionArgumentVariants } from "../../types";
 import { Hex } from "../../core/hex";
 import { EntryFunctionArgument, TransactionArgument } from "../../transactions/instances/transactionArgument";
-import { AccountAddress } from "../../core/accountAddress";
 
 /**
  * This class is the Aptos Typescript SDK representation of a Move `vector<T>`,
@@ -185,24 +184,6 @@ export class MoveVector<T extends Serializable & EntryFunctionArgument>
    */
   static MoveString(values: Array<string>): MoveVector<MoveString> {
     return new MoveVector<MoveString>(values.map((v) => new MoveString(v)));
-  }
-
-  /**
-   * Factory method to generate a MoveVector of AccountAddresses
-   *
-   * @example
-   * const v = MoveVector.AccountAddress(["hello", "world"]);
-   * @params values: an array of `HexInput | AccountAddress`
-   * @returns a `MoveVector<AccountAddress>`
-   */
-  static AccountAddress(values: Array<HexInput | AccountAddress>): MoveVector<AccountAddress> {
-    const accountAddresses = values.map((v) => {
-      if (v instanceof AccountAddress) {
-        return v;
-      }
-      return AccountAddress.fromHexInputRelaxed(v);
-    });
-    return new MoveVector<AccountAddress>(accountAddresses);
   }
 
   serialize(serializer: Serializer): void {
@@ -445,32 +426,6 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    */
   static MoveString(value?: string | null): MoveOption<MoveString> {
     return new MoveOption<MoveString>(value !== null && value !== undefined ? new MoveString(value) : undefined);
-  }
-
-  /**
-   * Factory method to generate a MoveOption<AccountAddress> from `HexInput`, `AccountAddress` or `undefined`
-   *
-   * @example
-   * MoveOption.AccountAddress("0x1").isSome() === true;
-   * MoveOption.AccountAddress("0xbeefcafe").isSome() === true;
-   * MoveOption.AccountAddress().isSome() === false;
-   * MoveOption.AccountAddress(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
-   * the resulting MoveOption's .isSome() method will return false.
-   * @returns a MoveOption<AccountAddress> with an inner value `value`
-   */
-  static AccountAddress(value?: HexInput | AccountAddress | null): MoveOption<AccountAddress> {
-    let accountAddress: AccountAddress | undefined;
-    if (value !== null && value !== undefined) {
-      if (value instanceof AccountAddress) {
-        accountAddress = value;
-      } else {
-        accountAddress = AccountAddress.fromHexInputRelaxed(value);
-      }
-    } else {
-      accountAddress = undefined;
-    }
-    return new MoveOption<AccountAddress>(accountAddress);
   }
 
   static deserialize<U extends Serializable & EntryFunctionArgument>(

--- a/src/bcs/serializable/moveStructs.ts
+++ b/src/bcs/serializable/moveStructs.ts
@@ -205,7 +205,7 @@ export class MoveVector<T extends Serializable & EntryFunctionArgument>
   }
 
   /**
-   * Factory method to generate a MoveVector of MoveObjectes
+   * Factory method to generate a MoveVector of MoveObjects
    *
    * @example
    * const v = MoveVector.MoveObject(["hello", "world"]);

--- a/tests/unit/bcsHelper.test.ts
+++ b/tests/unit/bcsHelper.test.ts
@@ -599,7 +599,7 @@ describe("Tests for the Serializable class", () => {
       const moveObjectWithConstructor = new MoveObject(AccountAddress.fromHexInputRelaxed("0x1"));
       const moveObject = MoveObject.fromAddress(AccountAddress.ONE);
       const moveObject2 = MoveObject.fromAddress("0x1");
-      expect(moveObject.bcsToBytes()).toEqual(moveObjectWithConstructor.bcsToBytes());      
+      expect(moveObject.bcsToBytes()).toEqual(moveObjectWithConstructor.bcsToBytes());
       expect(moveObject.bcsToBytes()).toEqual(moveObject2.bcsToBytes());
     });
 

--- a/tests/unit/bcsHelper.test.ts
+++ b/tests/unit/bcsHelper.test.ts
@@ -593,4 +593,50 @@ describe("Tests for the Serializable class", () => {
       expect(() => MoveVector.U8([BigInt(1)] as any)).toThrow();
     });
   });
+
+  describe("factory methods", () => {
+    it("serializes a vector of addresses and strings and objects correctly", () => {
+      const vectorStringWithConstructor = new MoveVector([
+        new MoveString("abc0x1abc"),
+        new MoveString("def0x2def"),
+        new MoveString("ghi0x3ghi"),
+      ]);
+      const vectorString = MoveVector.MoveString(["abc0x1abc", "def0x2def", "ghi0x3ghi"]);
+      expect(vectorString.bcsToBytes()).toEqual(vectorStringWithConstructor.bcsToBytes());
+
+      const vectorAddressWithConstructor = new MoveVector([
+        AccountAddress.ONE,
+        AccountAddress.TWO,
+        AccountAddress.THREE,
+      ]);
+      const vectorAddress = MoveVector.AccountAddress([AccountAddress.ONE, AccountAddress.TWO, AccountAddress.THREE]);
+      const vectorAddress2 = MoveVector.AccountAddress(["0x1", "0x2", "0x3"]);
+      expect(vectorAddress.bcsToBytes()).toEqual(vectorAddressWithConstructor.bcsToBytes());
+      expect(vectorAddress.bcsToBytes()).toEqual(vectorAddress2.bcsToBytes());
+
+      const vectorObjectWithConstructor = new MoveVector([
+        new MoveObject(AccountAddress.ONE),
+        new MoveObject(AccountAddress.TWO),
+        new MoveObject(AccountAddress.THREE),
+      ]);
+      const vectorObject = MoveVector.MoveObject([AccountAddress.ONE, AccountAddress.TWO, AccountAddress.THREE]);
+      const vectorObject2 = MoveVector.MoveObject(["0x1", "0x2", "0x3"]);
+      expect(vectorObject.bcsToBytes()).toEqual(vectorObjectWithConstructor.bcsToBytes());
+      expect(vectorObject.bcsToBytes()).toEqual(vectorObject2.bcsToBytes());
+    });
+
+    it("serializes options created with factory methods correctly", () => {
+      const optionObjectWithConstructor = new MoveOption(new MoveObject(AccountAddress.ONE));
+      const optionObject = MoveOption.MoveObject(AccountAddress.ONE);
+      const optionObject2 = MoveOption.MoveObject("0x1");
+      expect(optionObject.bcsToBytes()).toEqual(optionObject2.bcsToBytes());
+      expect(optionObject.bcsToBytes()).toEqual(optionObjectWithConstructor.bcsToBytes());
+
+      const optionAddressWithConstructor = new MoveOption(AccountAddress.ONE);
+      const optionAddress = MoveOption.AccountAddress(AccountAddress.ONE);
+      const optionAddress2 = MoveOption.AccountAddress("0x1");
+      expect(optionAddress.bcsToBytes()).toEqual(optionAddress2.bcsToBytes());
+      expect(optionAddress.bcsToBytes()).toEqual(optionAddressWithConstructor.bcsToBytes());
+    });
+  });
 });

--- a/tests/unit/bcsHelper.test.ts
+++ b/tests/unit/bcsHelper.test.ts
@@ -595,14 +595,6 @@ describe("Tests for the Serializable class", () => {
   });
 
   describe("factory methods", () => {
-    it("serializes a move object from an address with the factory method correctly", () => {
-      const moveObjectWithConstructor = new MoveObject(AccountAddress.fromHexInputRelaxed("0x1"));
-      const moveObject = MoveObject.fromAddress(AccountAddress.ONE);
-      const moveObject2 = MoveObject.fromAddress("0x1");
-      expect(moveObject.bcsToBytes()).toEqual(moveObjectWithConstructor.bcsToBytes());
-      expect(moveObject.bcsToBytes()).toEqual(moveObject2.bcsToBytes());
-    });
-
     it("serializes a vector of addresses and strings and objects correctly", () => {
       const vectorStringWithConstructor = new MoveVector([
         new MoveString("abc0x1abc"),
@@ -621,25 +613,9 @@ describe("Tests for the Serializable class", () => {
       const vectorAddress2 = MoveVector.AccountAddress(["0x1", "0x2", "0x3"]);
       expect(vectorAddress.bcsToBytes()).toEqual(vectorAddressWithConstructor.bcsToBytes());
       expect(vectorAddress.bcsToBytes()).toEqual(vectorAddress2.bcsToBytes());
-
-      const vectorObjectWithConstructor = new MoveVector([
-        new MoveObject(AccountAddress.ONE),
-        new MoveObject(AccountAddress.TWO),
-        new MoveObject(AccountAddress.THREE),
-      ]);
-      const vectorObject = MoveVector.MoveObject([AccountAddress.ONE, AccountAddress.TWO, AccountAddress.THREE]);
-      const vectorObject2 = MoveVector.MoveObject(["0x1", "0x2", "0x3"]);
-      expect(vectorObject.bcsToBytes()).toEqual(vectorObjectWithConstructor.bcsToBytes());
-      expect(vectorObject.bcsToBytes()).toEqual(vectorObject2.bcsToBytes());
     });
 
     it("serializes options created with factory methods correctly", () => {
-      const optionObjectWithConstructor = new MoveOption(new MoveObject(AccountAddress.ONE));
-      const optionObject = MoveOption.MoveObject(AccountAddress.ONE);
-      const optionObject2 = MoveOption.MoveObject("0x1");
-      expect(optionObject.bcsToBytes()).toEqual(optionObject2.bcsToBytes());
-      expect(optionObject.bcsToBytes()).toEqual(optionObjectWithConstructor.bcsToBytes());
-
       const optionAddressWithConstructor = new MoveOption(AccountAddress.ONE);
       const optionAddress = MoveOption.AccountAddress(AccountAddress.ONE);
       const optionAddress2 = MoveOption.AccountAddress("0x1");

--- a/tests/unit/bcsHelper.test.ts
+++ b/tests/unit/bcsHelper.test.ts
@@ -593,34 +593,4 @@ describe("Tests for the Serializable class", () => {
       expect(() => MoveVector.U8([BigInt(1)] as any)).toThrow();
     });
   });
-
-  describe("factory methods", () => {
-    it("serializes a vector of addresses and strings and objects correctly", () => {
-      const vectorStringWithConstructor = new MoveVector([
-        new MoveString("abc0x1abc"),
-        new MoveString("def0x2def"),
-        new MoveString("ghi0x3ghi"),
-      ]);
-      const vectorString = MoveVector.MoveString(["abc0x1abc", "def0x2def", "ghi0x3ghi"]);
-      expect(vectorString.bcsToBytes()).toEqual(vectorStringWithConstructor.bcsToBytes());
-
-      const vectorAddressWithConstructor = new MoveVector([
-        AccountAddress.ONE,
-        AccountAddress.TWO,
-        AccountAddress.THREE,
-      ]);
-      const vectorAddress = MoveVector.AccountAddress([AccountAddress.ONE, AccountAddress.TWO, AccountAddress.THREE]);
-      const vectorAddress2 = MoveVector.AccountAddress(["0x1", "0x2", "0x3"]);
-      expect(vectorAddress.bcsToBytes()).toEqual(vectorAddressWithConstructor.bcsToBytes());
-      expect(vectorAddress.bcsToBytes()).toEqual(vectorAddress2.bcsToBytes());
-    });
-
-    it("serializes options created with factory methods correctly", () => {
-      const optionAddressWithConstructor = new MoveOption(AccountAddress.ONE);
-      const optionAddress = MoveOption.AccountAddress(AccountAddress.ONE);
-      const optionAddress2 = MoveOption.AccountAddress("0x1");
-      expect(optionAddress.bcsToBytes()).toEqual(optionAddress2.bcsToBytes());
-      expect(optionAddress.bcsToBytes()).toEqual(optionAddressWithConstructor.bcsToBytes());
-    });
-  });
 });

--- a/tests/unit/bcsHelper.test.ts
+++ b/tests/unit/bcsHelper.test.ts
@@ -595,6 +595,14 @@ describe("Tests for the Serializable class", () => {
   });
 
   describe("factory methods", () => {
+    it("serializes a move object from an address with the factory method correctly", () => {
+      const moveObjectWithConstructor = new MoveObject(AccountAddress.fromHexInputRelaxed("0x1"));
+      const moveObject = MoveObject.fromAddress(AccountAddress.ONE);
+      const moveObject2 = MoveObject.fromAddress("0x1");
+      expect(moveObject.bcsToBytes()).toEqual(moveObjectWithConstructor.bcsToBytes());      
+      expect(moveObject.bcsToBytes()).toEqual(moveObject2.bcsToBytes());
+    });
+
     it("serializes a vector of addresses and strings and objects correctly", () => {
       const vectorStringWithConstructor = new MoveVector([
         new MoveString("abc0x1abc"),


### PR DESCRIPTION
### Description
Adding factory methods for MoveVector for AccountAddress and MoveOption:

```typescript
MoveVector.AccountAddress
MoveOption.AccountAddress
```

This is from an old PR

### Test Plan
added unit tests
`pnpm jest`
