### PR TITLE
[view] Add generic for typing view function outputs

### DIFF
--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -133,8 +133,8 @@ export class General {
    *
    * @returns an array of Move values
    */
-  async view(args: { payload: InputViewRequestData; options?: LedgerVersion }): Promise<Array<MoveValue>> {
-    return view({ aptosConfig: this.config, ...args });
+  async view<T extends Array<MoveValue>>(args: { payload: InputViewRequestData; options?: LedgerVersion }): Promise<T> {
+    return view<T>({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -83,11 +83,11 @@ export async function getTableItem<T>(args: {
   return response.data as T;
 }
 
-export async function view(args: {
+export async function view<T extends Array<MoveValue> = Array<MoveValue>>(args: {
   aptosConfig: AptosConfig;
   payload: InputViewRequestData;
   options?: LedgerVersion;
-}): Promise<MoveValue[]> {
+}): Promise<T> {
   const { aptosConfig, payload, options } = args;
   const { data } = await postAptosFullNode<ViewRequest, MoveValue[]>({
     aptosConfig,
@@ -100,7 +100,8 @@ export async function view(args: {
       arguments: payload.functionArguments ?? [],
     },
   });
-  return data;
+
+  return data as T;
 }
 
 export async function getChainTopUserTransactions(args: {


### PR DESCRIPTION
### Description
Similar to getResource, but typed accordingly with MoveValue[] as the default. Only types that extend that can be used.

### Test Plan
This adds a few view function input and output type tests.  Full tests will need a module properly published for it to work.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->