### PR TITLE
Add and use `indexed_type` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- `getAccountEventsByEventType` query uses new `indexed_type` indexed field to avoid rate limit
+
 ## 0.0.4 (2023-11-03)
 
 - [`Breaking`] Changed all instances of `AccountAddress.fromHexInput` to `AccountAddress.from` to accept AccountAddress as well

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -46,7 +46,7 @@ export async function getAccountEventsByEventType(args: {
 
   const whereCondition: EventsBoolExp = {
     account_address: { _eq: address },
-    type: { _eq: eventType },
+    indexed_type: { _eq: eventType },
   };
 
   const customOptions = {

--- a/src/internal/queries/getEvents.graphql
+++ b/src/internal/queries/getEvents.graphql
@@ -8,5 +8,6 @@ query getEvents($where_condition: events_bool_exp, $offset: Int, $limit: Int, $o
     transaction_block_height
     transaction_version
     type
+    indexed_type
   }
 }

--- a/src/types/generated/operations.ts
+++ b/src/types/generated/operations.ts
@@ -1,5 +1,23 @@
 import * as Types from "./types";
 
+export type TokenActivitiesFieldsFragment = {
+  after_value?: string | null;
+  before_value?: string | null;
+  entry_function_id_str?: string | null;
+  event_account_address: string;
+  event_index: any;
+  from_address?: string | null;
+  is_fungible_v2?: boolean | null;
+  property_version_v1: any;
+  to_address?: string | null;
+  token_amount: any;
+  token_data_id: string;
+  token_standard: string;
+  transaction_timestamp: any;
+  transaction_version: any;
+  type: string;
+};
+
 export type CurrentTokenOwnershipFieldsFragment = {
   token_standard: string;
   token_properties_mutated_v1?: any | null;
@@ -44,24 +62,6 @@ export type CurrentTokenOwnershipFieldsFragment = {
       uri: string;
     } | null;
   } | null;
-};
-
-export type TokenActivitiesFieldsFragment = {
-  after_value?: string | null;
-  before_value?: string | null;
-  entry_function_id_str?: string | null;
-  event_account_address: string;
-  event_index: any;
-  from_address?: string | null;
-  is_fungible_v2?: boolean | null;
-  property_version_v1: any;
-  to_address?: string | null;
-  token_amount: any;
-  token_data_id: string;
-  token_standard: string;
-  transaction_timestamp: any;
-  transaction_version: any;
-  type: string;
 };
 
 export type GetAccountCoinsCountQueryVariables = Types.Exact<{
@@ -431,6 +431,7 @@ export type GetEventsQuery = {
     transaction_block_height: any;
     transaction_version: any;
     type: string;
+    indexed_type: string;
   }>;
 };
 

--- a/src/types/generated/queries.ts
+++ b/src/types/generated/queries.ts
@@ -2,6 +2,25 @@ import * as Types from "./operations";
 
 import { GraphQLClient } from "graphql-request";
 import * as Dom from "graphql-request/dist/types.dom";
+export const TokenActivitiesFieldsFragmentDoc = `
+    fragment TokenActivitiesFields on token_activities_v2 {
+  after_value
+  before_value
+  entry_function_id_str
+  event_account_address
+  event_index
+  from_address
+  is_fungible_v2
+  property_version_v1
+  to_address
+  token_amount
+  token_data_id
+  token_standard
+  transaction_timestamp
+  transaction_version
+  type
+}
+    `;
 export const CurrentTokenOwnershipFieldsFragmentDoc = `
     fragment CurrentTokenOwnershipFields on current_token_ownerships_v2 {
   token_standard
@@ -47,25 +66,6 @@ export const CurrentTokenOwnershipFieldsFragmentDoc = `
       uri
     }
   }
-}
-    `;
-export const TokenActivitiesFieldsFragmentDoc = `
-    fragment TokenActivitiesFields on token_activities_v2 {
-  after_value
-  before_value
-  entry_function_id_str
-  event_account_address
-  event_index
-  from_address
-  is_fungible_v2
-  property_version_v1
-  to_address
-  token_amount
-  token_data_id
-  token_standard
-  transaction_timestamp
-  transaction_version
-  type
 }
     `;
 export const GetAccountCoinsCount = `
@@ -300,6 +300,7 @@ export const GetEvents = `
     transaction_block_height
     transaction_version
     type
+    indexed_type
   }
 }
     `;

--- a/src/types/generated/types.ts
+++ b/src/types/generated/types.ts
@@ -4628,6 +4628,7 @@ export type Events = {
   creation_number: Scalars["bigint"];
   data: Scalars["jsonb"];
   event_index: Scalars["bigint"];
+  indexed_type: Scalars["String"];
   sequence_number: Scalars["bigint"];
   transaction_block_height: Scalars["bigint"];
   transaction_version: Scalars["bigint"];
@@ -4648,6 +4649,7 @@ export type EventsBoolExp = {
   creation_number?: InputMaybe<BigintComparisonExp>;
   data?: InputMaybe<JsonbComparisonExp>;
   event_index?: InputMaybe<BigintComparisonExp>;
+  indexed_type?: InputMaybe<StringComparisonExp>;
   sequence_number?: InputMaybe<BigintComparisonExp>;
   transaction_block_height?: InputMaybe<BigintComparisonExp>;
   transaction_version?: InputMaybe<BigintComparisonExp>;
@@ -4660,6 +4662,7 @@ export type EventsOrderBy = {
   creation_number?: InputMaybe<OrderBy>;
   data?: InputMaybe<OrderBy>;
   event_index?: InputMaybe<OrderBy>;
+  indexed_type?: InputMaybe<OrderBy>;
   sequence_number?: InputMaybe<OrderBy>;
   transaction_block_height?: InputMaybe<OrderBy>;
   transaction_version?: InputMaybe<OrderBy>;
@@ -4676,6 +4679,8 @@ export enum EventsSelectColumn {
   Data = "data",
   /** column name */
   EventIndex = "event_index",
+  /** column name */
+  IndexedType = "indexed_type",
   /** column name */
   SequenceNumber = "sequence_number",
   /** column name */
@@ -4700,6 +4705,7 @@ export type EventsStreamCursorValueInput = {
   creation_number?: InputMaybe<Scalars["bigint"]>;
   data?: InputMaybe<Scalars["jsonb"]>;
   event_index?: InputMaybe<Scalars["bigint"]>;
+  indexed_type?: InputMaybe<Scalars["String"]>;
   sequence_number?: InputMaybe<Scalars["bigint"]>;
   transaction_block_height?: InputMaybe<Scalars["bigint"]>;
   transaction_version?: InputMaybe<Scalars["bigint"]>;


### PR DESCRIPTION
### Description

Add new `indexed_type` field for `events` query

https://aptos-org.slack.com/archives/C03MN5F7WUV/p1697815925868219

### Test Plan
`getAccountEventsByEventType` test is failing because localnet needs to be regenerate with the new field, @banool is working on it
https://aptos-org.slack.com/archives/C03MN5F7WUV/p1699286279415299?thread_ts=1697815925.868219&cid=C03MN5F7WUV

### Related Links
<!-- Please link to any relevant issues or pull requests! -->