### PR TITLE
[Rename] Changing ViewRequestData => InputViewRequestData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- [`Breaking`] Changed `ViewRequestData` to `InputViewRequestData`
 
 ## 0.0.5 (2023-11-09)
 

--- a/examples/typescript/swap.ts
+++ b/examples/typescript/swap.ts
@@ -23,7 +23,7 @@ import {
   Network,
   NetworkToNetworkName,
   U64,
-  ViewRequestData,
+  InputViewRequestData,
 } from "@aptos-labs/ts-sdk";
 import { createInterface } from "readline";
 // Default to devnet, but allow for overriding
@@ -40,7 +40,7 @@ const getOptimalLpAmount = async (
   token1Addr: AccountAddress,
   token2Addr: AccountAddress,
 ): Promise<void> => {
-  const payload: ViewRequestData = {
+  const payload: InputViewRequestData = {
     function: `${swap.toString()}::router::optimal_liquidity_amounts`,
     functionArguments: [token1Addr.toString(), token2Addr.toString(), false, "200000", "300000", "200", "300"],
   };

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -21,7 +21,7 @@ import {
   LedgerVersion,
   MoveValue,
   TableItemRequest,
-  ViewRequestData,
+  InputViewRequestData,
 } from "../types";
 
 /**
@@ -133,7 +133,7 @@ export class General {
    *
    * @returns an array of Move values
    */
-  async view(args: { payload: ViewRequestData; options?: LedgerVersion }): Promise<Array<MoveValue>> {
+  async view(args: { payload: InputViewRequestData; options?: LedgerVersion }): Promise<Array<MoveValue>> {
     return view({ aptosConfig: this.config, ...args });
   }
 

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -21,7 +21,7 @@ import {
   MoveValue,
   TableItemRequest,
   ViewRequest,
-  ViewRequestData,
+  InputViewRequestData,
 } from "../types";
 import { GetChainTopUserTransactionsQuery, GetProcessorStatusQuery } from "../types/generated/operations";
 import { GetChainTopUserTransactions, GetProcessorStatus } from "../types/generated/queries";
@@ -85,7 +85,7 @@ export async function getTableItem<T>(args: {
 
 export async function view(args: {
   aptosConfig: AptosConfig;
-  payload: ViewRequestData;
+  payload: InputViewRequestData;
   options?: LedgerVersion;
 }): Promise<MoveValue[]> {
   const { aptosConfig, payload, options } = args;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -893,7 +893,7 @@ export type Block = {
 /**
  * The data needed to generate a View Request payload
  */
-export type ViewRequestData = {
+export type InputViewRequestData = {
   function: MoveStructType;
   typeArguments?: Array<MoveStructType>;
   functionArguments?: Array<MoveValue>;

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig, Aptos, Network, GraphqlQuery, ViewRequestData } from "../../../src";
+import { AptosConfig, Aptos, Network, GraphqlQuery, InputViewRequestData } from "../../../src";
 
 describe("general api", () => {
   test("it fetches ledger info", async () => {
@@ -38,7 +38,7 @@ describe("general api", () => {
     const config = new AptosConfig({ network: Network.LOCAL });
     const aptos = new Aptos(config);
 
-    const payload: ViewRequestData = {
+    const payload: InputViewRequestData = {
       function: "0x1::chain_id::get",
     };
 


### PR DESCRIPTION
### Description
Renaming `ViewRequestData` to `InputViewRequestData` to adhere to our naming conventions

I mostly did this because I came across `ViewRequest` which seems to be the JSON payload response type from the node. Am I correct in my understanding @0xmaayan ?

### Test Plan
`pnpm jest`

Updated `CHANGELOG.md` as well to note that it's a breaking change