### PR TITLE
Optional Fee Payer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- [`Breaking`] Update and changed the flow of Fee payer transaction to be "Optional Fee Payer". A fee payer is now required to sign the transaction `asFeePayer`
 
 ## 0.0.4 (2023-11-03)
 

--- a/src/api/transactionSubmission.ts
+++ b/src/api/transactionSubmission.ts
@@ -95,6 +95,7 @@ export class TransactionSubmission {
    *
    * @param args.signer The signer account to sign the transaction
    * @param args.transaction An instance of a RawTransaction, plus optional secondary/fee payer addresses
+   * @param args.asFeePayer optional. If the signer is also the fee payer
    * ```
    * {
    *  rawTransaction: RawTransaction,
@@ -106,30 +107,15 @@ export class TransactionSubmission {
    * @return The signer AccountAuthenticator
    */
   /* eslint-disable class-methods-use-this */
-  signTransaction(args: { signer: Account; transaction: AnyRawTransaction }): AccountAuthenticator {
-    return signTransaction({ ...args });
-  }
-
-  /**
-   * Sign a transaction that can later be submitted to chain, as a fee payer. The signer who signs the transaction
-   * will be the one who pays the gas
-   *
-   * @param args.signer The signer or fee payer
-   * @param args.transaction A raw transaction type (note that it holds the raw transaction as a bcs serialized data)
-   * ```
-   * {
-   *  rawTransaction: Uint8Array,
-   *  secondarySignerAddresses? : Array<AccountAddress>,
-   *  feePayerAddress?: AccountAddress
-   * }
-   * ```
-   *
-   * @return The signer AccountAuthenticator
-   */
-  /* eslint-disable class-methods-use-this */
-  signTransactionAsPayer(args: { signer: Account; transaction: AnyRawTransaction }): AccountAuthenticator {
-    const { signer, transaction } = args;
-    transaction.feePayerAddress = signer.accountAddress;
+  signTransaction(args: {
+    signer: Account;
+    transaction: AnyRawTransaction;
+    asFeePayer?: boolean;
+  }): AccountAuthenticator {
+    const { signer, transaction, asFeePayer } = args;
+    if (asFeePayer) {
+      transaction.feePayerAddress = signer.accountAddress;
+    }
     return signTransaction({
       signer,
       transaction,

--- a/src/api/transactionSubmission.ts
+++ b/src/api/transactionSubmission.ts
@@ -111,6 +111,32 @@ export class TransactionSubmission {
   }
 
   /**
+   * Sign a transaction that can later be submitted to chain, as a fee payer. The signer who signs the transaction
+   * will be the one who pays the gas
+   *
+   * @param args.signer The signer or fee payer
+   * @param args.transaction A raw transaction type (note that it holds the raw transaction as a bcs serialized data)
+   * ```
+   * {
+   *  rawTransaction: Uint8Array,
+   *  secondarySignerAddresses? : Array<AccountAddress>,
+   *  feePayerAddress?: AccountAddress
+   * }
+   * ```
+   *
+   * @return The signer AccountAuthenticator
+   */
+  /* eslint-disable class-methods-use-this */
+  signTransactionAsPayer(args: { signer: Account; transaction: AnyRawTransaction }): AccountAuthenticator {
+    const { signer, transaction } = args;
+    transaction.feePayerAddress = signer.accountAddress;
+    return signTransaction({
+      signer,
+      transaction,
+    });
+  }
+
+  /**
    * Simulates a transaction before singing it.
    *
    * @param args.signerPublicKey The signer public key

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -76,11 +76,11 @@ export async function generateTransaction(
   args: { aptosConfig: AptosConfig } & InputGenerateTransactionData,
 ): Promise<AnyRawTransaction> {
   const { aptosConfig, sender, data, options, secondarySignerAddresses, hasSponsor } = args;
-  let { feePayerAddress } = args;
 
   // Upate feePayerAddress if it has sponsor
+  let feePayerAddress;
   if (hasSponsor === true) {
-    feePayerAddress = "0x0";
+    feePayerAddress = AccountAddress.ZERO.toString();
   }
 
   // Merge in aptosConfig for remote ABI on non-script payloads

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -75,11 +75,11 @@ import { UserTransactionResponse, PendingTransactionResponse, MimeType, HexInput
 export async function generateTransaction(
   args: { aptosConfig: AptosConfig } & InputGenerateTransactionData,
 ): Promise<AnyRawTransaction> {
-  const { aptosConfig, sender, data, options, secondarySignerAddresses, hasSponsor } = args;
+  const { aptosConfig, sender, data, options, secondarySignerAddresses, hasFeePayer } = args;
 
   // Upate feePayerAddress if it has sponsor
   let feePayerAddress;
-  if (hasSponsor === true) {
+  if (hasFeePayer === true) {
     feePayerAddress = AccountAddress.ZERO.toString();
   }
 

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -75,7 +75,13 @@ import { UserTransactionResponse, PendingTransactionResponse, MimeType, HexInput
 export async function generateTransaction(
   args: { aptosConfig: AptosConfig } & InputGenerateTransactionData,
 ): Promise<AnyRawTransaction> {
-  const { aptosConfig, sender, data, options, secondarySignerAddresses, feePayerAddress } = args;
+  const { aptosConfig, sender, data, options, secondarySignerAddresses, hasSponsor } = args;
+  let { feePayerAddress } = args;
+
+  // Upate feePayerAddress if it has sponsor
+  if (hasSponsor === true) {
+    feePayerAddress = "0x0";
+  }
 
   // Merge in aptosConfig for remote ABI on non-script payloads
   let generateTransactionPayloadData: InputGenerateTransactionPayloadDataWithRemoteABI;

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -267,7 +267,7 @@ export type InputSimulateTransactionOptions = {
  */
 export interface InputGenerateSingleSignerRawTransactionData {
   sender: AccountAddressInput;
-  hasSponsor?: undefined | false;
+  hasFeePayer?: undefined;
   secondarySignerAddresses?: undefined;
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
@@ -278,7 +278,7 @@ export interface InputGenerateSingleSignerRawTransactionData {
  */
 export interface InputGenerateFeePayerRawTransactionData {
   sender: AccountAddressInput;
-  hasSponsor: true;
+  hasFeePayer: true;
   secondarySignerAddresses?: AccountAddressInput[];
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
@@ -290,7 +290,7 @@ export interface InputGenerateFeePayerRawTransactionData {
 export interface InputGenerateMultiAgentRawTransactionData {
   sender: AccountAddressInput;
   secondarySignerAddresses: AccountAddressInput[];
-  hasSponsor?: undefined | false;
+  hasFeePayer?: undefined;
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
 }

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -268,6 +268,7 @@ export type InputSimulateTransactionOptions = {
 export interface InputGenerateSingleSignerRawTransactionData {
   sender: AccountAddressInput;
   feePayerAddress?: undefined;
+  hasSponsor?: undefined;
   secondarySignerAddresses?: undefined;
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
@@ -278,7 +279,8 @@ export interface InputGenerateSingleSignerRawTransactionData {
  */
 export interface InputGenerateFeePayerRawTransactionData {
   sender: AccountAddressInput;
-  feePayerAddress: AccountAddressInput;
+  feePayerAddress?: AccountAddressInput;
+  hasSponsor: boolean;
   secondarySignerAddresses?: AccountAddressInput[];
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
@@ -291,6 +293,7 @@ export interface InputGenerateMultiAgentRawTransactionData {
   sender: AccountAddressInput;
   secondarySignerAddresses: AccountAddressInput[];
   feePayerAddress?: undefined;
+  hasSponsor?: undefined;
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
 }

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -267,8 +267,7 @@ export type InputSimulateTransactionOptions = {
  */
 export interface InputGenerateSingleSignerRawTransactionData {
   sender: AccountAddressInput;
-  feePayerAddress?: undefined;
-  hasSponsor?: undefined;
+  hasSponsor?: undefined | false;
   secondarySignerAddresses?: undefined;
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
@@ -279,8 +278,7 @@ export interface InputGenerateSingleSignerRawTransactionData {
  */
 export interface InputGenerateFeePayerRawTransactionData {
   sender: AccountAddressInput;
-  feePayerAddress?: AccountAddressInput;
-  hasSponsor: boolean;
+  hasSponsor: true;
   secondarySignerAddresses?: AccountAddressInput[];
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
@@ -292,8 +290,7 @@ export interface InputGenerateFeePayerRawTransactionData {
 export interface InputGenerateMultiAgentRawTransactionData {
   sender: AccountAddressInput;
   secondarySignerAddresses: AccountAddressInput[];
-  feePayerAddress?: undefined;
-  hasSponsor?: undefined;
+  hasSponsor?: undefined | false;
   options?: InputGenerateTransactionOptions;
   data: InputGenerateTransactionPayloadData;
 }

--- a/tests/e2e/transaction/generateTransaction.test.ts
+++ b/tests/e2e/transaction/generateTransaction.test.ts
@@ -1,4 +1,4 @@
-import { AptosConfig, Network, Aptos, Account, Deserializer, U64 } from "../../../src";
+import { AptosConfig, Network, Aptos, Account, Deserializer, U64, AccountAddress } from "../../../src";
 import {
   RawTransaction,
   TransactionPayloadScript,
@@ -114,14 +114,14 @@ describe("generate transaction", () => {
     test("with script payload", async () => {
       const transaction = await aptos.generateTransaction({
         sender: senderAccount.accountAddress.toString(),
-        feePayerAddress: feePayerAccount.accountAddress.toString(),
+        hasSponsor: true,
         data: {
           bytecode: singleSignerScriptBytecode,
           functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
         },
       });
       expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
-      expect(transaction.feePayerAddress).toStrictEqual(feePayerAccount.accountAddress);
+      expect(transaction.feePayerAddress).toStrictEqual(AccountAddress.ZERO);
       expect(transaction.secondarySignerAddresses?.length).toBe(0);
       const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
@@ -132,7 +132,7 @@ describe("generate transaction", () => {
     test("with multi sig payload", async () => {
       const transaction = await aptos.generateTransaction({
         sender: senderAccount.accountAddress.toString(),
-        feePayerAddress: feePayerAccount.accountAddress.toString(),
+        hasSponsor: true,
         data: {
           multisigAddress: secondarySignerAccount.accountAddress,
           function: "0x1::aptos_account::transfer",
@@ -141,7 +141,7 @@ describe("generate transaction", () => {
       });
       expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses?.length).toBe(0);
-      expect(transaction.feePayerAddress).toStrictEqual(feePayerAccount.accountAddress);
+      expect(transaction.feePayerAddress).toStrictEqual(AccountAddress.ZERO);
       const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
@@ -151,7 +151,7 @@ describe("generate transaction", () => {
     test("with entry function transaction", async () => {
       const transaction = await aptos.generateTransaction({
         sender: senderAccount.accountAddress.toString(),
-        feePayerAddress: feePayerAccount.accountAddress.toString(),
+        hasSponsor: true,
         data: {
           function: "0x1::aptos_account::transfer",
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
@@ -159,7 +159,7 @@ describe("generate transaction", () => {
       });
       expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses?.length).toBe(0);
-      expect(transaction.feePayerAddress).toStrictEqual(feePayerAccount.accountAddress);
+      expect(transaction.feePayerAddress).toStrictEqual(AccountAddress.ZERO);
       const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
@@ -170,7 +170,7 @@ describe("generate transaction", () => {
       const transaction = await aptos.generateTransaction({
         sender: senderAccount.accountAddress.toString(),
         secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-        feePayerAddress: feePayerAccount.accountAddress.toString(),
+        hasSponsor: true,
         data: {
           function: "0x1::aptos_account::transfer",
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
@@ -178,7 +178,7 @@ describe("generate transaction", () => {
       });
       expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
       expect(transaction.secondarySignerAddresses![0]).toStrictEqual(secondarySignerAccount.accountAddress);
-      expect(transaction.feePayerAddress).toStrictEqual(feePayerAccount.accountAddress);
+      expect(transaction.feePayerAddress).toStrictEqual(AccountAddress.ZERO);
       const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
       const deserializedTransaction = RawTransaction.deserialize(deserializer);
       expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();

--- a/tests/e2e/transaction/generateTransaction.test.ts
+++ b/tests/e2e/transaction/generateTransaction.test.ts
@@ -114,7 +114,7 @@ describe("generate transaction", () => {
     test("with script payload", async () => {
       const transaction = await aptos.generateTransaction({
         sender: senderAccount.accountAddress.toString(),
-        hasSponsor: true,
+        hasFeePayer: true,
         data: {
           bytecode: singleSignerScriptBytecode,
           functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -132,7 +132,7 @@ describe("generate transaction", () => {
     test("with multi sig payload", async () => {
       const transaction = await aptos.generateTransaction({
         sender: senderAccount.accountAddress.toString(),
-        hasSponsor: true,
+        hasFeePayer: true,
         data: {
           multisigAddress: secondarySignerAccount.accountAddress,
           function: "0x1::aptos_account::transfer",
@@ -151,7 +151,7 @@ describe("generate transaction", () => {
     test("with entry function transaction", async () => {
       const transaction = await aptos.generateTransaction({
         sender: senderAccount.accountAddress.toString(),
-        hasSponsor: true,
+        hasFeePayer: true,
         data: {
           function: "0x1::aptos_account::transfer",
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],
@@ -170,7 +170,7 @@ describe("generate transaction", () => {
       const transaction = await aptos.generateTransaction({
         sender: senderAccount.accountAddress.toString(),
         secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-        hasSponsor: true,
+        hasFeePayer: true,
         data: {
           function: "0x1::aptos_account::transfer",
           functionArguments: [recieverAccounts[0].accountAddress, new U64(1)],

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -118,6 +118,7 @@ export const rawTransactionMultiAgentHelper = async (
 ): Promise<UserTransactionResponse> => {
   const transactionData: InputGenerateTransactionData = {
     sender: senderAccount.accountAddress.toString(),
+    hasSponsor: false,
     data: {
       function: `${senderAccount.accountAddress.toString()}::tx_args_module::${functionName}`,
       typeArguments: typeArgs,

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -116,16 +116,17 @@ export const rawTransactionMultiAgentHelper = async (
   secondarySignerAccounts: Array<Account>,
   feePayerAccount?: Account,
 ): Promise<UserTransactionResponse> => {
+  const hasSponsor = feePayerAccount !== undefined;
+
   const transactionData: InputGenerateTransactionData = {
     sender: senderAccount.accountAddress.toString(),
-    hasSponsor: false,
+    hasSponsor,
     data: {
       function: `${senderAccount.accountAddress.toString()}::tx_args_module::${functionName}`,
       typeArguments: typeArgs,
       functionArguments: args,
     },
     secondarySignerAddresses: secondarySignerAccounts?.map((account) => account.accountAddress.data),
-    feePayerAddress: feePayerAccount?.accountAddress.data,
   };
 
   const generatedTransaction = await aptos.generateTransaction(transactionData);
@@ -144,7 +145,7 @@ export const rawTransactionMultiAgentHelper = async (
 
   let feePayerAuthenticator;
   if (feePayerAccount !== undefined) {
-    feePayerAuthenticator = aptos.signTransaction({
+    feePayerAuthenticator = aptos.signTransactionAsPayer({
       signer: feePayerAccount,
       transaction: generatedTransaction,
     });

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -116,11 +116,11 @@ export const rawTransactionMultiAgentHelper = async (
   secondarySignerAccounts: Array<Account>,
   feePayerAccount?: Account,
 ): Promise<UserTransactionResponse> => {
-  const hasSponsor = feePayerAccount !== undefined;
+  const hasFeePayer = feePayerAccount !== undefined ? true : undefined;
 
   const transactionData: InputGenerateTransactionData = {
     sender: senderAccount.accountAddress.toString(),
-    hasSponsor,
+    hasFeePayer,
     data: {
       function: `${senderAccount.accountAddress.toString()}::tx_args_module::${functionName}`,
       typeArguments: typeArgs,
@@ -145,9 +145,10 @@ export const rawTransactionMultiAgentHelper = async (
 
   let feePayerAuthenticator;
   if (feePayerAccount !== undefined) {
-    feePayerAuthenticator = aptos.signTransactionAsPayer({
+    feePayerAuthenticator = aptos.signTransaction({
       signer: feePayerAccount,
       transaction: generatedTransaction,
+      asFeePayer: true,
     });
   }
 

--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -128,6 +128,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -145,6 +146,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -161,6 +163,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
@@ -180,6 +183,7 @@ describe("transaction simulation", () => {
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -306,6 +310,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -323,6 +328,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -339,6 +345,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
@@ -358,6 +365,7 @@ describe("transaction simulation", () => {
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -484,6 +492,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -501,6 +510,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -517,6 +527,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
@@ -536,6 +547,7 @@ describe("transaction simulation", () => {
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
           feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: false,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -557,38 +569,40 @@ describe("transaction simulation", () => {
         expect(response.success).toBeTruthy();
       });
 
-      test("with entry function payload and optional fee payer", async () => {
-        console.log("feePayerAccount", feePayerAccount.accountAddress.toString());
-        console.log("singleSignerED25519SenderAccount", singleSignerED25519SenderAccount.accountAddress.toString());
+      test(
+        "with entry function payload and optional fee payer",
+        async () => {
+          // Generate the transaction
+          const transaction = await aptos.generateTransaction({
+            sender: singleSignerED25519SenderAccount.accountAddress.toString(),
+            hasSponsor: true,
+            data: {
+              function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
+              functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+            },
+          });
 
-        // Generate the transaction
-        let transaction = await aptos.generateTransaction({
-          sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: "0x0",
-          data: {
-            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
-            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
-          },
-        });
+          // Sender signs the transaction
+          const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
 
-        // Sender signs the transaction
-        const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
-        
-        // Update fee payer address and sign the transaction
-        transaction.feePayerAddress = feePayerAccount.accountAddress;
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+          // Update fee payer address and sign the transaction
+          transaction.feePayerAddress = feePayerAccount.accountAddress;
+          const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
 
-        const response = await aptos.submitTransaction({
-          transaction,
-          senderAuthenticator,
-          secondarySignerAuthenticators: { feePayerAuthenticator: feePayerSignerAuthenticator },
-        });
+          // Submit the updated transaction, which includes the payer address
+          const response = await aptos.submitTransaction({
+            transaction,
+            senderAuthenticator,
+            secondarySignerAuthenticators: { feePayerAuthenticator: feePayerSignerAuthenticator },
+          });
 
-        await aptos.waitForTransaction({
-          transactionHash: response.hash
-        });
-        expect(response.signature?.type).toBe("fee_payer_signature");
-      }, longTestTimeout);
+          await aptos.waitForTransaction({
+            transactionHash: response.hash,
+          });
+          expect(response.signature?.type).toBe("fee_payer_signature");
+        },
+        longTestTimeout,
+      );
     });
   });
 });

--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -127,7 +127,7 @@ describe("transaction simulation", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -145,7 +145,7 @@ describe("transaction simulation", () => {
       test("with entry function payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -163,7 +163,7 @@ describe("transaction simulation", () => {
       test("with multisig payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
@@ -183,7 +183,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -310,7 +310,7 @@ describe("transaction simulation", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -328,7 +328,7 @@ describe("transaction simulation", () => {
       test("with entry function payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -346,7 +346,7 @@ describe("transaction simulation", () => {
       test("with multisig payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
@@ -366,7 +366,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -493,7 +493,7 @@ describe("transaction simulation", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -511,7 +511,7 @@ describe("transaction simulation", () => {
       test("with entry function payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
@@ -529,7 +529,7 @@ describe("transaction simulation", () => {
       test("with multisig payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
@@ -549,7 +549,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [

--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -127,13 +127,13 @@ describe("transaction simulation", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: singleSignerED25519SenderAccount.publicKey,
@@ -145,13 +145,14 @@ describe("transaction simulation", () => {
       test("with entry function payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
+
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: singleSignerED25519SenderAccount.publicKey,
           transaction: rawTxn,
@@ -162,14 +163,14 @@ describe("transaction simulation", () => {
       test("with multisig payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: singleSignerED25519SenderAccount.publicKey,
@@ -182,8 +183,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -195,6 +195,7 @@ describe("transaction simulation", () => {
             ],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: singleSignerED25519SenderAccount.publicKey,
@@ -309,13 +310,13 @@ describe("transaction simulation", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: singleSignerSecp256k1Account.publicKey,
@@ -327,13 +328,14 @@ describe("transaction simulation", () => {
       test("with entry function payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
+
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: singleSignerSecp256k1Account.publicKey,
           transaction: rawTxn,
@@ -344,14 +346,14 @@ describe("transaction simulation", () => {
       test("with multisig payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: singleSignerSecp256k1Account.publicKey,
@@ -364,8 +366,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -377,6 +378,7 @@ describe("transaction simulation", () => {
             ],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: singleSignerSecp256k1Account.publicKey,
@@ -491,13 +493,13 @@ describe("transaction simulation", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: legacyED25519SenderAccount.publicKey,
@@ -509,13 +511,14 @@ describe("transaction simulation", () => {
       test("with entry function payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
+
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: legacyED25519SenderAccount.publicKey,
           transaction: rawTxn,
@@ -526,14 +529,14 @@ describe("transaction simulation", () => {
       test("with multisig payload", async () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             multisigAddress: secondarySignerAccount.accountAddress,
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: legacyED25519SenderAccount.publicKey,
@@ -546,8 +549,7 @@ describe("transaction simulation", () => {
         const rawTxn = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
-          hasSponsor: false,
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -559,6 +561,7 @@ describe("transaction simulation", () => {
             ],
           },
         });
+        rawTxn.feePayerAddress = feePayerAccount.accountAddress;
 
         const [response] = await aptos.simulateTransaction({
           signerPublicKey: legacyED25519SenderAccount.publicKey,
@@ -568,41 +571,6 @@ describe("transaction simulation", () => {
         });
         expect(response.success).toBeTruthy();
       });
-
-      test(
-        "with entry function payload and optional fee payer",
-        async () => {
-          // Generate the transaction
-          const transaction = await aptos.generateTransaction({
-            sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-            hasSponsor: true,
-            data: {
-              function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
-              functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
-            },
-          });
-
-          // Sender signs the transaction
-          const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
-
-          // Update fee payer address and sign the transaction
-          transaction.feePayerAddress = feePayerAccount.accountAddress;
-          const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
-
-          // Submit the updated transaction, which includes the payer address
-          const response = await aptos.submitTransaction({
-            transaction,
-            senderAuthenticator,
-            secondarySignerAuthenticators: { feePayerAuthenticator: feePayerSignerAuthenticator },
-          });
-
-          await aptos.waitForTransaction({
-            transactionHash: response.hash,
-          });
-          expect(response.signature?.type).toBe("fee_payer_signature");
-        },
-        longTestTimeout,
-      );
     });
   });
 });

--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -556,6 +556,39 @@ describe("transaction simulation", () => {
         });
         expect(response.success).toBeTruthy();
       });
+
+      test("with entry function payload and optional fee payer", async () => {
+        console.log("feePayerAccount", feePayerAccount.accountAddress.toString());
+        console.log("singleSignerED25519SenderAccount", singleSignerED25519SenderAccount.accountAddress.toString());
+
+        // Generate the transaction
+        let transaction = await aptos.generateTransaction({
+          sender: singleSignerED25519SenderAccount.accountAddress.toString(),
+          feePayerAddress: "0x0",
+          data: {
+            function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
+            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+          },
+        });
+
+        // Sender signs the transaction
+        const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
+        
+        // Update fee payer address and sign the transaction
+        transaction.feePayerAddress = feePayerAccount.accountAddress;
+        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+
+        const response = await aptos.submitTransaction({
+          transaction,
+          senderAuthenticator,
+          secondarySignerAuthenticators: { feePayerAuthenticator: feePayerSignerAuthenticator },
+        });
+
+        await aptos.waitForTransaction({
+          transactionHash: response.hash
+        });
+        expect(response.signature?.type).toBe("fee_payer_signature");
+      }, longTestTimeout);
     });
   });
 });

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -157,7 +157,7 @@ describe("transaction submission", () => {
       test("with script payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
@@ -165,7 +165,11 @@ describe("transaction submission", () => {
         });
 
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -182,14 +186,18 @@ describe("transaction submission", () => {
       test("with entry function payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -207,7 +215,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -222,7 +230,11 @@ describe("transaction submission", () => {
 
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
         const secondarySignerAuthenticator = aptos.signTransaction({ signer: secondarySignerAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -351,7 +363,7 @@ describe("transaction submission", () => {
       test("with script payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
@@ -359,7 +371,11 @@ describe("transaction submission", () => {
         });
 
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerSecp256k1Account, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -376,14 +392,18 @@ describe("transaction submission", () => {
       test("with entry function payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerSecp256k1Account, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -401,7 +421,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -416,7 +436,11 @@ describe("transaction submission", () => {
 
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerSecp256k1Account, transaction });
         const secondarySignerAuthenticator = aptos.signTransaction({ signer: secondarySignerAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -545,7 +569,7 @@ describe("transaction submission", () => {
       test("with script payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
@@ -553,7 +577,11 @@ describe("transaction submission", () => {
         });
 
         const senderAuthenticator = aptos.signTransaction({ signer: legacyED25519SenderAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -570,14 +598,18 @@ describe("transaction submission", () => {
       test("with entry function payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const senderAuthenticator = aptos.signTransaction({ signer: legacyED25519SenderAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -595,7 +627,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          hasSponsor: true,
+          hasFeePayer: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -610,7 +642,11 @@ describe("transaction submission", () => {
 
         const senderAuthenticator = aptos.signTransaction({ signer: legacyED25519SenderAccount, transaction });
         const secondarySignerAuthenticator = aptos.signTransaction({ signer: secondarySignerAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransaction({
+          signer: feePayerAccount,
+          transaction,
+          asFeePayer: true,
+        });
 
         const response = await aptos.submitTransaction({
           transaction,

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -157,7 +157,7 @@ describe("transaction submission", () => {
       test("with script payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
@@ -165,7 +165,7 @@ describe("transaction submission", () => {
         });
 
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -182,14 +182,14 @@ describe("transaction submission", () => {
       test("with entry function payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -207,7 +207,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -222,7 +222,7 @@ describe("transaction submission", () => {
 
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerED25519SenderAccount, transaction });
         const secondarySignerAuthenticator = aptos.signTransaction({ signer: secondarySignerAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -351,7 +351,7 @@ describe("transaction submission", () => {
       test("with script payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
@@ -359,7 +359,7 @@ describe("transaction submission", () => {
         });
 
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerSecp256k1Account, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -376,14 +376,14 @@ describe("transaction submission", () => {
       test("with entry function payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerSecp256k1Account, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -401,7 +401,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: singleSignerSecp256k1Account.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -416,7 +416,7 @@ describe("transaction submission", () => {
 
         const senderAuthenticator = aptos.signTransaction({ signer: singleSignerSecp256k1Account, transaction });
         const secondarySignerAuthenticator = aptos.signTransaction({ signer: secondarySignerAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -545,7 +545,7 @@ describe("transaction submission", () => {
       test("with script payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             bytecode: singleSignerScriptBytecode,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
@@ -553,7 +553,7 @@ describe("transaction submission", () => {
         });
 
         const senderAuthenticator = aptos.signTransaction({ signer: legacyED25519SenderAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -570,14 +570,14 @@ describe("transaction submission", () => {
       test("with entry function payload", async () => {
         const transaction = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
             functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const senderAuthenticator = aptos.signTransaction({ signer: legacyED25519SenderAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,
@@ -595,7 +595,7 @@ describe("transaction submission", () => {
         const transaction = await aptos.generateTransaction({
           sender: legacyED25519SenderAccount.accountAddress.toString(),
           secondarySignerAddresses: [secondarySignerAccount.accountAddress.toString()],
-          feePayerAddress: feePayerAccount.accountAddress.toString(),
+          hasSponsor: true,
           data: {
             function: `${contractPublisherAccount.accountAddress.toString()}::transfer::two_by_two`,
             functionArguments: [
@@ -610,7 +610,7 @@ describe("transaction submission", () => {
 
         const senderAuthenticator = aptos.signTransaction({ signer: legacyED25519SenderAccount, transaction });
         const secondarySignerAuthenticator = aptos.signTransaction({ signer: secondarySignerAccount, transaction });
-        const feePayerSignerAuthenticator = aptos.signTransaction({ signer: feePayerAccount, transaction });
+        const feePayerSignerAuthenticator = aptos.signTransactionAsPayer({ signer: feePayerAccount, transaction });
 
         const response = await aptos.submitTransaction({
           transaction,


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

1. Added "hasSponsor" field to all `InputGenerateTransactionData`. If set to `true`, feepayer address will be overrided to "0x0".
2. Fee payer will have to use "signTransactionAsPayer" to sign the transaction.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

```
Test Suites: 38 passed, 38 total
Tests:       1 skipped, 450 passed, 451 total
Snapshots:   0 total
Time:        24.384 s, estimated 25 s
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->