### PR TITLE
Print logs from local testnet on failure for examples CI

### DIFF
--- a/.github/actions/run-examples/action.yaml
+++ b/.github/actions/run-examples/action.yaml
@@ -56,3 +56,8 @@ runs:
         timeout_minutes: 25
         # This runs all of the examples
         command: pnpm test
+
+    - name: Print local testnet logs on failure
+      shell: bash
+      if: failure()
+      run: cat ${{ runner.temp }}/local-testnet-logs.txt


### PR DESCRIPTION
The other action has this. Without it, you can't see why the local testnet failed to start / crashed.