### PR TITLE
Respect api key header config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Respect `API_KEY` option in `clientConfig` when making indexer and/or fullnode queries
+
 ## 0.0.7 (2023-11-16)
 
 - Adds additional ANS APIs

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -38,6 +38,9 @@ export async function request<Req, Res>(options: ClientRequest<Req>, client: Cli
   if (overrides?.AUTH_TOKEN && url.includes("faucet")) {
     headers.Authorization = `Bearer ${overrides?.AUTH_TOKEN}`;
   }
+  if (overrides?.API_KEY && !url.includes("faucet")) {
+    headers.Authorization = `Bearer ${overrides?.API_KEY}`;
+  }
 
   /*
    * make a call using the @aptos-labs/aptos-client package
@@ -99,15 +102,14 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
 
   let errorMessage: string;
 
-  // If it is the shape of an AptosApiError, convert it properly
-  if ("message" in response.data && "error_code" in response.data) {
-    errorMessage = JSON.stringify(response.data);
+  if (result && result.data && "message" in result.data && "error_code" in result.data) {
+    errorMessage = JSON.stringify(result.data);
   } else if (result.status in errors) {
     // If it's not an API type, it must come form infra, these are prehandled
     errorMessage = errors[result.status];
   } else {
     // Everything else is unhandled
-    errorMessage = `Unhandled Error ${response.status} : ${response.statusText}`;
+    errorMessage = `Unhandled Error ${result.status} : ${result.statusText}`;
   }
 
   throw new AptosApiError(options, result, errorMessage);

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -110,6 +110,31 @@ describe("aptos request", () => {
     );
   });
 
+  describe("api key", () => {
+    test(
+      "should set api_token for full node requests",
+      async () => {
+        try {
+          const response = await aptosRequest(
+            {
+              url: `${NetworkToNodeAPI[config.network]}`,
+              method: "GET",
+              path: "accounts/0x1",
+              overrides: { API_KEY: "my-api-key" },
+              originMethod: "test when token is set",
+            },
+            config,
+          );
+          expect(response.config.headers).toHaveProperty("authorization", "Bearer my-api-key");
+        } catch (error: any) {
+          // should not get here
+          expect(true).toBe(false);
+        }
+      },
+      longTestTimeout,
+    );
+  });
+
   describe("full node", () => {
     describe("200 response", () => {
       test(


### PR DESCRIPTION
### Description
We recently add API_KEY to clientConfig but never really respect it. With this change, one can
```
const aptosConfig = new AptosConfig({
    network: Network.TESTNET,
    clientConfig: {
      API_KEY: "my-key",
    },
  });
```

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->