### PR TITLE
Respect max gas amount value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+
 - [`Breaking`] Changed `ViewRequestData` to `InputViewRequestData`
+- Respect max gas amount value when generating a transaction
 
 ## 0.0.5 (2023-11-09)
 

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -232,7 +232,7 @@ export async function generateRawTransaction(args: {
   );
 
   const { maxGasAmount, gasUnitPrice, expireTimestamp } = {
-    maxGasAmount: BigInt(DEFAULT_MAX_GAS_AMOUNT),
+    maxGasAmount: options?.maxGasAmount ? BigInt(options.maxGasAmount) : BigInt(DEFAULT_MAX_GAS_AMOUNT),
     gasUnitPrice: BigInt(gasEstimate),
     expireTimestamp: BigInt(Math.floor(Date.now() / 1000) + DEFAULT_TXN_EXP_SEC_FROM_NOW),
     ...options,

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -204,6 +204,31 @@ describe("transaction builder", () => {
       expect(rawTxn instanceof RawTransaction).toBeTruthy();
       expect(rawTxn.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
     });
+
+    test("it uses the correct max gas amount value", async () => {
+      const alice = Account.generate();
+      await aptos.fundAccount({ accountAddress: alice.accountAddress.toString(), amount: FUND_AMOUNT });
+      const bob = Account.generate();
+      const payload = await generateTransactionPayload({
+        aptosConfig: config,
+        function: `${contractPublisherAccount.accountAddress.toString()}::transfer::transfer`,
+        functionArguments: [new U64(1), bob.accountAddress],
+      });
+      const rawTxnWithCustomMaxGasAmount = await generateRawTransaction({
+        aptosConfig: config,
+        sender: alice.accountAddress.toString(),
+        payload,
+        options: { maxGasAmount: 20 },
+      });
+      expect(rawTxnWithCustomMaxGasAmount.max_gas_amount).toBe(20n);
+
+      const rawTxnWithDefaultMaxGasAmount = await generateRawTransaction({
+        aptosConfig: config,
+        sender: alice.accountAddress.toString(),
+        payload,
+      });
+      expect(rawTxnWithDefaultMaxGasAmount.max_gas_amount).toBe(200000n);
+    });
   });
   describe("generate transaction", () => {
     test("it returns a serialized raw transaction", async () => {


### PR DESCRIPTION
### Description
Although we give the option to pass in `maxGasAmount` value when generating transaction, we dont respect it.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->