### PR TITLE
Fix comment on getAccountResource

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -167,7 +167,7 @@ export class Account {
    * @example An example of an account resource
    * ```
    * {
-   *    data: { value: 6 }
+   *    value: 6
    * }
    * ```
    */


### PR DESCRIPTION
### Description
Comment is misleading, the SDK unwraps `data` and returns what is inside it.

### Test Plan
Tested manually, the output of the function is not keyed by `data`.