### PR TITLE
[Error message] Adding a clearer error message for when the typeTagParser encounters a generic but generics aren't allowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - [`Breaking`] Changed `ViewRequestData` to `InputViewRequestData`
 - Respect max gas amount value when generating a transaction
-- Added a clearer error message for when the typeTagParser encounters a possible generic TypeTag but generics are disabled
+- Added a clearer error message for when the typeTagParser encounters a possible generic TypeTag but generics are disallowed
 
 ## 0.0.5 (2023-11-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - [`Breaking`] Changed `ViewRequestData` to `InputViewRequestData`
 - Respect max gas amount value when generating a transaction
+- Added a clearer error message for when the typeTagParser encounters a possible generic TypeTag but generics are disabled
 
 ## 0.0.5 (2023-11-09)
 

--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -54,7 +54,7 @@ type TypeTagState = {
 
 export enum TypeTagParserErrorType {
   InvalidTypeTag = "unknown type",
-  InvalidButPossiblyGeneric = "unknown type. Did you mean to enable generics?",
+  InvalidButPossiblyGeneric = "unknown type. Did you mean to allow generics?",
   UnexpectedTypeArgumentClose = "unexpected '>'",
   UnexpectedWhitespaceCharacter = "unexpected whitespace character",
   UnexpectedComma = "unexpected ','",

--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -267,15 +267,15 @@ function parseTypeTagInner(str: string, types: Array<TypeTag>, allowGenerics: bo
       }
       return new TypeTagVector(types[0]);
     default:
-      if (allowGenerics && isGeneric(str)) {
-        return new TypeTagGeneric(Number(str.split("T")[1]));
+      if (isGeneric(str)) {
+        if (allowGenerics) {
+          return new TypeTagGeneric(Number(str.split("T")[1]));
+        }
+        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedGenericType);
       }
 
       // If the value doesn't contain a colon, then we'll assume it isn't trying to be a struct
       if (!str.match(/.*:.*/)) {
-        if (isGeneric(str)) {
-          throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedGenericType);
-        }
         throw new TypeTagParserError(str, TypeTagParserErrorType.InvalidTypeTag);
       }
 

--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -54,7 +54,7 @@ type TypeTagState = {
 
 export enum TypeTagParserErrorType {
   InvalidTypeTag = "unknown type",
-  InvalidButPossiblyGeneric = "unknown type. Did you mean to allow generics?",
+  UnexpectedGenericType = "unexpected generic type",
   UnexpectedTypeArgumentClose = "unexpected '>'",
   UnexpectedWhitespaceCharacter = "unexpected whitespace character",
   UnexpectedComma = "unexpected ','",
@@ -274,7 +274,7 @@ function parseTypeTagInner(str: string, types: Array<TypeTag>, allowGenerics: bo
       // If the value doesn't contain a colon, then we'll assume it isn't trying to be a struct
       if (!str.match(/.*:.*/)) {
         if (isGeneric(str)) {
-          throw new TypeTagParserError(str, TypeTagParserErrorType.InvalidButPossiblyGeneric);
+          throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedGenericType);
         }
         throw new TypeTagParserError(str, TypeTagParserErrorType.InvalidTypeTag);
       }

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -51,7 +51,7 @@ describe("TypeTagParser", () => {
     typeTagParserError("&address", TypeTagParserErrorType.InvalidTypeTag);
 
     // Standalone generic (with allow generics off)
-    typeTagParserError("T1", TypeTagParserErrorType.InvalidTypeTag);
+    typeTagParserError("T1", TypeTagParserErrorType.InvalidButPossiblyGeneric);
 
     // Not enough colons
     typeTagParserError("0x1:tag::Tag", TypeTagParserErrorType.UnexpectedStructFormat);

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -51,7 +51,7 @@ describe("TypeTagParser", () => {
     typeTagParserError("&address", TypeTagParserErrorType.InvalidTypeTag);
 
     // Standalone generic (with allow generics off)
-    typeTagParserError("T1", TypeTagParserErrorType.InvalidButPossiblyGeneric);
+    typeTagParserError("T1", TypeTagParserErrorType.UnexpectedGenericType);
 
     // Not enough colons
     typeTagParserError("0x1:tag::Tag", TypeTagParserErrorType.UnexpectedStructFormat);


### PR DESCRIPTION
### Description
While using the `typeTagParser(...)` function, I was getting this error:

```shell
TypeTagParserError: Failed to parse typeTag 'T0', unknown type.
```

I added a clearer error message if the string matches a generic type but generics are disallowed:

```shell
TypeTagParserError: Failed to parse typeTag 'T0', unexpected generic type.
```

Updated the tests

```shell
pnpm jest typeTagParser.test.ts
```
