### PR TITLE
Add rotateAuthKey

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -38,6 +38,9 @@ import {
   getTransactions,
   lookupOriginalAccountAddress,
 } from "../internal/account";
+import { RotationProofChallenge } from "../transactions/instances/rotationProofChallenge";
+import { generateTransaction, signAndSubmitTransaction } from "../internal/transactionSubmission";
+import { MoveVector, U8 } from "../bcs";
 
 /**
  * A class to query all `Account` related queries on Aptos.
@@ -376,5 +379,59 @@ export class Account {
    */
   async deriveAccountFromPrivateKey(args: { privateKey: PrivateKey }): Promise<AccountModule> {
     return deriveAccountFromPrivateKey({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Rotate an account's auth key. After rotation, only the new private key can be used to sign txns for
+   * the account.
+   * @param args.fromAccount The account to rotate the auth key for
+   * @param args.toNewPrivateKey The new private key to rotate to
+   *
+   * @returns PendingTransactionResponse
+   */
+  async rotateAuthKey(args: { fromAccount: AccountModule; toNewPrivateKey: PrivateKey }): Promise<TransactionResponse> {
+    const { fromAccount, toNewPrivateKey } = args;
+    const aptosConfig = this.config;
+    const accountInfo = await getInfo({
+      aptosConfig,
+      accountAddress: fromAccount.accountAddress.toString(),
+    });
+
+    const newAccount = AccountModule.fromPrivateKey({ privateKey: toNewPrivateKey, legacy: true });
+
+    const challenge = new RotationProofChallenge({
+      sequenceNumber: BigInt(accountInfo.sequence_number),
+      originator: fromAccount.accountAddress,
+      currentAuthKey: AccountAddress.fromHexInput(accountInfo.authentication_key),
+      newPublicKey: newAccount.publicKey,
+    });
+
+    // Sign the challenge
+    const challengeHex = challenge.bcsToBytes();
+    const proofSignedByCurrentPrivateKey = fromAccount.sign(challengeHex);
+    const proofSignedByNewPrivateKey = newAccount.sign(challengeHex);
+
+    // Generate transaction
+    const rawTxn = await generateTransaction({
+      aptosConfig,
+      sender: fromAccount.accountAddress.toString(),
+      data: {
+        function: "0x1::account::rotate_authentication_key",
+        functionArguments: [
+          new U8(fromAccount.signingScheme.valueOf()), // from scheme
+          MoveVector.U8(fromAccount.publicKey.toUint8Array()),
+          new U8(newAccount.signingScheme.valueOf()), // to scheme
+          MoveVector.U8(newAccount.publicKey.toUint8Array()),
+          MoveVector.U8(proofSignedByCurrentPrivateKey.toUint8Array()),
+          MoveVector.U8(proofSignedByNewPrivateKey.toUint8Array()),
+        ],
+      },
+    });
+    const pendingTxn = await signAndSubmitTransaction({
+      aptosConfig,
+      signer: fromAccount,
+      transaction: rawTxn,
+    });
+    return pendingTxn;
   }
 }

--- a/src/api/transactionSubmission.ts
+++ b/src/api/transactionSubmission.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosConfig } from "./aptosConfig";
-import { Account } from "../core";
+import { Account, PrivateKey } from "../core";
 import { AccountAuthenticator } from "../transactions/authenticator/account";
 import {
   AnyRawTransaction,
@@ -16,10 +16,11 @@ import {
   InputSimulateTransactionData,
   InputGenerateTransactionOptions,
 } from "../transactions/types";
-import { UserTransactionResponse, PendingTransactionResponse, HexInput } from "../types";
+import { UserTransactionResponse, PendingTransactionResponse, HexInput, TransactionResponse } from "../types";
 import {
   generateTransaction,
   publicPackageTransaction,
+  rotateAuthKey,
   signAndSubmitTransaction,
   signTransaction,
   simulateTransaction,
@@ -188,5 +189,17 @@ export class TransactionSubmission {
     options?: InputGenerateTransactionOptions;
   }): Promise<InputSingleSignerTransaction> {
     return publicPackageTransaction({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Rotate an account's auth key. After rotation, only the new private key can be used to sign txns for
+   * the account.
+   * @param args.fromAccount The account to rotate the auth key for
+   * @param args.toNewPrivateKey The new private key to rotate to
+   *
+   * @returns PendingTransactionResponse
+   */
+  async rotateAuthKey(args: { fromAccount: Account; toNewPrivateKey: PrivateKey }): Promise<TransactionResponse> {
+    return rotateAuthKey({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/transactionSubmission.ts
+++ b/src/api/transactionSubmission.ts
@@ -194,6 +194,8 @@ export class TransactionSubmission {
   /**
    * Rotate an account's auth key. After rotation, only the new private key can be used to sign txns for
    * the account.
+   * Note: Only legacy Ed25519 scheme is supported for now.
+   * More info: {@link https://aptos.dev/guides/account-management/key-rotation/}
    * @param args.fromAccount The account to rotate the auth key for
    * @param args.toNewPrivateKey The new private key to rotate to
    *

--- a/src/transactions/instances/index.ts
+++ b/src/transactions/instances/index.ts
@@ -5,6 +5,7 @@ export * from "./chainId";
 export * from "./identifier";
 export * from "./moduleId";
 export * from "./rawTransaction";
+export * from "./rotationProofChallenge";
 export * from "./signedTransaction";
 export * from "./transactionArgument";
 export * from "./transactionPayload";

--- a/src/transactions/instances/rotationProofChallenge.ts
+++ b/src/transactions/instances/rotationProofChallenge.ts
@@ -12,19 +12,26 @@ import { MoveString, MoveVector, U64, U8 } from "../../bcs";
  * to rotate the authentication key.
  */
 export class RotationProofChallenge extends Serializable {
+  // Resource account address
   public readonly accountAddress: AccountAddress = AccountAddress.ONE;
 
-  public readonly sequenceNumber: U64;
-
+  // Module name, i.e: 0x1::account
   public readonly moduleName: MoveString = new MoveString("account");
 
+  // The rotation proof challenge struct name that live under the module
   public readonly structName: MoveString = new MoveString("RotationProofChallenge");
 
+  // Signer's address
   public readonly originator: AccountAddress;
 
+  // Signer's current authentication key
   public readonly currentAuthKey: AccountAddress;
 
+  // New public key to rotate to
   public readonly newPublicKey: MoveVector<U8>;
+
+  // Sequence number of the account
+  public readonly sequenceNumber: U64;
 
   constructor(args: {
     sequenceNumber: AnyNumber;

--- a/src/transactions/instances/rotationProofChallenge.ts
+++ b/src/transactions/instances/rotationProofChallenge.ts
@@ -1,0 +1,51 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Serializer, Serializable } from "../../bcs/serializer";
+import { AccountAddress } from "../../core/accountAddress";
+import { AnyNumber } from "../../types";
+import { PublicKey } from "../../core/crypto/asymmetricCrypto";
+import { MoveString, MoveVector, U64, U8 } from "../../bcs";
+
+/**
+ * Representation of the challenge which is needed to sign by owner of the account
+ * to rotate the authentication key.
+ */
+export class RotationProofChallenge extends Serializable {
+  public readonly accountAddress: AccountAddress = AccountAddress.ONE;
+
+  public readonly sequenceNumber: U64;
+
+  public readonly moduleName: MoveString = new MoveString("account");
+
+  public readonly structName: MoveString = new MoveString("RotationProofChallenge");
+
+  public readonly originator: AccountAddress;
+
+  public readonly currentAuthKey: AccountAddress;
+  
+  public readonly newPublicKey: MoveVector<U8>;
+
+  constructor(args: {
+    sequenceNumber: AnyNumber;
+    originator: AccountAddress;
+    currentAuthKey: AccountAddress;
+    newPublicKey: PublicKey;
+  }) {
+    super();
+    this.sequenceNumber = new U64(args.sequenceNumber);
+    this.originator = args.originator;
+    this.currentAuthKey = args.currentAuthKey;
+    this.newPublicKey = MoveVector.U8(args.newPublicKey.toUint8Array());
+  }
+
+  serialize(serializer: Serializer): void {
+    serializer.serialize(this.accountAddress);
+    serializer.serialize(this.moduleName);
+    serializer.serialize(this.structName);
+    serializer.serialize(this.sequenceNumber);
+    serializer.serialize(this.originator);
+    serializer.serialize(this.currentAuthKey);
+    serializer.serialize(this.newPublicKey);
+  }
+}

--- a/src/transactions/instances/rotationProofChallenge.ts
+++ b/src/transactions/instances/rotationProofChallenge.ts
@@ -23,7 +23,7 @@ export class RotationProofChallenge extends Serializable {
   public readonly originator: AccountAddress;
 
   public readonly currentAuthKey: AccountAddress;
-  
+
   public readonly newPublicKey: MoveVector<U8>;
 
   constructor(args: {


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

This PR creates an new api method rotateAuthKey

Note:
1. I place it under /api folder only and not /internal, because of dependency cycle
2. This only supports legacy ed25519, the move side does not support Single Signer or Secp.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

pnpm test

### Related Links
<!-- Please link to any relevant issues or pull requests! -->