### PR TITLE
Adds additional ANS contract APIs

### DIFF
--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -1,9 +1,17 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { RegisterNameParameters, getExpiration, getOwnerAddress, registerName } from "../internal/ans";
-import { InputSingleSignerTransaction } from "../transactions/types";
-import { MoveAddressType } from "../types";
+import { Account } from "../core";
+import {
+  RegisterNameParameters,
+  getExpiration,
+  getOwnerAddress,
+  registerName,
+  getPrimaryName,
+  setPrimaryName,
+} from "../internal/ans";
+import { InputGenerateTransactionOptions, InputSingleSignerTransaction } from "../transactions/types";
+import { HexInput, MoveAddressType } from "../types";
 import { AptosConfig } from "./aptosConfig";
 
 /**
@@ -30,6 +38,35 @@ export class ANS {
    */
   async getOwnerAddress(args: { name: string }): Promise<MoveAddressType | undefined> {
     return getOwnerAddress({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Retrieve the primary name for an account address.
+   *
+   * @param args.address - A HexInput (address) of the account
+   *
+   * @returns null if no primary name is set
+   * and an object {domainName: string, subdomainName?: string} if a primary name is set
+   *
+   */
+  async getPrimaryName(args: { address: HexInput }): ReturnType<typeof getPrimaryName> {
+    return getPrimaryName({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Sets the primary name for the sender's account.
+   *
+   * @param args.sender - The sender account
+   * @param args.name - A string of the name: primary, primary.apt, secondary.primary, secondary.primary.apt, etc.
+   *
+   * @returns SingleSignerTransaction
+   */
+  async setPrimaryName(args: {
+    sender: Account;
+    name: string;
+    options?: InputGenerateTransactionOptions;
+  }): ReturnType<typeof setPrimaryName> {
+    return setPrimaryName({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -46,8 +46,7 @@ export class ANS {
   /**
    * Retrieve the expiration time of a domain name or subdomain name.
    *
-   * @param args.domainName - A string of the domain name to retrieve
-   * @param args.subdomainName - A string of the subdomain name to retrieve
+   * @param args.name - A string of the name to retrieve
    *
    * @returns number as a unix timestamp in seconds.
    */
@@ -119,35 +118,31 @@ export class ANS {
   }
 
   /**
-   * Registers a new domain name
+   * Registers a new name
    *
    * ```ts
-   * // Example of building the transaction if the domain expires in 30 days
-   * // Notes, `valueOf` gives us milliseconds.
-   * const expirationTime = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).valueOf()
-   *
-   * // Build the transaction
-   * const txn = await aptos.ans.registerSubdomain({
-   *   domainName,
-   *   subdomainName,
-   *   expirationPolicy: "independent",
-   *   expirationDateInMillisecondsSinceEpoch: expirationTime,
-   *   transferable: true,
-   *   sender: alice,
-   *   targetAddress: bob.accountAddress.toString(),
-   *   toAddress: bob.accountAddress.toString(),
-   * })
+   * // An example of registering a subdomain name assuming def.apt is already registered
+   * // and belongs to the sender alice.
+   *  const txn = aptos.registerName({
+   *    sender: alice,
+   *    name: "abc.def.apt",
+   *    expiration: {
+   *      policy: "subdomain:independent",
+   *      expirationDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+   *    },
+   *  });
    * ```
    *
    * @param args.sender - The sender account
-   * @param args.name - A string or {domainName: string, subdomainName?: string} of the name to register. This
-   * can be inclusive or exclusive of the .apt suffix.
-   * Examples include: "xyz", "xyz.apt", "xyz.kyc.apt", {domainName: "xyz"}, {domainName: "kyc", subdomainName: "xyz"}.
+   * @param args.name - A string of the name to register. This can be inclusive or exclusive of the .apt suffix.
+   * Examples include: "xyz", "xyz.apt", "xyz.kyc.apt", etc.
    * @param args.expiration  - An object with the expiration policy of the name.
    * @param args.expiration.policy - 'domain' | 'subdomain:follow-domain' | 'subdomain:independent'
    * - domain: Years is required and the name will expire after the given number of years.
    * - subdomain:follow-domain: The name will expire at the same time as the domain name.
    * - subdomain:independent: The name will expire at the given date.
+   * @param args.expiration.expirationDate - A javascript date of when the subdomain will expire. Only applicable when
+   * the policy is set to 'subdomain:independent'.
    * @param args.transferable  - Determines if the subdomain being minted is soul-bound. Applicable only to subdomains.
    * @param args.targetAddress optional - The address the domain name will resolve to. If not provided,
    * the sender's address will be used.

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -11,6 +11,7 @@ import {
   setPrimaryName,
   getTargetAddress,
   setTargetAddress,
+  renewDomain,
 } from "../internal/ans";
 import { InputGenerateTransactionOptions, InputSingleSignerTransaction } from "../transactions/types";
 import { HexInput, MoveAddressType } from "../types";
@@ -157,5 +158,21 @@ export class ANS {
    */
   async registerName(args: Omit<RegisterNameParameters, "aptosConfig">): Promise<InputSingleSignerTransaction> {
     return registerName({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Renews a domain name
+   *
+   * Note: If a domain name was minted with V1 of the contract, it will automatically be upgraded to V2 via this transaction.
+   *
+   * @param args.sender - The sender account
+   * @param args.name - A string of the domain the subdomain will be under. The signer must be the domain owner.
+   * Subdomains cannot be renewed.
+   * @param args.years - The number of years to renew the name. Currently only one year is permitted.
+   *
+   * @returns SingleSignerTransaction
+   */
+  async renewDomain(args: { sender: Account; name: string; years: 1 }): Promise<InputSingleSignerTransaction> {
+    return renewDomain({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -9,6 +9,8 @@ import {
   registerName,
   getPrimaryName,
   setPrimaryName,
+  getTargetAddress,
+  setTargetAddress,
 } from "../internal/ans";
 import { InputGenerateTransactionOptions, InputSingleSignerTransaction } from "../transactions/types";
 import { HexInput, MoveAddressType } from "../types";
@@ -41,7 +43,53 @@ export class ANS {
   }
 
   /**
-   * Retrieve the primary name for an account address.
+   * Retrieve the expiration time of a domain name or subdomain name.
+   *
+   * @param args.domainName - A string of the domain name to retrieve
+   * @param args.subdomainName - A string of the subdomain name to retrieve
+   *
+   * @returns number as a unix timestamp in seconds.
+   */
+  async getExpiration(args: { name: string }): ReturnType<typeof getExpiration> {
+    return getExpiration({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Retrieve the expiration time of a domain name or subdomain name.
+   *
+   * @param args.name - A string of the name: primary, primary.apt, secondary.primary, secondary.primary.apt, etc.
+   *
+   * @returns MoveAddressType if the name has a target, undefined otherwise
+   */
+  async getTargetAddress(args: { name: string }): ReturnType<typeof getTargetAddress> {
+    return getTargetAddress({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Sets the target address for a domain name or subdomain name.
+   *
+   * @param args.name - A string of the name: primary, primary.apt, secondary.primary, secondary.primary.apt, etc.
+   * @param args.address - A HexInput of the address to set the domain or subdomain to
+   *
+   * @returns SingleSignerTransaction
+   */
+  async setTargetAddress(args: {
+    sender: Account;
+    name: string;
+    address: HexInput;
+  }): ReturnType<typeof setTargetAddress> {
+    return setTargetAddress({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Retrieve the primary name for an account address. Note, with the recent migration from
+   * ANS v1 to ANS v2, it is possible for an account to have two primary names, one for each version.
+   *
+   * For example, if the account address `0x1` has the primary name `aptos` in ANS v1 and `test` in ANS v2,
+   * this function will return `{v1: "aptos", v2: "test"}`.
+   *
+   * Similarly, if the account has a subdomain as their primary name in v2 without a primary name in v1
+   * (e.g. `test.aptos.apt`), this function will return `{v2: "test.aptos"}`.
    *
    * @param args.address - A HexInput (address) of the account
    *
@@ -67,18 +115,6 @@ export class ANS {
     options?: InputGenerateTransactionOptions;
   }): ReturnType<typeof setPrimaryName> {
     return setPrimaryName({ aptosConfig: this.config, ...args });
-  }
-
-  /**
-   * Retrieve the expiration time of a domain name or subdomain name.
-   *
-   * @param args.domainName - A string of the domain name to retrieve
-   * @param args.subdomainName - A string of the subdomain name to retrieve
-   *
-   * @returns number as a unix timestamp in seconds.
-   */
-  async getExpiration(args: { domainName: string; subdomainName?: string }): ReturnType<typeof getExpiration> {
-    return getExpiration({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { RegisterNameParameters, getOwnerAddress, registerName } from "../internal/ans";
+import { RegisterNameParameters, getExpiration, getOwnerAddress, registerName } from "../internal/ans";
 import { InputSingleSignerTransaction } from "../transactions/types";
 import { MoveAddressType } from "../types";
 import { AptosConfig } from "./aptosConfig";
@@ -33,7 +33,37 @@ export class ANS {
   }
 
   /**
-   * Registers a new domain or subdomain name
+   * Retrieve the expiration time of a domain name or subdomain name.
+   *
+   * @param args.domainName - A string of the domain name to retrieve
+   * @param args.subdomainName - A string of the subdomain name to retrieve
+   *
+   * @returns number as a unix timestamp in seconds.
+   */
+  async getExpiration(args: { domainName: string; subdomainName?: string }): ReturnType<typeof getExpiration> {
+    return getExpiration({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Registers a new domain name
+   *
+   * ```ts
+   * // Example of building the transaction if the domain expires in 30 days
+   * // Notes, `valueOf` gives us milliseconds.
+   * const expirationTime = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).valueOf()
+   *
+   * // Build the transaction
+   * const txn = await aptos.ans.registerSubdomain({
+   *   domainName,
+   *   subdomainName,
+   *   expirationPolicy: "independent",
+   *   expirationDateInMillisecondsSinceEpoch: expirationTime,
+   *   transferable: true,
+   *   sender: alice,
+   *   targetAddress: bob.accountAddress.toString(),
+   *   toAddress: bob.accountAddress.toString(),
+   * })
+   * ```
    *
    * @param args.sender - The sender account
    * @param args.name - A string or {domainName: string, subdomainName?: string} of the name to register. This

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -103,7 +103,7 @@ export class ANS {
    */
   async setPrimaryName(args: {
     sender: Account;
-    name: string;
+    name: string | null;
     options?: InputGenerateTransactionOptions;
   }): Promise<InputSingleSignerTransaction> {
     return setPrimaryName({ aptosConfig: this.config, ...args });

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -77,6 +77,7 @@ export class ANS {
     sender: Account;
     name: string;
     address: AccountAddressInput;
+    options?: InputGenerateTransactionOptions;
   }): Promise<InputSingleSignerTransaction> {
     return setTargetAddress({ aptosConfig: this.config, ...args });
   }
@@ -158,7 +159,12 @@ export class ANS {
    *
    * @returns SingleSignerTransaction
    */
-  async renewDomain(args: { sender: Account; name: string; years?: 1 }): Promise<InputSingleSignerTransaction> {
+  async renewDomain(args: {
+    sender: Account;
+    name: string;
+    years?: 1;
+    options?: InputGenerateTransactionOptions;
+  }): Promise<InputSingleSignerTransaction> {
     return renewDomain({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -82,20 +82,11 @@ export class ANS {
   }
 
   /**
-   * Retrieve the primary name for an account address. Note, with the recent migration from
-   * ANS v1 to ANS v2, it is possible for an account to have two primary names, one for each version.
-   *
-   * For example, if the account address `0x1` has the primary name `aptos` in ANS v1 and `test` in ANS v2,
-   * this function will return `{v1: "aptos", v2: "test"}`.
-   *
-   * Similarly, if the account has a subdomain as their primary name in v2 without a primary name in v1
-   * (e.g. `test.aptos.apt`), this function will return `{v2: "test.aptos"}`.
+   * Retrieve the primary name for an account address.
    *
    * @param args.address - A HexInput (address) of the account
    *
-   * @returns null if no primary name is set
-   * and an object {domainName: string, subdomainName?: string} if a primary name is set
-   *
+   * @returns a string if the account has a primary name, undefined otherwise
    */
   async getPrimaryName(args: { address: HexInput }): ReturnType<typeof getPrimaryName> {
     return getPrimaryName({ aptosConfig: this.config, ...args });

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account } from "../core";
+import { Account, AccountAddressInput } from "../core";
 import {
   RegisterNameParameters,
   getExpiration,
@@ -14,7 +14,7 @@ import {
   renewDomain,
 } from "../internal/ans";
 import { InputGenerateTransactionOptions, InputSingleSignerTransaction } from "../transactions/types";
-import { HexInput, MoveAddressType } from "../types";
+import { MoveAddressType } from "../types";
 import { AptosConfig } from "./aptosConfig";
 
 /**
@@ -50,7 +50,7 @@ export class ANS {
    *
    * @returns number as a unix timestamp in seconds.
    */
-  async getExpiration(args: { name: string }): ReturnType<typeof getExpiration> {
+  async getExpiration(args: { name: string }): Promise<number | undefined> {
     return getExpiration({ aptosConfig: this.config, ...args });
   }
 
@@ -61,7 +61,7 @@ export class ANS {
    *
    * @returns MoveAddressType if the name has a target, undefined otherwise
    */
-  async getTargetAddress(args: { name: string }): ReturnType<typeof getTargetAddress> {
+  async getTargetAddress(args: { name: string }): Promise<MoveAddressType | undefined> {
     return getTargetAddress({ aptosConfig: this.config, ...args });
   }
 
@@ -69,14 +69,14 @@ export class ANS {
    * Sets the target address for a domain name or subdomain name.
    *
    * @param args.name - A string of the name: primary, primary.apt, secondary.primary, secondary.primary.apt, etc.
-   * @param args.address - A HexInput of the address to set the domain or subdomain to
+   * @param args.address - A AccountAddressInput of the address to set the domain or subdomain to
    *
    * @returns SingleSignerTransaction
    */
   async setTargetAddress(args: {
     sender: Account;
     name: string;
-    address: HexInput;
+    address: AccountAddressInput;
   }): Promise<InputSingleSignerTransaction> {
     return setTargetAddress({ aptosConfig: this.config, ...args });
   }
@@ -84,11 +84,11 @@ export class ANS {
   /**
    * Retrieve the primary name for an account address.
    *
-   * @param args.address - A HexInput (address) of the account
+   * @param args.address - A AccountAddressInput (address) of the account
    *
    * @returns a string if the account has a primary name, undefined otherwise
    */
-  async getPrimaryName(args: { address: HexInput }): ReturnType<typeof getPrimaryName> {
+  async getPrimaryName(args: { address: AccountAddressInput }): Promise<string | undefined> {
     return getPrimaryName({ aptosConfig: this.config, ...args });
   }
 
@@ -158,7 +158,7 @@ export class ANS {
    *
    * @returns SingleSignerTransaction
    */
-  async renewDomain(args: { sender: Account; name: string; years: 1 }): Promise<InputSingleSignerTransaction> {
+  async renewDomain(args: { sender: Account; name: string; years?: 1 }): Promise<InputSingleSignerTransaction> {
     return renewDomain({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -77,7 +77,7 @@ export class ANS {
     sender: Account;
     name: string;
     address: HexInput;
-  }): ReturnType<typeof setTargetAddress> {
+  }): Promise<InputSingleSignerTransaction> {
     return setTargetAddress({ aptosConfig: this.config, ...args });
   }
 
@@ -113,7 +113,7 @@ export class ANS {
     sender: Account;
     name: string;
     options?: InputGenerateTransactionOptions;
-  }): ReturnType<typeof setPrimaryName> {
+  }): Promise<InputSingleSignerTransaction> {
     return setPrimaryName({ aptosConfig: this.config, ...args });
   }
 

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -327,3 +327,18 @@ export async function setTargetAddress(args: {
 
   return transaction as InputSingleSignerTransaction;
 }
+
+export async function getGracePeriodInSeconds(args: { aptosConfig: AptosConfig }): Promise<number> {
+  const { aptosConfig } = args;
+  const routerAddress = getRouterAddress(aptosConfig);
+
+  const res = await view({
+    aptosConfig,
+    payload: {
+      function: `${routerAddress}::config::reregistration_grace_sec`,
+      functionArguments: [],
+    },
+  });
+
+  return res[0] as number;
+}

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -253,11 +253,26 @@ export async function getPrimaryName(args: {
 export async function setPrimaryName(args: {
   aptosConfig: AptosConfig;
   sender: Account;
-  name: string;
+  name: string | null;
   options?: InputGenerateTransactionOptions;
 }): Promise<InputSingleSignerTransaction> {
   const { aptosConfig, sender, name, options } = args;
   const routerAddress = getRouterAddress(aptosConfig);
+
+  if (!name) {
+    const transaction = await generateTransaction({
+      aptosConfig,
+      sender: sender.accountAddress.toString(),
+      data: {
+        function: `${routerAddress}::router::clear_primary_name`,
+        functionArguments: [],
+      },
+      options,
+    });
+
+    return transaction as InputSingleSignerTransaction;
+  }
+
   const { domainName, subdomainName } = isValidANSName(name);
 
   const transaction = await generateTransaction({

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -81,8 +81,8 @@ function getRouterAddress(aptosConfig: AptosConfig): string {
   return address;
 }
 
-const Some = <T>(value: T): MoveValue => ({ vec: [value] } as any);
-const None = (): MoveValue => ({ vec: [] } as any);
+const Some = <T>(value: T): MoveValue => ({ vec: [value] }) as any;
+const None = (): MoveValue => ({ vec: [] }) as any;
 // != here is intentional, we want to check for null and undefined
 // eslint-disable-next-line eqeqeq
 const Option = <T>(value: T | undefined | null): MoveValue => (value != undefined ? Some(value) : None());

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -234,7 +234,7 @@ export async function getExpiration(args: { aptosConfig: AptosConfig; name: stri
 export async function getPrimaryName(args: {
   aptosConfig: AptosConfig;
   address: HexInput;
-}): Promise<null | { domainName: MoveAddressType; subdomainName?: MoveAddressType }> {
+}): Promise<string | undefined> {
   const { aptosConfig, address } = args;
   const routerAddress = getRouterAddress(aptosConfig);
 
@@ -249,9 +249,9 @@ export async function getPrimaryName(args: {
   const domainName = unwrapOption<MoveAddressType>(res[1]);
   const subdomainName = unwrapOption<MoveAddressType>(res[0]);
 
-  if (!domainName) return null;
+  if (!domainName) return undefined;
 
-  return { domainName, subdomainName };
+  return [subdomainName, domainName].filter(Boolean).join(".");
 }
 
 export async function setPrimaryName(args: {

--- a/tests/e2e/ans/ans.test.ts
+++ b/tests/e2e/ans/ans.test.ts
@@ -160,6 +160,14 @@ describe("ANS", () => {
         await aptos.registerName({
           name,
           sender: alice,
+          expiration: { policy: "domain" },
+        }),
+      ).toBeTruthy();
+
+      expect(
+        await aptos.registerName({
+          name,
+          sender: alice,
           expiration: { policy: "domain", years: 1 },
         }),
       ).toBeTruthy();
@@ -169,7 +177,7 @@ describe("ANS", () => {
           sender: alice,
           name,
           // Force the year to be absent
-          expiration: { policy: "domain" } as any,
+          expiration: { policy: "domain", years: 0 } as any,
         }),
       ).rejects.toThrow();
 
@@ -191,7 +199,7 @@ describe("ANS", () => {
         alice,
         await aptos.registerName({
           name,
-          expiration: { policy: "domain", years: 1 },
+          expiration: { policy: "domain" },
           sender: alice,
         }),
       );
@@ -207,7 +215,7 @@ describe("ANS", () => {
         alice,
         await aptos.registerName({
           name,
-          expiration: { policy: "domain", years: 1 },
+          expiration: { policy: "domain" },
           sender: alice,
           targetAddress: bob.accountAddress.toString(),
           toAddress: bob.accountAddress.toString(),
@@ -223,7 +231,7 @@ describe("ANS", () => {
         alice,
         await aptos.registerName({
           name: domainName,
-          expiration: { policy: "domain", years: 1 },
+          expiration: { policy: "domain" },
           sender: alice,
         }),
       );
@@ -247,7 +255,7 @@ describe("ANS", () => {
         alice,
         await aptos.registerName({
           name: domainName,
-          expiration: { policy: "domain", years: 1 },
+          expiration: { policy: "domain" },
           sender: alice,
         }),
       );
@@ -304,7 +312,7 @@ describe("ANS", () => {
         alice,
         await aptos.registerName({
           name,
-          expiration: { policy: "domain", years: 1 },
+          expiration: { policy: "domain" },
           sender: alice,
           targetAddress: alice.accountAddress.toString(),
           toAddress: alice.accountAddress.toString(),
@@ -333,7 +341,7 @@ describe("ANS", () => {
         alice,
         await aptos.registerName({
           name: domainName,
-          expiration: { policy: "domain", years: 1 },
+          expiration: { policy: "domain" },
           sender: alice,
         }),
       );
@@ -394,10 +402,7 @@ describe("ANS", () => {
     test("it sets and gets domain primary names", async () => {
       const name = domainName;
 
-      await signAndSubmit(
-        alice,
-        await aptos.registerName({ name, expiration: { policy: "domain", years: 1 }, sender: alice }),
-      );
+      await signAndSubmit(alice, await aptos.registerName({ name, expiration: { policy: "domain" }, sender: alice }));
 
       await signAndSubmit(alice, await aptos.setPrimaryName({ name, sender: alice }));
 
@@ -412,7 +417,7 @@ describe("ANS", () => {
 
       await signAndSubmit(
         alice,
-        await aptos.registerName({ name: tld, expiration: { policy: "domain", years: 1 }, sender: alice }),
+        await aptos.registerName({ name: tld, expiration: { policy: "domain" }, sender: alice }),
       );
 
       await signAndSubmit(
@@ -460,7 +465,7 @@ describe("ANS", () => {
         alice,
         await aptos.registerName({
           name,
-          expiration: { policy: "domain", years: 1 },
+          expiration: { policy: "domain" },
           sender: alice,
         }),
       );
@@ -471,7 +476,7 @@ describe("ANS", () => {
       const newExpirationDate = Math.floor(new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).valueOf() / 1000);
       await changeExpirationDate(1, newExpirationDate, name);
 
-      await signAndSubmit(alice, await aptos.renewDomain({ name, years: 1, sender: alice }));
+      await signAndSubmit(alice, await aptos.renewDomain({ name, sender: alice }));
 
       // We expect the renewed expiration time to be one year from tomorrow
       const expectedExpirationDate = newExpirationDate + 365 * 24 * 60 * 60;
@@ -489,7 +494,7 @@ describe("ANS", () => {
         alice,
         await aptos.registerName({
           name: tld,
-          expiration: { policy: "domain", years: 1 },
+          expiration: { policy: "domain" },
           sender: alice,
         }),
       );
@@ -503,7 +508,7 @@ describe("ANS", () => {
         }),
       );
 
-      expect(aptos.renewDomain({ name, years: 1, sender: alice })).rejects.toThrow();
+      expect(aptos.renewDomain({ name, sender: alice })).rejects.toThrow();
     });
   });
 });


### PR DESCRIPTION
### Description
This adds the remaining P0 contract APIs for ANS. There are a few indexer queries to pull in after this PR gets merged. The functions include:
* Registering a subdomain via `registerName`
* Setting and Getting primary name for an account `getPrimaryName` and `setPrimaryName`
* Setting and Getting target addresses for a name `getTargetAddress` and `setTargetAddress`
* Renewing a domain with `renewDomain`. **Note**, this is `Domain` and not `Name` as subdomains are not renewable.

**Note**: I am currently skipping one test for name renewal. I need to work with someone on the contract side to see what is going on. I think I might be missing one config variable when setting up the contract.

### Test Plan
E2E test suite

### Related Links
_na_