### PR TITLE
[examples] Add typescript-esm to CI, ignore build artifacts in lint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,4 @@
 dist/**
 node_modules/**
+**/dist/**
+**/node_modules/**

--- a/.github/actions/run-examples/action.yaml
+++ b/.github/actions/run-examples/action.yaml
@@ -57,6 +57,25 @@ runs:
       if: failure()
       run: cat ${{ runner.temp }}/local-testnet-logs.txt
 
+    # Run the typescript-esm examples
+    - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+      name: sdk-pnpm-examples
+      env:
+        # This is important, it ensures that the tempdir we create for cloning the ANS
+        # repo and mounting it into the CLI container is created in a location that
+        # actually supports mounting. Learn more here: https://stackoverflow.com/a/76523941/3846032.
+        TMPDIR: ${{ runner.temp }}
+        APTOS_NETWORK: local
+      with:
+        max_attempts: 3
+        timeout_minutes: 25
+        command: cd examples/typescript-esm && pnpm install && pnpm test
+
+    - name: Print local testnet logs on failure
+      shell: bash
+      if: failure()
+      run: cat ${{ runner.temp }}/local-testnet-logs.txt
+
     # Run the javascript examples
     - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
       name: sdk-pnpm-examples

--- a/examples/typescript-esm/.npmrc
+++ b/examples/typescript-esm/.npmrc
@@ -1,0 +1,2 @@
+auto-install-peers=true
+strict-peer-dependencies=false

--- a/examples/typescript-esm/pnpm-lock.yaml
+++ b/examples/typescript-esm/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '6.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 dependencies:


### PR DESCRIPTION
### Description
- Typescript-esm examples had to be added manually, and now are there
- Ignoring build artifacts that if left around from examples would cause lint to fail

### Test Plan
Built locally, tested the build artifacts accordingly.

Examples will be tested in the CI for this PR.
