### PR TITLE
Unifies ANS dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - Respect `API_KEY` option in `clientConfig` when making indexer and/or fullnode queries
 
+Breaking:
+- Changes ANS date usage to consistently use epoch timestamps represented in milliseconds.
+  - `getExpiration`: Previously returned seconds, now returns milliseconds
+  - `registerName`: Argument `expiration.expirationDate` was previously a `Date` object, now it is an epoch timestamp represented in milliseconds
+  - All query functions return epoch milliseconds instead of ISO date strings.
+
 ## 0.0.7 (2023-11-16)
 
 - Adds additional ANS APIs

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -166,7 +166,7 @@ export class ANS {
    *    name: "test.aptos.apt",
    *    expiration: {
    *      policy: "subdomain:independent",
-   *      expirationDate: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+   *      expirationDate: Date.now() + 30 * 24 * 60 * 60 * 1000,
    *    },
    *  });
    * ```
@@ -179,8 +179,9 @@ export class ANS {
    * - domain: Years is required and the name will expire after the given number of years.
    * - subdomain:follow-domain: The name will expire at the same time as the domain name.
    * - subdomain:independent: The name will expire at the given date.
-   * @param args.expiration.expirationDate - A javascript date of when the subdomain will expire. Only applicable when
-   * the policy is set to 'subdomain:independent'.
+   * @param args.expiration.expirationDate - An epoch number in milliseconds of
+   * the date when the subdomain will expire. Only applicable when the policy is
+   * set to 'subdomain:independent'.
    * @param args.transferable  - Determines if the subdomain being minted is soul-bound. Applicable only to subdomains.
    * @param args.targetAddress optional - The address the domain name will resolve to. If not provided,
    * the sender's address will be used.

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -64,7 +64,7 @@ export class ANS {
    *
    * @param args.name - A string of the name to retrieve
    *
-   * @returns number as a unix timestamp in seconds.
+   * @returns number as a unix timestamp in milliseconds.
    */
   async getExpiration(args: { name: string }): Promise<number | undefined> {
     return getExpiration({ aptosConfig: this.config, ...args });

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -123,7 +123,7 @@ export interface RegisterNameParameters {
   expiration:
     | { policy: "domain"; years?: 1 }
     | { policy: "subdomain:follow-domain" }
-    | { policy: "subdomain:independent"; expirationDate: Date };
+    | { policy: "subdomain:independent"; expirationDate: number };
   transferable?: boolean;
   toAddress?: AccountAddressInput;
   targetAddress?: AccountAddressInput;
@@ -181,7 +181,7 @@ export async function registerName(args: RegisterNameParameters): Promise<Single
   }
 
   const expirationDateInMillisecondsSinceEpoch =
-    expiration.policy === "subdomain:independent" ? expiration.expirationDate.valueOf() : tldExpiration;
+    expiration.policy === "subdomain:independent" ? expiration.expirationDate : tldExpiration;
 
   if (expirationDateInMillisecondsSinceEpoch > tldExpiration) {
     throw new Error("The subdomain expiration time cannot be greater than the domain expiration time");

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -175,12 +175,10 @@ export async function registerName(args: RegisterNameParameters): Promise<Single
     throw new Error(`${expiration.policy} requires a subdomain to be provided.`);
   }
 
-  let tldExpiration = await getExpiration({ aptosConfig, name: domainName });
+  const tldExpiration = await getExpiration({ aptosConfig, name: domainName });
   if (!tldExpiration) {
     throw new Error("The domain does not exist");
   }
-  // The contract gives us seconds, but JS expects milliseconds
-  tldExpiration *= 1000;
 
   const expirationDateInMillisecondsSinceEpoch =
     expiration.policy === "subdomain:independent" ? expiration.expirationDate.valueOf() : tldExpiration;
@@ -224,7 +222,8 @@ export async function getExpiration(args: { aptosConfig: AptosConfig; name: stri
       },
     });
 
-    return res[0] as number;
+    // Normalize expiration time from epoch seconds to epoch milliseconds
+    return Number(res[0]) * 1000;
   } catch (e) {
     return undefined;
   }

--- a/tests/e2e/ans/ans.test.ts
+++ b/tests/e2e/ans/ans.test.ts
@@ -477,8 +477,6 @@ describe("ANS", () => {
         }),
       );
 
-      let res = await aptos.getExpiration({ name });
-
       // Change the expiration date of the name to be tomorrow
       const newExpirationDate = Math.floor(new Date(Date.now() + 1 * 24 * 60 * 60 * 1000).valueOf() / 1000);
       await changeExpirationDate(1, newExpirationDate, name);
@@ -486,8 +484,8 @@ describe("ANS", () => {
       await signAndSubmit(alice, await aptos.renewDomain({ name, sender: alice }));
 
       // We expect the renewed expiration time to be one year from tomorrow
-      const expectedExpirationDate = newExpirationDate + 365 * 24 * 60 * 60;
-      res = await aptos.getExpiration({ name });
+      const expectedExpirationDate = (newExpirationDate + 365 * 24 * 60 * 60) * 1000;
+      const res = await aptos.getExpiration({ name });
       expect(res?.toString()).toBe(expectedExpirationDate.toString());
     });
 

--- a/tests/e2e/ans/ans.test.ts
+++ b/tests/e2e/ans/ans.test.ts
@@ -274,7 +274,7 @@ describe("ANS", () => {
           expiration: {
             policy: "subdomain:independent",
             // Expire the subdomain two seconds before the TLD expires
-            expirationDate: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000 - 2000),
+            expirationDate: Date.now() + 365 * 24 * 60 * 60 * 1000 - 2000,
           },
           transferable: true,
           sender: alice,


### PR DESCRIPTION
### Description
ANS had 3 different implementations for times. This converts all uses of time to be milliseconds since the epoch. 

### Test Plan
Updated and passing test cases

### Related Links
https://aptos-org.slack.com/archives/C05NLAKJM9U/p1700245777573069
