### PR TITLE
[MoveValue] Cleanup types to match the proper types

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -13,7 +13,7 @@ import {
   LedgerVersion,
   MoveModuleBytecode,
   MoveResource,
-  MoveStructType,
+  MoveStructId,
   OrderBy,
   PaginationArgs,
   TokenStandard,
@@ -174,7 +174,7 @@ export class Account {
    */
   async getAccountResource<T extends {} = any>(args: {
     accountAddress: AccountAddressInput;
-    resourceType: MoveStructType;
+    resourceType: MoveStructId;
     options?: LedgerVersion;
   }): Promise<T> {
     return getResource<T>({ aptosConfig: this.config, ...args });

--- a/src/api/coin.ts
+++ b/src/api/coin.ts
@@ -5,7 +5,7 @@ import { AptosConfig } from "./aptosConfig";
 import { Account, AccountAddressInput } from "../core";
 import { transferCoinTransaction } from "../internal/coin";
 import { InputSingleSignerTransaction, InputGenerateTransactionOptions } from "../transactions/types";
-import { AnyNumber, MoveStructType } from "../types";
+import { AnyNumber, MoveStructId } from "../types";
 
 /**
  * A class to handle all `Coin` operations
@@ -31,7 +31,7 @@ export class Coin {
     sender: Account;
     recipient: AccountAddressInput;
     amount: AnyNumber;
-    coinType?: MoveStructType;
+    coinType?: MoveStructId;
     options?: InputGenerateTransactionOptions;
   }): Promise<InputSingleSignerTransaction> {
     return transferCoinTransaction({ aptosConfig: this.config, ...args });

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -3,7 +3,7 @@
 
 import { AptosConfig } from "./aptosConfig";
 import { getAccountEventsByCreationNumber, getAccountEventsByEventType, getEvents } from "../internal/event";
-import { AnyNumber, GetEventsResponse, MoveStructType, OrderBy, PaginationArgs } from "../types";
+import { AnyNumber, GetEventsResponse, MoveStructId, OrderBy, PaginationArgs } from "../types";
 import { EventsBoolExp } from "../types/generated/types";
 import { AccountAddressInput } from "../core";
 
@@ -42,7 +42,7 @@ export class Event {
    */
   async getAccountEventsByEventType(args: {
     accountAddress: AccountAddressInput;
-    eventType: MoveStructType;
+    eventType: MoveStructId;
     options?: {
       pagination?: PaginationArgs;
       orderBy?: OrderBy<GetEventsResponse[0]>;

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -24,7 +24,7 @@ import {
   LedgerVersion,
   MoveModuleBytecode,
   MoveResource,
-  MoveStructType,
+  MoveStructId,
   OrderBy,
   PaginationArgs,
   SigningScheme,
@@ -165,7 +165,7 @@ export async function getResources(args: {
 export async function getResource<T extends {}>(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  resourceType: MoveStructType;
+  resourceType: MoveStructId;
   options?: LedgerVersion;
 }): Promise<T> {
   const { aptosConfig, accountAddress, resourceType, options } = args;

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -2,7 +2,7 @@ import { AptosConfig } from "../api/aptosConfig";
 import { U64 } from "../bcs/serializable/movePrimitives";
 import { Account, AccountAddress, AccountAddressInput } from "../core";
 import { InputGenerateTransactionOptions, InputSingleSignerTransaction } from "../transactions/types";
-import { AnyNumber, MoveStructType } from "../types";
+import { AnyNumber, MoveStructId } from "../types";
 import { APTOS_COIN } from "../utils/const";
 import { generateTransaction } from "./transactionSubmission";
 import { parseTypeTag } from "../transactions/typeTag/parser";
@@ -12,7 +12,7 @@ export async function transferCoinTransaction(args: {
   sender: Account;
   recipient: AccountAddressInput;
   amount: AnyNumber;
-  coinType?: MoveStructType;
+  coinType?: MoveStructId;
   options?: InputGenerateTransactionOptions;
 }): Promise<InputSingleSignerTransaction> {
   const { aptosConfig, sender, recipient, amount, coinType, options } = args;

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -10,7 +10,7 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import { AccountAddress, AccountAddressInput } from "../core";
-import { AnyNumber, GetEventsResponse, PaginationArgs, MoveStructType, OrderBy } from "../types";
+import { AnyNumber, GetEventsResponse, PaginationArgs, MoveStructId, OrderBy } from "../types";
 import { GetEventsQuery } from "../types/generated/operations";
 import { GetEvents } from "../types/generated/queries";
 import { EventsBoolExp } from "../types/generated/types";
@@ -35,7 +35,7 @@ export async function getAccountEventsByCreationNumber(args: {
 export async function getAccountEventsByEventType(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  eventType: MoveStructType;
+  eventType: MoveStructId;
   options?: {
     pagination?: PaginationArgs;
     orderBy?: OrderBy<GetEventsResponse[0]>;

--- a/src/transactions/transactionBuilder/helpers.ts
+++ b/src/transactions/transactionBuilder/helpers.ts
@@ -10,7 +10,7 @@ import {
 } from "../types";
 import { Bool, FixedBytes, MoveString, U128, U16, U256, U32, U64, U8 } from "../../bcs";
 import { AccountAddress } from "../../core";
-import { MoveFunction, MoveStructType } from "../../types";
+import { MoveFunction, MoveFunctionId } from "../../types";
 
 export function isBool(arg: SimpleEntryFunctionArgumentTypes): arg is boolean {
   return typeof arg === "boolean";
@@ -91,7 +91,7 @@ export function findFirstNonSignerArg(functionAbi: MoveFunction): number {
   return index;
 }
 
-export function getFunctionParts(functionArg: MoveStructType) {
+export function getFunctionParts(functionArg: MoveFunctionId) {
   const funcNameParts = functionArg.split("::");
   if (funcNameParts.length !== 3) {
     throw new Error(`Invalid function ${functionArg}`);

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -15,7 +15,7 @@ import {
   TransactionPayloadMultisig,
   TransactionPayloadScript,
 } from "./instances";
-import { AnyNumber, HexInput, MoveFunctionGenericTypeParam, MoveStructType } from "../types";
+import { AnyNumber, HexInput, MoveFunctionGenericTypeParam, MoveFunctionId } from "../types";
 import { TypeTag } from "./typeTag";
 import { AccountAuthenticator } from "./authenticator/account";
 
@@ -105,7 +105,7 @@ export type InputGenerateTransactionPayloadDataWithRemoteABI =
  * The data needed to generate an Entry Function payload
  */
 export type InputEntryFunctionData = {
-  function: MoveStructType;
+  function: MoveFunctionId;
   typeArguments?: Array<TypeTag | string>;
   functionArguments: Array<EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes>;
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -252,7 +252,7 @@ export type GasEstimation = {
 };
 
 export type MoveResource = {
-  type: MoveStructType;
+  type: MoveStructId;
   data: {};
 };
 
@@ -521,7 +521,7 @@ export type TransactionPayloadResponse = EntryFunctionPayloadResponse | ScriptPa
 
 export type EntryFunctionPayloadResponse = {
   type: string;
-  function: MoveStructType;
+  function: MoveFunctionId;
   /**
    * Type arguments of the function
    */
@@ -686,7 +686,13 @@ export type MoveOptionType = MoveType | null | undefined;
 /**
  * This is the format for a fully qualified struct, resource, or entry function in Move.
  */
-export type MoveStructType = `${string}::${string}::${string}`;
+export type MoveStructId = `${string}::${string}::${string}`;
+// These are the same, unfortunately, it reads really strangely to take a StructId for a Function and there wasn't a
+// good middle ground name.
+export type MoveFunctionId = MoveStructId;
+
+// TODO: Add support for looking up ABI to add proper typing
+export type MoveStructType = {};
 
 export type MoveType =
   | boolean
@@ -736,7 +742,7 @@ export type MoveValue =
   | MoveUint256Type
   | MoveAddressType
   | MoveObjectType
-  | MoveStructType
+  | MoveStructId
   | MoveOptionType
   | Array<MoveValue>;
 
@@ -894,8 +900,8 @@ export type Block = {
  * The data needed to generate a View Request payload
  */
 export type InputViewRequestData = {
-  function: MoveStructType;
-  typeArguments?: Array<MoveStructType>;
+  function: MoveFunctionId;
+  typeArguments?: Array<MoveStructId>;
   functionArguments?: Array<MoveValue>;
 };
 
@@ -904,14 +910,14 @@ export type InputViewRequestData = {
 /**
  * View request for the Move view function API
  *
- * `type MoveStructType = ${string}::${string}::${string}`;
+ * `type MoveFunctionId = ${string}::${string}::${string}`;
  */
 export type ViewRequest = {
-  function: MoveStructType;
+  function: MoveFunctionId;
   /**
    * Type arguments of the function
    */
-  type_arguments: Array<MoveStructType>;
+  typeArguments: Array<MoveStructId>;
   /**
    * Arguments of the function
    */


### PR DESCRIPTION
### Description
Struct types were not able to be used as MoveValue which breaks some use cases.  Additionally, the MoveStructType has been renamed to MoveStructId as there was some strange merging of the two.

### Test Plan
CI, but need to follow up with a full suite of tests on view function outputs.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->