### PR TITLE
Replace all instances of `rawTransaction: Uint8Array` with an actual `RawTransaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Support derive account from private key `Account.fromPrivateKey()`
 - Derive account from derivation path secp256k1 support
 - Default Account generation to Legacy Ed25519
+- Remove unnecessary pre-emptive serialization of the field `rawTransaction: Uint8Array` by replacing it with the unserialized `rawTransaction: RawTransaction` class
 
 ## 0.0.3 (2023-10-31)
 

--- a/src/api/transactionSubmission.ts
+++ b/src/api/transactionSubmission.ts
@@ -77,10 +77,10 @@ export class TransactionSubmission {
    * }
    * ```
    *
-   * @return A raw transaction type (note that it holds the raw transaction as a bcs serialized data)
+   * @return An instance of a RawTransaction, plus optional secondary/fee payer addresses
    * ```
    * {
-   *  rawTransaction: Uint8Array,
+   *  rawTransaction: RawTransaction,
    *  secondarySignerAddresses? : Array<AccountAddress>,
    *  feePayerAddress?: AccountAddress
    * }
@@ -94,10 +94,10 @@ export class TransactionSubmission {
    * Sign a transaction that can later be submitted to chain
    *
    * @param args.signer The signer account to sign the transaction
-   * @param args.transaction A raw transaction type (note that it holds the raw transaction as a bcs serialized data)
+   * @param args.transaction An instance of a RawTransaction, plus optional secondary/fee payer addresses
    * ```
    * {
-   *  rawTransaction: Uint8Array,
+   *  rawTransaction: RawTransaction,
    *  secondarySignerAddresses? : Array<AccountAddress>,
    *  feePayerAddress?: AccountAddress
    * }
@@ -140,10 +140,10 @@ export class TransactionSubmission {
    * Sign and submit a single signer transaction to chain
    *
    * @param args.signer The signer account to sign the transaction
-   * @param args.transaction A raw transaction type (note that it holds the raw transaction as a bcs serialized data)
+   * @param args.transaction An instance of a RawTransaction, plus optional secondary/fee payer addresses
    * ```
    * {
-   *  rawTransaction: Uint8Array,
+   *  rawTransaction: RawTransaction,
    *  secondarySignerAddresses? : Array<AccountAddress>,
    *  feePayerAddress?: AccountAddress
    * }

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -63,10 +63,10 @@ import { getInfo } from "./account";
  * }
  * ```
  *
- * @return A raw transaction type (note that it holds the raw transaction as a bcs serialized data)
+ * @return An instance of a RawTransaction, plus optional secondary/fee payer addresses
  * ```
  * {
- *  rawTransaction: Uint8Array,
+ *  rawTransaction: RawTransaction,
  *  secondarySignerAddresses? : Array<AccountAddress>,
  *  feePayerAddress?: AccountAddress
  * }
@@ -112,10 +112,10 @@ export async function generateTransaction(
  * Sign a transaction that can later be submitted to chain
  *
  * @param args.signer The signer account to sign the transaction
- * @param args.transaction A raw transaction type (note that it holds the raw transaction as a bcs serialized data)
+ * @param args.transaction An instance of a RawTransaction, plus optional secondary/fee payer addresses
  * ```
  * {
- *  rawTransaction: Uint8Array,
+ *  rawTransaction: RawTransaction,
  *  secondarySignerAddresses? : Array<AccountAddress>,
  *  feePayerAddress?: AccountAddress
  * }

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -521,21 +521,18 @@ export function generateSignedTransaction(args: InputSubmitTransactionData): Uin
  * @returns FeePayerRawTransaction | MultiAgentRawTransaction | RawTransaction
  */
 export function deriveTransactionType(transaction: AnyRawTransaction): AnyRawTransactionInstance {
-  const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
-  const deserializedTransaction = RawTransaction.deserialize(deserializer);
-
   if (transaction.feePayerAddress) {
     return new FeePayerRawTransaction(
-      deserializedTransaction,
+      transaction.rawTransaction,
       transaction.secondarySignerAddresses ?? [],
       transaction.feePayerAddress,
     );
   }
   if (transaction.secondarySignerAddresses) {
-    return new MultiAgentRawTransaction(deserializedTransaction, transaction.secondarySignerAddresses);
+    return new MultiAgentRawTransaction(transaction.rawTransaction, transaction.secondarySignerAddresses);
   }
 
-  return deserializedTransaction as RawTransaction;
+  return transaction.rawTransaction as RawTransaction;
 }
 
 /**

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -284,10 +284,10 @@ export async function buildTransaction(args: InputGenerateRawTransactionArgs): P
  * @param args.secondarySignerAddresses optional. For when want to create a multi signers transaction
  * @param args.feePayerAddress optional. For when want to create a fee payer (aka sponsored) transaction
  *
- * @return An Aptos raw transaction type (note that it holds the raw transaction as a bcs serialized data)
+ * @return An instance of a RawTransaction, plus optional secondary/fee payer addresses
  * ```
  * {
- *  rawTransaction: Uint8Array,
+ *  rawTransaction: RawTransaction,
  *  secondarySignerAddresses? : Array<AccountAddress>,
  *  feePayerAddress?: AccountAddress
  * }
@@ -309,7 +309,7 @@ export async function buildTransaction(args: InputGenerateRawTransactionArgs): P
       : [];
 
     return {
-      rawTransaction: rawTxn.bcsToBytes(),
+      rawTransaction: rawTxn,
       secondarySignerAddresses: signers,
       feePayerAddress: AccountAddress.fromHexInput(feePayerAddress),
     };
@@ -321,12 +321,12 @@ export async function buildTransaction(args: InputGenerateRawTransactionArgs): P
     );
 
     return {
-      rawTransaction: rawTxn.bcsToBytes(),
+      rawTransaction: rawTxn,
       secondarySignerAddresses: signers,
     };
   }
   // return the raw transaction
-  return { rawTransaction: rawTxn.bcsToBytes() };
+  return { rawTransaction: rawTxn };
 }
 
 /**
@@ -343,7 +343,7 @@ export async function buildTransaction(args: InputGenerateRawTransactionArgs): P
 export function generateSignedTransactionForSimulation(args: InputSimulateTransactionData): Uint8Array {
   const { signerPublicKey, transaction, secondarySignersPublicKeys, feePayerPublicKey } = args;
 
-  const deserializer = new Deserializer(transaction.rawTransaction);
+  const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
   const deserializedTransaction = RawTransaction.deserialize(deserializer);
 
   const accountAuthenticator = getAuthenticatorForSimulation(signerPublicKey);
@@ -521,7 +521,7 @@ export function generateSignedTransaction(args: InputSubmitTransactionData): Uin
  * @returns FeePayerRawTransaction | MultiAgentRawTransaction | RawTransaction
  */
 export function deriveTransactionType(transaction: AnyRawTransaction): AnyRawTransactionInstance {
-  const deserializer = new Deserializer(transaction.rawTransaction);
+  const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
   const deserializedTransaction = RawTransaction.deserialize(deserializer);
 
   if (transaction.feePayerAddress) {

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -197,7 +197,7 @@ export type InputGenerateRawTransactionArgs =
  * @param rawTransaction a bcs serialized raw transaction
  */
 export interface InputSingleSignerTransaction {
-  rawTransaction: Uint8Array;
+  rawTransaction: RawTransaction;
   feePayerAddress?: undefined;
   secondarySignerAddresses?: undefined;
 }
@@ -210,7 +210,7 @@ export interface InputSingleSignerTransaction {
  * @param feePayerAddress fee payer address for a fee payer transaction (aka Sponsored Transaction)
  */
 export interface InputFeePayerTransaction {
-  rawTransaction: Uint8Array;
+  rawTransaction: RawTransaction;
   feePayerAddress: AccountAddress;
   secondarySignerAddresses?: AccountAddress[];
 }
@@ -222,7 +222,7 @@ export interface InputFeePayerTransaction {
  * @param secondarySignerAddresses secondary signer addresses for multi-agent transaction
  */
 export interface InputMultiAgentTransaction {
-  rawTransaction: Uint8Array;
+  rawTransaction: RawTransaction;
   secondarySignerAddresses: AccountAddress[];
   feePayerAddress?: undefined;
 }

--- a/tests/e2e/api/coin.test.ts
+++ b/tests/e2e/api/coin.test.ts
@@ -17,7 +17,7 @@ describe("coin", () => {
       amount: 10,
     });
 
-    const txnDeserializer = new Deserializer(transaction.rawTransaction);
+    const txnDeserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
     const rawTransaction = RawTransaction.deserialize(txnDeserializer);
     const typeArgs = (rawTransaction.payload as TransactionPayloadEntryFunction).entryFunction.type_args;
     expect((typeArgs[0] as TypeTagStruct).value.address.toString()).toBe("0x1");
@@ -39,7 +39,7 @@ describe("coin", () => {
       coinType: "0x1::my_coin::type",
     });
 
-    const txnDeserializer = new Deserializer(transaction.rawTransaction);
+    const txnDeserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
     const rawTransaction = RawTransaction.deserialize(txnDeserializer);
     const typeArgs = (rawTransaction.payload as TransactionPayloadEntryFunction).entryFunction.type_args;
     expect((typeArgs[0] as TypeTagStruct).value.address.toString()).toBe("0x1");

--- a/tests/e2e/transaction/generateTransaction.test.ts
+++ b/tests/e2e/transaction/generateTransaction.test.ts
@@ -28,10 +28,10 @@ describe("generate transaction", () => {
           functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses).not.toBeDefined();
       expect(transaction.feePayerAddress).not.toBeDefined();
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadScript).toBeTruthy();
@@ -45,10 +45,10 @@ describe("generate transaction", () => {
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses).not.toBeDefined();
       expect(transaction.feePayerAddress).not.toBeDefined();
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadMultisig).toBeTruthy();
@@ -62,10 +62,10 @@ describe("generate transaction", () => {
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses).not.toBeDefined();
       expect(transaction.feePayerAddress).not.toBeDefined();
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
@@ -82,10 +82,10 @@ describe("generate transaction", () => {
           functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses[0]).toStrictEqual(secondarySignerAccount.accountAddress);
       expect(transaction.feePayerAddress).not.toBeDefined();
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadScript).toBeTruthy();
@@ -100,10 +100,10 @@ describe("generate transaction", () => {
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses[0]).toStrictEqual(secondarySignerAccount.accountAddress);
       expect(transaction.feePayerAddress).not.toBeDefined();
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
@@ -120,10 +120,10 @@ describe("generate transaction", () => {
           functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.feePayerAddress).toStrictEqual(feePayerAccount.accountAddress);
       expect(transaction.secondarySignerAddresses?.length).toBe(0);
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadScript).toBeTruthy();
@@ -139,10 +139,10 @@ describe("generate transaction", () => {
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses?.length).toBe(0);
       expect(transaction.feePayerAddress).toStrictEqual(feePayerAccount.accountAddress);
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadMultisig).toBeTruthy();
@@ -157,10 +157,10 @@ describe("generate transaction", () => {
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses?.length).toBe(0);
       expect(transaction.feePayerAddress).toStrictEqual(feePayerAccount.accountAddress);
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
@@ -176,10 +176,10 @@ describe("generate transaction", () => {
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
         },
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses![0]).toStrictEqual(secondarySignerAccount.accountAddress);
       expect(transaction.feePayerAddress).toStrictEqual(feePayerAccount.accountAddress);
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -224,7 +224,7 @@ describe("transaction builder", () => {
         sender: alice.accountAddress.toString(),
         payload,
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses).toBeUndefined();
       expect(transaction.feePayerAddress).toBeUndefined();
     });
@@ -245,7 +245,7 @@ describe("transaction builder", () => {
         payload,
         secondarySignerAddresses: [secondarySignerAddress.accountAddress.toString()],
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses).not.toBeUndefined();
       expect(transaction.secondarySignerAddresses?.length).toBe(1);
       expect(transaction.secondarySignerAddresses![0].data).toStrictEqual(
@@ -270,7 +270,7 @@ describe("transaction builder", () => {
         payload,
         feePayerAddress: feePayer.accountAddress.toString(),
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses?.length).toBe(0);
       expect(transaction.feePayerAddress).not.toBeUndefined();
       expect(transaction.feePayerAddress?.data).toStrictEqual(feePayer.accountAddress.toUint8Array());
@@ -296,7 +296,7 @@ describe("transaction builder", () => {
           secondarySignerAddresses: [secondarySignerAddress.accountAddress.toString()],
           feePayerAddress: feePayer.accountAddress.toString(),
         });
-        expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+        expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
         expect(transaction.secondarySignerAddresses).not.toBeUndefined();
         expect(transaction.secondarySignerAddresses?.length).toBe(1);
         expect(transaction.secondarySignerAddresses![0].data).toStrictEqual(

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -696,10 +696,10 @@ describe("transaction submission", () => {
         metadataBytes,
         moduleBytecode: [byteCode],
       });
-      expect(transaction.rawTransaction instanceof Uint8Array).toBeTruthy();
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses).not.toBeDefined();
       expect(transaction.feePayerAddress).not.toBeDefined();
-      const deserializer = new Deserializer(transaction.rawTransaction);
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
       expect(deserializedTransaction.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();


### PR DESCRIPTION
### Description
After working with the wallet adapter more, I realized my initial motivation for suggesting @0xmaayan use a `Uint8Array` was misled and premature, because we can perform this conversion at the wallet adapter layer if necessary.

Until it's necessary, it is ideally more strongly typed as an actual RawTransaction instance.

1. This saves us an unnecessary round of serialization/deserialization in `deriveTransaction`
2. Increases clarity, because it's confusing knowing what the `Uint8Array` bytes really are
3. We can very easily just perform this conversion at the wallet adapter layer when it's necessary

After trying to build transactions/come up with a more intuitive flow, I realized how premature converting to bcs bytes was, and that's the motivation for this PR.

### Test Plan
```typescript
pnpm jest
```
