### PR TITLE
Some fixes across the SDK

### DIFF
--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -32,8 +32,11 @@ export async function request<Req, Res>(options: ClientRequest<Req>, client: Cli
     "content-type": contentType ?? MimeType.JSON,
   };
 
-  if (overrides?.TOKEN) {
-    headers.Authorization = `Bearer ${overrides?.TOKEN}`;
+  // TODO - auth token is being used only for faucet, it breaks full node requests.
+  // Find a more sophisticated way than that but without the need to add the
+  // auth_token on every `aptos.fundAccount()` call
+  if (overrides?.AUTH_TOKEN && url.includes("faucet")) {
+    headers.Authorization = `Bearer ${overrides?.AUTH_TOKEN}`;
   }
 
   /*
@@ -98,8 +101,7 @@ export async function aptosRequest<Req, Res>(
 
   // If it is the shape of an AptosApiError, convert it properly
   if ("message" in response.data && "error_code" in response.data) {
-    const data = response.data as { message: string; error_code: string; vm_error_code?: string };
-    errorMessage = JSON.stringify(data);
+    errorMessage = JSON.stringify(response.data);
   } else if (result.status in errors) {
     // If it's not an API type, it must come form infra, these are prehandled
     errorMessage = errors[result.status];

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -74,7 +74,7 @@ export async function fetchEntryFunctionAbi(
 
   // Remove the signer arguments
   const first = findFirstNonSignerArg(functionAbi);
-  const params = [];
+  const params: TypeTag[] = [];
   for (let i = first; i < functionAbi.params.length; i += 1) {
     params.push(parseTypeTag(functionAbi.params[i], { allowGenerics: true }));
   }

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -139,10 +139,6 @@ export function generateTransactionPayloadWithABI(
 export function generateTransactionPayloadWithABI(
   args: InputGenerateTransactionPayloadData,
   functionAbi: EntryFunctionABI,
-): AnyTransactionPayloadInstance;
-export function generateTransactionPayloadWithABI(
-  args: InputGenerateTransactionPayloadData,
-  functionAbi: EntryFunctionABI,
 ): AnyTransactionPayloadInstance {
   if (isScriptDataInput(args)) {
     return generateTransactionPayloadScript(args);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -161,12 +161,14 @@ export interface PaginationArgs {
 /**
  * A configuration object we can pass with the request to the server.
  *
- * @param TOKEN - an auth token to send with the request
+ * @param AUTH_TOKEN - an auth token to send with a faucet request
+ * @param API_KEY - api key generated from developer portal {@link https://developers.aptoslabs.com/manage/api-keys}}
  * @param HEADERS - extra headers we want to send with the request
  * @param WITH_CREDENTIALS - whether to carry cookies. By default, it is set to true and cookies will be sent
  */
 export type ClientConfig = {
-  TOKEN?: string;
+  AUTH_TOKEN?: string;
+  API_KEY?: string;
   HEADERS?: Record<string, string | number | boolean>;
   WITH_CREDENTIALS?: boolean;
 };

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -65,7 +65,7 @@ describe("aptos request", () => {
 
   describe("token", () => {
     test(
-      "when token is set",
+      "should not set auth_token for full node requests",
       async () => {
         try {
           const response = await aptosRequest(
@@ -73,12 +73,12 @@ describe("aptos request", () => {
               url: `${NetworkToNodeAPI[config.network]}`,
               method: "GET",
               path: "accounts/0x1",
-              overrides: { TOKEN: "my-token" },
+              overrides: { AUTH_TOKEN: "my-token" },
               originMethod: "test when token is set",
             },
             config,
           );
-          expect(response.config.headers).toHaveProperty("authorization", "Bearer my-token");
+          expect(response.config.headers).not.toHaveProperty("authorization", "Bearer my-token");
         } catch (error: any) {
           // should not get here
           expect(true).toBe(false);


### PR DESCRIPTION
### Description
Some fixes to the SDK while working on the wallet adapter

1. Type `params` in remote abi fetch flow with `TypeTag[]`
2. Remove unneeded function overload
3. Rename TOKEN => AUTH_TOKEN 
4. Use AUTH_TOKEN only for faucet requests - need to find a nicer way here
5. Add API_KEY for future use


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->