### PR TITLE
[refactor] Flatten options to be consistent across all, remove casts, fix imports and exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Respect `API_KEY` option in `clientConfig` when making indexer and/or fullnode queries
 - [`Added`] Added `waitForIndexer` function to wait for indexer to sync up with full node. All indexer query functions now accepts a new optional param `minimumLedgerVersion` to wait for indexer to sync up with the target processor.
 - Add `getSigningMessage` to allow users to sign transactions with external signers and other use cases
-
-Breaking:
-- Changes ANS date usage to consistently use epoch timestamps represented in milliseconds.
+- [`Breaking`] Changes ANS date usage to consistently use epoch timestamps represented in milliseconds.
   - `getExpiration`: Previously returned seconds, now returns milliseconds
   - `registerName`: Argument `expiration.expirationDate` was previously a `Date` object, now it is an epoch timestamp represented in milliseconds
   - All query functions return epoch milliseconds instead of ISO date strings.
+- [`Breaking`] Flatten options for all functions to be a single level
+- Cleanup internal usage of casting
+- Export AnyPublicKey and AnySignature types
 
 ## 0.0.7 (2023-11-16)
 

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -10,14 +10,15 @@ import {
   GetAccountOwnedObjectsResponse,
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
-  LedgerVersion,
+  LedgerVersionArg,
   MoveModuleBytecode,
   MoveResource,
   MoveStructId,
-  OrderBy,
+  OrderByArg,
   PaginationArgs,
-  TokenStandard,
+  TokenStandardArg,
   TransactionResponse,
+  WhereArg,
 } from "../types";
 import {
   deriveAccountFromPrivateKey,
@@ -84,7 +85,7 @@ export class Account {
 
   async getAccountModules(args: {
     accountAddress: AccountAddressInput;
-    options?: PaginationArgs & LedgerVersion;
+    options?: PaginationArgs & LedgerVersionArg;
   }): Promise<MoveModuleBytecode[]> {
     return getModules({ aptosConfig: this.config, ...args });
   }
@@ -109,7 +110,7 @@ export class Account {
   async getAccountModule(args: {
     accountAddress: AccountAddressInput;
     moduleName: string;
-    options?: LedgerVersion;
+    options?: LedgerVersionArg;
   }): Promise<MoveModuleBytecode> {
     return getModule({ aptosConfig: this.config, ...args });
   }
@@ -150,7 +151,7 @@ export class Account {
    */
   async getAccountResources(args: {
     accountAddress: AccountAddressInput;
-    options?: PaginationArgs & LedgerVersion;
+    options?: PaginationArgs & LedgerVersionArg;
   }): Promise<MoveResource[]> {
     return getResources({ aptosConfig: this.config, ...args });
   }
@@ -176,7 +177,7 @@ export class Account {
   async getAccountResource<T extends {} = any>(args: {
     accountAddress: AccountAddressInput;
     resourceType: MoveStructId;
-    options?: LedgerVersion;
+    options?: LedgerVersionArg;
   }): Promise<T> {
     return getResource<T>({ aptosConfig: this.config, ...args });
   }
@@ -194,7 +195,7 @@ export class Account {
   async lookupOriginalAccountAddress(args: {
     authenticationKey: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: LedgerVersion;
+    options?: LedgerVersionArg;
   }): Promise<AccountAddress> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -236,19 +237,15 @@ export class Account {
    * @param args.accountAddress The account address we want to get the tokens for
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
    * @param args.options.tokenStandard The NFT standard to query for
-   * @param args.options.pagination.offset The number token to start returning results from
-   * @param args.options.pagination.limit The number of results to return
+   * @param args.options.offset The number token to start returning results from
+   * @param args.options.limit The number of results to return
    * @param args.options.orderBy The order to sort the tokens by
    * @returns Tokens array with the token data
    */
   async getAccountOwnedTokens(args: {
     accountAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      tokenStandard?: TokenStandard;
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetAccountOwnedTokensQueryResponse[0]>;
-    };
+    options?: TokenStandardArg & PaginationArgs & OrderByArg<GetAccountOwnedTokensQueryResponse[0]>;
   }): Promise<GetAccountOwnedTokensQueryResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -271,8 +268,8 @@ export class Account {
    * @param args.collectionAddress The address of the collection being queried
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
    * @param args.options.tokenStandard The NFT standard to query for
-   * @param args.options.pagination.offset The number token to start returning results from
-   * @param args.options.pagination.limit The number of results to return
+   * @param args.options.offset The number token to start returning results from
+   * @param args.options.limit The number of results to return
    * @param args.options.orderBy The order to sort the tokens by
    * @returns Tokens array with the token data
    */
@@ -280,11 +277,7 @@ export class Account {
     accountAddress: AccountAddressInput;
     collectionAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      tokenStandard?: TokenStandard;
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetAccountOwnedTokensFromCollectionResponse[0]>;
-    };
+    options?: TokenStandardArg & PaginationArgs & OrderByArg<GetAccountOwnedTokensFromCollectionResponse[0]>;
   }): Promise<GetAccountOwnedTokensFromCollectionResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -306,19 +299,15 @@ export class Account {
    * @param args.accountAddress The account address we want to get the collections for
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
    * @param args.options.tokenStandard The NFT standard to query for
-   * @param args.options.pagination.offset The number collection to start returning results from
-   * @param args.options.pagination.limit The number of results to return
+   * @param args.options.offset The number collection to start returning results from
+   * @param args.options.limit The number of results to return
    * @param args.options.orderBy The order to sort the tokens by
    * @returns Collections array with the collections data
    */
   async getAccountCollectionsWithOwnedTokens(args: {
     accountAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      tokenStandard?: TokenStandard;
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetAccountCollectionsWithOwnedTokenResponse[0]>;
-    };
+    options?: TokenStandardArg & PaginationArgs & OrderByArg<GetAccountCollectionsWithOwnedTokenResponse[0]>;
   }): Promise<GetAccountCollectionsWithOwnedTokenResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -358,8 +347,8 @@ export class Account {
    *
    * @param args.accountAddress The account address we want to get the coins data for
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
-   * @param args.options.pagination.offset optional. The number coin to start returning results from
-   * @param args.options.pagination.limit optional. The number of results to return
+   * @param args.options.offset optional. The number coin to start returning results from
+   * @param args.options.limit optional. The number of results to return
    * @param args.options.orderBy optional. The order to sort the coins by
    * @param args.options.where optional. Filter the results by
    * @returns Array with the coins data
@@ -367,11 +356,9 @@ export class Account {
   async getAccountCoinsData(args: {
     accountAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetAccountCoinsDataResponse[0]>;
-      where?: CurrentFungibleAssetBalancesBoolExp;
-    };
+    options?: PaginationArgs &
+      OrderByArg<GetAccountCoinsDataResponse[0]> &
+      WhereArg<CurrentFungibleAssetBalancesBoolExp>;
   }): Promise<GetAccountCoinsDataResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -448,18 +435,15 @@ export class Account {
    *
    * @param args.accountAddress The account address we want to get the objects for
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
-   * @param args.options.pagination.offset The starting position to start returning results from
-   * @param args.options.pagination.limit The number of results to return
+   * @param args.options.offset The starting position to start returning results from
+   * @param args.options.limit The number of results to return
    * @param args.options.orderBy The order to sort the objects by
    * @returns Objects array with the object data
    */
   async getAccountOwnedObjects(args: {
     accountAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetAccountOwnedObjectsResponse[0]>;
-    };
+    options?: PaginationArgs & OrderByArg<GetAccountOwnedObjectsResponse[0]>;
   }): Promise<GetAccountOwnedObjectsResponse> {
     await waitForIndexerOnVersion({
       config: this.config,

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -145,7 +145,7 @@ export class ANS {
    */
   async setPrimaryName(args: {
     sender: Account;
-    name: string | null;
+    name?: string;
     options?: InputGenerateTransactionOptions;
   }): Promise<SingleSignerTransaction> {
     return setPrimaryName({ aptosConfig: this.config, ...args });
@@ -233,8 +233,8 @@ export class ANS {
    *
    * @param args
    * @param args.accountAddress - A AccountAddressInput of the address to retrieve names for.
-   * @param args.options.pagination.offset - Optional, the offset to start from when fetching names
-   * @param args.options.pagination.limit - Optional, A number of the names to fetch per request
+   * @param args.options.offset - Optional, the offset to start from when fetching names
+   * @param args.options.limit - Optional, A number of the names to fetch per request
    * @param args.options.orderBy - The order to sort the names by
    * @param args.options.where - Additional filters to apply to the query
    *
@@ -249,8 +249,8 @@ export class ANS {
    *
    * @param args
    * @param args.accountAddress - A AccountAddressInput of the address to retrieve domain names for.
-   * @param args.options.pagination.offset - Optional, the offset to start from when fetching names
-   * @param args.options.pagination.limit - Optional, A number of the names to fetch per request
+   * @param args.options.offset - Optional, the offset to start from when fetching names
+   * @param args.options.limit - Optional, A number of the names to fetch per request
    * @param args.options.orderBy - The order to sort the names by
    * @param args.options.where - Additional filters to apply to the query
    *
@@ -265,8 +265,8 @@ export class ANS {
    *
    * @param args
    * @param args.accountAddress - A AccountAddressInput of the address to retrieve subdomains names for.
-   * @param args.options.pagination.offset - Optional, the offset to start from when fetching names
-   * @param args.options.pagination.limit - Optional, A number of the names to fetch per request
+   * @param args.options.offset - Optional, the offset to start from when fetching names
+   * @param args.options.limit - Optional, A number of the names to fetch per request
    * @param args.options.orderBy - The order to sort the names by
    * @param args.options.where - Additional filters to apply to the query
    *
@@ -281,8 +281,8 @@ export class ANS {
    *
    * @param args
    * @param args.domain - A string of the domain name: eg. "test.apt" or "test" (without the suffix of .apt)
-   * @param args.options.pagination.offset - Optional, the offset to start from when fetching names
-   * @param args.options.pagination.limit - Optional, A number of the names to fetch per request
+   * @param args.options.offset - Optional, the offset to start from when fetching names
+   * @param args.options.limit - Optional, A number of the names to fetch per request
    * @param args.options.orderBy - The order to sort the names by
    * @param args.options.where - Additional filters to apply to the query
    *

--- a/src/api/digitalAsset.ts
+++ b/src/api/digitalAsset.ts
@@ -8,9 +8,10 @@ import {
   GetOwnedTokensResponse,
   GetTokenActivityResponse,
   GetTokenDataResponse,
-  OrderBy,
+  OrderByArg,
   PaginationArgs,
   TokenStandard,
+  TokenStandardArg,
 } from "../types";
 import { Account, AccountAddressInput } from "../core";
 import { InputGenerateTransactionOptions, SingleSignerTransaction } from "../transactions/types";
@@ -88,9 +89,7 @@ export class DigitalAsset {
     creatorAddress: AccountAddressInput;
     collectionName: string;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      tokenStandard?: TokenStandard;
-    };
+    options?: TokenStandardArg;
   }): Promise<GetCollectionDataResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -116,9 +115,7 @@ export class DigitalAsset {
     creatorAddress: AccountAddressInput;
     collectionName: string;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      tokenStandard?: TokenStandard;
-    };
+    options?: TokenStandardArg;
   }): Promise<string> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -200,10 +197,7 @@ export class DigitalAsset {
   async getOwnedTokens(args: {
     ownerAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetOwnedTokensResponse[0]>;
-    };
+    options?: PaginationArgs & OrderByArg<GetOwnedTokensResponse[0]>;
   }): Promise<GetOwnedTokensResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -224,10 +218,7 @@ export class DigitalAsset {
   async getTokenActivity(args: {
     tokenAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetTokenActivityResponse[0]>;
-    };
+    options?: PaginationArgs & OrderByArg<GetTokenActivityResponse[0]>;
   }): Promise<GetTokenActivityResponse> {
     await waitForIndexerOnVersion({
       config: this.config,

--- a/src/api/event.ts
+++ b/src/api/event.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { getAccountEventsByCreationNumber, getAccountEventsByEventType, getEvents } from "../internal/event";
-import { AnyNumber, GetEventsResponse, MoveStructId, OrderBy, PaginationArgs } from "../types";
+import { AnyNumber, GetEventsResponse, MoveStructId, OrderByArg, PaginationArgs, WhereArg } from "../types";
 import { EventsBoolExp } from "../types/generated/types";
 import { AccountAddressInput } from "../core";
 import { ProcessorType } from "../utils/const";
@@ -50,10 +50,7 @@ export class Event {
     accountAddress: AccountAddressInput;
     eventType: MoveStructId;
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetEventsResponse[0]>;
-    };
+    options?: PaginationArgs & OrderByArg<GetEventsResponse[0]>;
   }): Promise<GetEventsResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -81,11 +78,7 @@ export class Event {
    */
   async getEvents(args?: {
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      where?: EventsBoolExp;
-      pagination?: PaginationArgs;
-      orderBy?: OrderBy<GetEventsResponse[0]>;
-    };
+    options?: PaginationArgs & OrderByArg<GetEventsResponse[0]> & WhereArg<EventsBoolExp>;
   }): Promise<GetEventsResponse> {
     await waitForIndexerOnVersion({
       config: this.config,

--- a/src/api/fungibleAsset.ts
+++ b/src/api/fungibleAsset.ts
@@ -7,6 +7,7 @@ import {
   GetFungibleAssetActivitiesResponse,
   GetFungibleAssetMetadataResponse,
   PaginationArgs,
+  WhereArg,
 } from "../types";
 import {
   getCurrentFungibleAssetBalances,
@@ -39,10 +40,7 @@ export class FungibleAsset {
    */
   async getFungibleAssetMetadata(args?: {
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      pagination?: PaginationArgs;
-      where?: FungibleAssetMetadataBoolExp;
-    };
+    options?: PaginationArgs & WhereArg<FungibleAssetMetadataBoolExp>;
   }): Promise<GetFungibleAssetMetadataResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -58,7 +56,7 @@ export class FungibleAsset {
    * This query returns the fungible asset metadata for a specific fungible asset.
    *
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
-   * @param assetType The asset type of the fungible asset.
+   * @param args.assetType The asset type of the fungible asset.
    * e.g
    * "0x1::aptos_coin::AptosCoin" for Aptos Coin
    * "0xc2948283c2ce03aafbb294821de7ee684b06116bb378ab614fa2de07a99355a8" - address format if this is fungible asset
@@ -97,10 +95,7 @@ export class FungibleAsset {
    */
   async getFungibleAssetActivities(args?: {
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      pagination?: PaginationArgs;
-      where?: FungibleAssetActivitiesBoolExp;
-    };
+    options?: PaginationArgs & WhereArg<FungibleAssetActivitiesBoolExp>;
   }): Promise<GetFungibleAssetActivitiesResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
@@ -121,10 +116,7 @@ export class FungibleAsset {
    */
   async getCurrentFungibleAssetBalances(args?: {
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      pagination?: PaginationArgs;
-      where?: CurrentFungibleAssetBalancesBoolExp;
-    };
+    options?: PaginationArgs & WhereArg<CurrentFungibleAssetBalancesBoolExp>;
   }): Promise<GetCurrentFungibleAssetBalancesResponse> {
     await waitForIndexerOnVersion({
       config: this.config,

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -20,7 +20,7 @@ import {
   GetProcessorStatusResponse,
   GraphqlQuery,
   LedgerInfo,
-  LedgerVersion,
+  LedgerVersionArg,
   MoveValue,
   TableItemRequest,
   InputViewRequestData,
@@ -117,7 +117,7 @@ export class General {
    *
    * @returns Table item value rendered in JSON
    */
-  async getTableItem<T>(args: { handle: string; data: TableItemRequest; options?: LedgerVersion }): Promise<T> {
+  async getTableItem<T>(args: { handle: string; data: TableItemRequest; options?: LedgerVersionArg }): Promise<T> {
     return getTableItem<T>({ aptosConfig: this.config, ...args });
   }
 
@@ -136,7 +136,10 @@ export class General {
    *
    * @returns an array of Move values
    */
-  async view<T extends Array<MoveValue>>(args: { payload: InputViewRequestData; options?: LedgerVersion }): Promise<T> {
+  async view<T extends Array<MoveValue>>(args: {
+    payload: InputViewRequestData;
+    options?: LedgerVersionArg;
+  }): Promise<T> {
     return view<T>({ aptosConfig: this.config, ...args });
   }
 

--- a/src/api/staking.ts
+++ b/src/api/staking.ts
@@ -6,7 +6,7 @@ import {
   getNumberOfDelegators,
   getNumberOfDelegatorsForAllPools,
 } from "../internal/staking";
-import { AnyNumber, GetDelegatedStakingActivitiesResponse, GetNumberOfDelegatorsResponse, OrderBy } from "../types";
+import { AnyNumber, GetDelegatedStakingActivitiesResponse, GetNumberOfDelegatorsResponse, OrderByArg } from "../types";
 import { AccountAddressInput } from "../core";
 import { ProcessorType } from "../utils/const";
 import { AptosConfig } from "./aptosConfig";
@@ -45,9 +45,7 @@ export class Staking {
    */
   async getNumberOfDelegatorsForAllPools(args?: {
     minimumLedgerVersion?: AnyNumber;
-    options?: {
-      orderBy?: OrderBy<GetNumberOfDelegatorsResponse[0]>;
-    };
+    options?: OrderByArg<GetNumberOfDelegatorsResponse[0]>;
   }): Promise<GetNumberOfDelegatorsResponse> {
     await waitForIndexerOnVersion({
       config: this.config,

--- a/src/client/get.ts
+++ b/src/client/get.ts
@@ -78,17 +78,18 @@ export async function getAptosFullNode<Req extends {}, Res extends {}>(
 }
 
 /// This function is a helper for paginating using a function wrapping an API
-export async function paginateWithCursor<Req extends Record<string, any>, Res extends any[]>(
+export async function paginateWithCursor<Req extends Record<string, any>, Res extends Array<{}>>(
   options: GetAptosRequestOptions,
 ): Promise<Res> {
-  const out = [];
+  const out: any[] = [];
   let cursor: string | undefined;
-  const requestParams = options.params as Req & { start?: string; limit?: number };
+  const requestParams = options.params as { start?: string; limit?: number };
   // eslint-disable-next-line no-constant-condition
   while (true) {
     requestParams.start = cursor;
     // eslint-disable-next-line no-await-in-loop
-    const response = await getAptosFullNode<Req, Res>({
+    const response = await get<Req, Res>({
+      type: AptosApiType.FULLNODE,
       aptosConfig: options.aptosConfig,
       originMethod: options.originMethod,
       path: options.path,
@@ -103,11 +104,11 @@ export async function paginateWithCursor<Req extends Record<string, any>, Res ex
     cursor = response.headers["x-aptos-cursor"];
     // Now that we have the cursor (if any), we remove the headers before
     // adding these to the output of this function.
-    delete (response as any).headers;
+    delete response.headers;
     out.push(...response.data);
     if (cursor === null || cursor === undefined) {
       break;
     }
   }
-  return out as any;
+  return out as Res;
 }

--- a/src/core/accountAddress.ts
+++ b/src/core/accountAddress.ts
@@ -326,11 +326,10 @@ export class AccountAddress extends Serializable implements TransactionArgument 
       // the hex string to bytes. Every two characters in a hex string constitutes a
       // single byte. So a 64 length hex string becomes a 32 byte array.
       addressBytes = hexToBytes(parsedInput.padStart(64, "0"));
-    } catch (e) {
-      const error = e as Error;
+    } catch (error: any) {
       // At this point the only way this can fail is if the hex string contains
       // invalid characters.
-      throw new ParsingError(`Hex characters are invalid: ${error.message}`, AddressInvalidReason.INVALID_HEX_CHARS);
+      throw new ParsingError(`Hex characters are invalid: ${error?.message}`, AddressInvalidReason.INVALID_HEX_CHARS);
     }
 
     return new AccountAddress(addressBytes);
@@ -389,12 +388,11 @@ export class AccountAddress extends Serializable implements TransactionArgument 
         AccountAddress.from(args.input);
       }
       return { valid: true };
-    } catch (e) {
-      const error = e as ParsingError<AddressInvalidReason>;
+    } catch (error: any) {
       return {
         valid: false,
-        invalidReason: error.invalidReason,
-        invalidReasonMessage: error.message,
+        invalidReason: error?.invalidReason,
+        invalidReasonMessage: error?.message,
       };
     }
   }

--- a/src/core/crypto/anyPublicKey.ts
+++ b/src/core/crypto/anyPublicKey.ts
@@ -77,4 +77,16 @@ export class AnyPublicKey extends PublicKey {
         throw new Error(`Unknown variant index for AnyPublicKey: ${index}`);
     }
   }
+
+  static isPublicKey(publicKey: PublicKey): publicKey is AnyPublicKey {
+    return publicKey instanceof AnyPublicKey;
+  }
+
+  isEd25519(): this is Ed25519PublicKey {
+    return this.publicKey instanceof Ed25519PublicKey;
+  }
+
+  isSecp256k1PublicKey(): this is Secp256k1PublicKey {
+    return this.publicKey instanceof Secp256k1PublicKey;
+  }
 }

--- a/src/core/crypto/ed25519.ts
+++ b/src/core/crypto/ed25519.ts
@@ -88,6 +88,11 @@ export class Ed25519PublicKey extends PublicKey {
     const bytes = deserializer.deserializeBytes();
     return new Ed25519PublicKey(bytes);
   }
+
+  // TODO(greg): Currently, we can't put this on the abstract type, because of a circular dependency
+  static isPublicKey(publicKey: PublicKey): publicKey is Ed25519PublicKey {
+    return publicKey instanceof Ed25519PublicKey;
+  }
 }
 
 /**
@@ -226,6 +231,10 @@ export class Ed25519PrivateKey extends PrivateKey {
     });
     return new Ed25519PrivateKey(privateKey);
   }
+
+  static isPrivateKey(privateKey: PrivateKey): privateKey is Ed25519PrivateKey {
+    return privateKey instanceof Ed25519PrivateKey;
+  }
 }
 
 /**
@@ -283,5 +292,9 @@ export class Ed25519Signature extends Signature {
   static load(deserializer: Deserializer): Ed25519Signature {
     const bytes = deserializer.deserializeBytes();
     return new Ed25519Signature(bytes);
+  }
+
+  static isSignature(signature: Signature): signature is Ed25519Signature {
+    return signature instanceof Ed25519Signature;
   }
 }

--- a/src/core/crypto/index.ts
+++ b/src/core/crypto/index.ts
@@ -7,3 +7,5 @@ export * from "./multiEd25519";
 export * from "./secp256k1";
 export * from "./multiKey";
 export * from "./hdKey";
+export * from "./anyPublicKey";
+export * from "./anySignature";

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -83,6 +83,10 @@ export class Secp256k1PublicKey extends PublicKey {
     const bytes = deserializer.deserializeBytes();
     return new Secp256k1PublicKey(bytes);
   }
+
+  static isPublicKey(publicKey: PublicKey): publicKey is Secp256k1PublicKey {
+    return publicKey instanceof Secp256k1PublicKey;
+  }
 }
 
 /**
@@ -209,6 +213,10 @@ export class Secp256k1PrivateKey extends PrivateKey {
 
     return new Secp256k1PrivateKey(privateKey);
   }
+
+  static isPrivateKey(privateKey: PrivateKey): privateKey is Secp256k1PrivateKey {
+    return privateKey instanceof Secp256k1PrivateKey;
+  }
 }
 
 /**
@@ -271,5 +279,9 @@ export class Secp256k1Signature extends Signature {
   static load(deserializer: Deserializer): Secp256k1Signature {
     const bytes = deserializer.deserializeBytes();
     return new Secp256k1Signature(bytes);
+  }
+
+  static isSignature(signature: Signature): signature is Secp256k1Signature {
+    return signature instanceof Secp256k1Signature;
   }
 }

--- a/src/core/hex.ts
+++ b/src/core/hex.ts
@@ -115,10 +115,9 @@ export class Hex {
 
     try {
       return new Hex(hexToBytes(input));
-    } catch (e) {
-      const error = e as Error;
+    } catch (error: any) {
       throw new ParsingError(
-        `Hex string contains invalid hex characters: ${error.message}`,
+        `Hex string contains invalid hex characters: ${error?.message}`,
         HexInvalidReason.INVALID_HEX_CHARS,
       );
     }
@@ -153,12 +152,11 @@ export class Hex {
     try {
       Hex.fromString(str);
       return { valid: true };
-    } catch (e) {
-      const error = e as ParsingError<HexInvalidReason>;
+    } catch (error: any) {
       return {
         valid: false,
-        invalidReason: error.invalidReason,
-        invalidReasonMessage: error.message,
+        invalidReason: error?.invalidReason,
+        invalidReasonMessage: error?.message,
       };
     }
   }

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -21,15 +21,16 @@ import {
   GetAccountOwnedObjectsResponse,
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
-  LedgerVersion,
+  LedgerVersionArg,
   MoveModuleBytecode,
   MoveResource,
   MoveStructId,
-  OrderBy,
+  OrderByArg,
   PaginationArgs,
   SigningScheme,
-  TokenStandard,
+  TokenStandardArg,
   TransactionResponse,
+  WhereArg,
 } from "../types";
 import {
   GetAccountCoinsCountQuery,
@@ -72,7 +73,7 @@ export async function getInfo(args: {
 export async function getModules(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  options?: PaginationArgs & LedgerVersion;
+  options?: PaginationArgs & LedgerVersionArg;
 }): Promise<MoveModuleBytecode[]> {
   const { aptosConfig, accountAddress, options } = args;
   return paginateWithCursor<{}, MoveModuleBytecode[]>({
@@ -99,7 +100,7 @@ export async function getModule(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
   moduleName: string;
-  options?: LedgerVersion;
+  options?: LedgerVersionArg;
 }): Promise<MoveModuleBytecode> {
   // We don't memoize the account module by ledger version, as it's not a common use case, this would be handled
   // by the developer directly
@@ -118,7 +119,7 @@ async function getModuleInner(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
   moduleName: string;
-  options?: LedgerVersion;
+  options?: LedgerVersionArg;
 }): Promise<MoveModuleBytecode> {
   const { aptosConfig, accountAddress, moduleName, options } = args;
 
@@ -148,7 +149,7 @@ export async function getTransactions(args: {
 export async function getResources(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  options?: PaginationArgs & LedgerVersion;
+  options?: PaginationArgs & LedgerVersionArg;
 }): Promise<MoveResource[]> {
   const { aptosConfig, accountAddress, options } = args;
   return paginateWithCursor<{}, MoveResource[]>({
@@ -167,7 +168,7 @@ export async function getResource<T extends {}>(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
   resourceType: MoveStructId;
-  options?: LedgerVersion;
+  options?: LedgerVersionArg;
 }): Promise<T> {
   const { aptosConfig, accountAddress, resourceType, options } = args;
   const { data } = await getAptosFullNode<{}, MoveResource>({
@@ -182,7 +183,7 @@ export async function getResource<T extends {}>(args: {
 export async function lookupOriginalAccountAddress(args: {
   aptosConfig: AptosConfig;
   authenticationKey: AccountAddressInput;
-  options?: LedgerVersion;
+  options?: LedgerVersionArg;
 }): Promise<AccountAddress> {
   const { aptosConfig, authenticationKey, options } = args;
   type OriginatingAddress = {
@@ -259,11 +260,7 @@ export async function getAccountTokensCount(args: {
 export async function getAccountOwnedTokens(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  options?: {
-    tokenStandard?: TokenStandard;
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetAccountOwnedTokensQueryResponse[0]>;
-  };
+  options?: TokenStandardArg & PaginationArgs & OrderByArg<GetAccountOwnedTokensQueryResponse[0]>;
 }): Promise<GetAccountOwnedTokensQueryResponse> {
   const { aptosConfig, accountAddress, options } = args;
   const address = AccountAddress.from(accountAddress).toStringLong();
@@ -282,8 +279,8 @@ export async function getAccountOwnedTokens(args: {
     query: GetAccountOwnedTokens,
     variables: {
       where_condition: whereCondition,
-      offset: options?.pagination?.offset,
-      limit: options?.pagination?.limit,
+      offset: options?.offset,
+      limit: options?.limit,
       order_by: options?.orderBy,
     },
   };
@@ -301,11 +298,7 @@ export async function getAccountOwnedTokensFromCollectionAddress(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
   collectionAddress: AccountAddressInput;
-  options?: {
-    tokenStandard?: TokenStandard;
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetAccountOwnedTokensFromCollectionResponse[0]>;
-  };
+  options?: TokenStandardArg & PaginationArgs & OrderByArg<GetAccountOwnedTokensFromCollectionResponse[0]>;
 }): Promise<GetAccountOwnedTokensFromCollectionResponse> {
   const { aptosConfig, accountAddress, collectionAddress, options } = args;
   const ownerAddress = AccountAddress.from(accountAddress).toStringLong();
@@ -330,8 +323,8 @@ export async function getAccountOwnedTokensFromCollectionAddress(args: {
     query: GetAccountOwnedTokensFromCollection,
     variables: {
       where_condition: whereCondition,
-      offset: options?.pagination?.offset,
-      limit: options?.pagination?.limit,
+      offset: options?.offset,
+      limit: options?.limit,
       order_by: options?.orderBy,
     },
   };
@@ -348,11 +341,7 @@ export async function getAccountOwnedTokensFromCollectionAddress(args: {
 export async function getAccountCollectionsWithOwnedTokens(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  options?: {
-    tokenStandard?: TokenStandard;
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetAccountCollectionsWithOwnedTokenResponse[0]>;
-  };
+  options?: TokenStandardArg & PaginationArgs & OrderByArg<GetAccountCollectionsWithOwnedTokenResponse[0]>;
 }): Promise<GetAccountCollectionsWithOwnedTokenResponse> {
   const { aptosConfig, accountAddress, options } = args;
   const address = AccountAddress.from(accountAddress).toStringLong();
@@ -376,8 +365,8 @@ export async function getAccountCollectionsWithOwnedTokens(args: {
     query: GetAccountCollectionsWithOwnedTokens,
     variables: {
       where_condition: whereCondition,
-      offset: options?.pagination?.offset,
-      limit: options?.pagination?.limit,
+      offset: options?.offset,
+      limit: options?.limit,
       order_by: options?.orderBy,
     },
   };
@@ -439,11 +428,7 @@ export async function getAccountCoinAmount(args: {
 export async function getAccountCoinsData(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  options?: {
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetAccountCoinsDataResponse[0]>;
-    where?: CurrentFungibleAssetBalancesBoolExp;
-  };
+  options?: PaginationArgs & OrderByArg<GetAccountCoinsDataResponse[0]> & WhereArg<CurrentFungibleAssetBalancesBoolExp>;
 }): Promise<GetAccountCoinsDataResponse> {
   const { aptosConfig, accountAddress, options } = args;
   const address = AccountAddress.from(accountAddress).toStringLong();
@@ -457,8 +442,8 @@ export async function getAccountCoinsData(args: {
     query: GetAccountCoinsData,
     variables: {
       where_condition: whereCondition,
-      offset: options?.pagination?.offset,
-      limit: options?.pagination?.limit,
+      offset: options?.offset,
+      limit: options?.limit,
       order_by: options?.orderBy,
     },
   };
@@ -500,10 +485,7 @@ export async function getAccountCoinsCount(args: {
 export async function getAccountOwnedObjects(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  options?: {
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetAccountOwnedObjectsResponse[0]>;
-  };
+  options?: PaginationArgs & OrderByArg<GetAccountOwnedObjectsResponse[0]>;
 }): Promise<GetAccountOwnedObjectsResponse> {
   const { aptosConfig, accountAddress, options } = args;
   const address = AccountAddress.from(accountAddress).toStringLong();
@@ -515,8 +497,8 @@ export async function getAccountOwnedObjects(args: {
     query: GetAccountOwnedObjects,
     variables: {
       where_condition: whereCondition,
-      offset: options?.pagination?.offset,
-      limit: options?.pagination?.limit,
+      offset: options?.offset,
+      limit: options?.limit,
       order_by: options?.orderBy,
     },
   };

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -84,8 +84,8 @@ function getRouterAddress(aptosConfig: AptosConfig): string {
   return address;
 }
 
-const Some = <T>(value: T): MoveValue => ({ vec: [value] }) as any;
-const None = (): MoveValue => ({ vec: [] }) as any;
+const Some = <T>(value: T): MoveValue => ({ vec: [value] });
+const None = (): MoveValue => ({ vec: [] });
 // != here is intentional, we want to check for null and undefined
 // eslint-disable-next-line eqeqeq
 const Option = <T>(value: T | undefined | null): MoveValue => (value != undefined ? Some(value) : None());
@@ -514,7 +514,7 @@ async function getANSExpirationDate(args: { aptosConfig: AptosConfig }): Promise
   const { aptosConfig } = args;
   const routerAddress = getRouterAddress(aptosConfig);
 
-  const res = await view({
+  const [gracePeriodInSeconds] = await view<[number]>({
     aptosConfig,
     payload: {
       function: `${routerAddress}::config::reregistration_grace_sec`,
@@ -522,7 +522,6 @@ async function getANSExpirationDate(args: { aptosConfig: AptosConfig }): Promise
     },
   });
 
-  const gracePeriodInSeconds = res[0] as number;
   const gracePeriodInDays = gracePeriodInSeconds / 60 / 60 / 24;
   const now = () => new Date();
   return new Date(now().setDate(now().getDate() - gracePeriodInDays)).toISOString();

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -167,7 +167,7 @@ export async function registerName(args: RegisterNameParameters): Promise<Single
       options,
     });
 
-    return transaction as SingleSignerTransaction;
+    return transaction;
   }
 
   // We are a subdomain
@@ -205,7 +205,7 @@ export async function registerName(args: RegisterNameParameters): Promise<Single
     options,
   });
 
-  return transaction as SingleSignerTransaction;
+  return transaction;
 }
 
 export async function getExpiration(args: { aptosConfig: AptosConfig; name: string }): Promise<number | undefined> {
@@ -272,7 +272,7 @@ export async function setPrimaryName(args: {
       options,
     });
 
-    return transaction as SingleSignerTransaction;
+    return transaction;
   }
 
   const { domainName, subdomainName } = isValidANSName(name);
@@ -287,7 +287,7 @@ export async function setPrimaryName(args: {
     options,
   });
 
-  return transaction as SingleSignerTransaction;
+  return transaction;
 }
 
 export async function getTargetAddress(args: {
@@ -331,7 +331,7 @@ export async function setTargetAddress(args: {
     options,
   });
 
-  return transaction as SingleSignerTransaction;
+  return transaction;
 }
 
 export async function getName(args: {
@@ -359,7 +359,7 @@ export async function getName(args: {
   });
 
   // Convert the expiration_timestamp from an ISO string to milliseconds since epoch
-  let res = data.current_aptos_names[0] as GetANSNameResponse[0] | undefined;
+  let res = data.current_aptos_names[0];
   if (res) {
     res = sanitizeANSName(res);
   }
@@ -558,7 +558,7 @@ export async function renewDomain(args: {
     options,
   });
 
-  return transaction as SingleSignerTransaction;
+  return transaction;
 }
 
 /**

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -11,7 +11,7 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { Account, AccountAddress, AccountAddressInput } from "../core";
 import { InputGenerateTransactionOptions, SingleSignerTransaction } from "../transactions/types";
-import { GetANSNameResponse, MoveAddressType, MoveValue, OrderBy, PaginationArgs } from "../types";
+import { GetANSNameResponse, MoveAddressType, MoveValue, OrderByArg, PaginationArgs, WhereArg } from "../types";
 import { GetNamesQuery } from "../types/generated/operations";
 import { GetNames } from "../types/generated/queries";
 import { CurrentAptosNamesBoolExp } from "../types/generated/types";
@@ -255,7 +255,7 @@ export async function getPrimaryName(args: {
 export async function setPrimaryName(args: {
   aptosConfig: AptosConfig;
   sender: Account;
-  name: string | null;
+  name?: string;
   options?: InputGenerateTransactionOptions;
 }): Promise<SingleSignerTransaction> {
   const { aptosConfig, sender, name, options } = args;
@@ -368,11 +368,7 @@ export async function getName(args: {
 }
 
 interface QueryNamesOptions {
-  options?: {
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetANSNameResponse[0]>;
-    where?: CurrentAptosNamesBoolExp;
-  };
+  options?: PaginationArgs & OrderByArg<GetANSNameResponse[0]> & WhereArg<CurrentAptosNamesBoolExp>;
 }
 
 export interface GetAccountNamesArgs extends QueryNamesOptions {
@@ -392,8 +388,8 @@ export async function getAccountNames(
     query: {
       query: GetNames,
       variables: {
-        limit: options?.pagination?.limit,
-        offset: options?.pagination?.offset,
+        limit: options?.limit,
+        offset: options?.offset,
         order_by: options?.orderBy,
         where_condition: {
           ...(args.options?.where ?? {}),
@@ -424,8 +420,8 @@ export async function getAccountDomains(
     query: {
       query: GetNames,
       variables: {
-        limit: options?.pagination?.limit,
-        offset: options?.pagination?.offset,
+        limit: options?.limit,
+        offset: options?.offset,
         order_by: options?.orderBy,
         where_condition: {
           ...(args.options?.where ?? {}),
@@ -457,8 +453,8 @@ export async function getAccountSubdomains(
     query: {
       query: GetNames,
       variables: {
-        limit: options?.pagination?.limit,
-        offset: options?.pagination?.offset,
+        limit: options?.limit,
+        offset: options?.offset,
         order_by: options?.orderBy,
         where_condition: {
           ...(args.options?.where ?? {}),
@@ -488,8 +484,8 @@ export async function getDomainSubdomains(
     query: {
       query: GetNames,
       variables: {
-        limit: options?.pagination?.limit,
-        offset: options?.pagination?.offset,
+        limit: options?.limit,
+        offset: options?.offset,
         order_by: options?.orderBy,
         where_condition: {
           ...(args.options?.where ?? {}),

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -28,5 +28,5 @@ export async function transferCoinTransaction(args: {
     options,
   });
 
-  return transaction as SingleSignerTransaction;
+  return transaction;
 }

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -19,9 +19,9 @@ import {
   GetOwnedTokensResponse,
   GetTokenActivityResponse,
   GetTokenDataResponse,
-  OrderBy,
+  OrderByArg,
   PaginationArgs,
-  TokenStandard,
+  TokenStandardArg,
 } from "../types";
 import {
   GetCollectionDataQuery,
@@ -132,10 +132,7 @@ export async function getCurrentTokenOwnership(args: {
 export async function getOwnedTokens(args: {
   aptosConfig: AptosConfig;
   ownerAddress: AccountAddressInput;
-  options?: {
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetTokenActivityResponse[0]>;
-  };
+  options?: PaginationArgs & OrderByArg<GetTokenActivityResponse[0]>;
 }): Promise<GetOwnedTokensResponse> {
   const { aptosConfig, ownerAddress, options } = args;
 
@@ -147,8 +144,8 @@ export async function getOwnedTokens(args: {
     query: GetCurrentTokenOwnership,
     variables: {
       where_condition: whereCondition,
-      offset: options?.pagination?.offset,
-      limit: options?.pagination?.limit,
+      offset: options?.offset,
+      limit: options?.limit,
       order_by: options?.orderBy,
     },
   };
@@ -165,10 +162,7 @@ export async function getOwnedTokens(args: {
 export async function getTokenActivity(args: {
   aptosConfig: AptosConfig;
   tokenAddress: AccountAddressInput;
-  options?: {
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetTokenActivityResponse[0]>;
-  };
+  options?: PaginationArgs & OrderByArg<GetTokenActivityResponse[0]>;
 }): Promise<GetTokenActivityResponse> {
   const { aptosConfig, tokenAddress, options } = args;
 
@@ -180,8 +174,8 @@ export async function getTokenActivity(args: {
     query: GetTokenActivity,
     variables: {
       where_condition: whereCondition,
-      offset: options?.pagination?.offset,
-      limit: options?.pagination?.limit,
+      offset: options?.offset,
+      limit: options?.limit,
       order_by: options?.orderBy,
     },
   };
@@ -254,9 +248,7 @@ export async function getCollectionData(args: {
   aptosConfig: AptosConfig;
   creatorAddress: AccountAddressInput;
   collectionName: string;
-  options?: {
-    tokenStandard?: TokenStandard;
-  };
+  options?: TokenStandardArg;
 }): Promise<GetCollectionDataResponse> {
   const { aptosConfig, creatorAddress, collectionName, options } = args;
   const address = AccountAddress.from(creatorAddress);
@@ -289,9 +281,7 @@ export async function getCollectionId(args: {
   aptosConfig: AptosConfig;
   creatorAddress: AccountAddressInput;
   collectionName: string;
-  options?: {
-    tokenStandard?: TokenStandard;
-  };
+  options?: TokenStandardArg;
 }): Promise<string> {
   return (await getCollectionData(args)).collection_id;
 }

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -74,7 +74,7 @@ export async function mintTokenTransaction(args: {
     },
     options,
   });
-  return transaction as SingleSignerTransaction;
+  return transaction;
 }
 
 export async function getTokenData(args: {
@@ -241,7 +241,7 @@ export async function createCollectionTransaction(
     },
     options,
   });
-  return transaction as SingleSignerTransaction;
+  return transaction;
 }
 
 export async function getCollectionData(args: {

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -10,7 +10,7 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import { AccountAddress, AccountAddressInput } from "../core";
-import { AnyNumber, GetEventsResponse, PaginationArgs, MoveStructId, OrderBy } from "../types";
+import { AnyNumber, GetEventsResponse, PaginationArgs, MoveStructId, OrderByArg, WhereArg } from "../types";
 import { GetEventsQuery } from "../types/generated/operations";
 import { GetEvents } from "../types/generated/queries";
 import { EventsBoolExp } from "../types/generated/types";
@@ -36,10 +36,7 @@ export async function getAccountEventsByEventType(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
   eventType: MoveStructId;
-  options?: {
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetEventsResponse[0]>;
-  };
+  options?: PaginationArgs & OrderByArg<GetEventsResponse[0]>;
 }): Promise<GetEventsResponse> {
   const { accountAddress, aptosConfig, eventType, options } = args;
   const address = AccountAddress.fromRelaxed(accountAddress).toStringLong();
@@ -51,7 +48,7 @@ export async function getAccountEventsByEventType(args: {
 
   const customOptions = {
     where: whereCondition,
-    pagination: options?.pagination,
+    pagination: options,
     orderBy: options?.orderBy,
   };
 
@@ -60,11 +57,7 @@ export async function getAccountEventsByEventType(args: {
 
 export async function getEvents(args: {
   aptosConfig: AptosConfig;
-  options?: {
-    where?: EventsBoolExp;
-    pagination?: PaginationArgs;
-    orderBy?: OrderBy<GetEventsResponse[0]>;
-  };
+  options?: PaginationArgs & OrderByArg<GetEventsResponse[0]> & WhereArg<EventsBoolExp>;
 }): Promise<GetEventsResponse> {
   const { aptosConfig, options } = args;
 
@@ -72,8 +65,8 @@ export async function getEvents(args: {
     query: GetEvents,
     variables: {
       where_condition: options?.where,
-      offset: options?.pagination?.offset,
-      limit: options?.pagination?.limit,
+      offset: options?.offset,
+      limit: options?.limit,
       order_by: options?.orderBy,
     },
   };

--- a/src/internal/faucet.ts
+++ b/src/internal/faucet.ts
@@ -46,7 +46,7 @@ export async function fundAccount(args: {
 
   // Response is always User transaction for a user submitted transaction
   if (res.type === TransactionResponseType.User) {
-    return res as UserTransactionResponse;
+    return res;
   }
 
   throw new Error(`Unexpected transaction received for fund account: ${res.type}`);

--- a/src/internal/fungibleAsset.ts
+++ b/src/internal/fungibleAsset.ts
@@ -14,6 +14,7 @@ import {
   GetFungibleAssetActivitiesResponse,
   GetFungibleAssetMetadataResponse,
   PaginationArgs,
+  WhereArg,
 } from "../types";
 import { queryIndexer } from "./general";
 import {
@@ -34,10 +35,7 @@ import {
 
 export async function getFungibleAssetMetadata(args: {
   aptosConfig: AptosConfig;
-  options?: {
-    pagination?: PaginationArgs;
-    where?: FungibleAssetMetadataBoolExp;
-  };
+  options?: PaginationArgs & WhereArg<FungibleAssetMetadataBoolExp>;
 }): Promise<GetFungibleAssetMetadataResponse> {
   const { aptosConfig, options } = args;
 
@@ -45,8 +43,8 @@ export async function getFungibleAssetMetadata(args: {
     query: GetFungibleAssetMetadata,
     variables: {
       where_condition: options?.where,
-      limit: options?.pagination?.limit,
-      offset: options?.pagination?.offset,
+      limit: options?.limit,
+      offset: options?.offset,
     },
   };
 
@@ -61,10 +59,7 @@ export async function getFungibleAssetMetadata(args: {
 
 export async function getFungibleAssetActivities(args: {
   aptosConfig: AptosConfig;
-  options?: {
-    pagination?: PaginationArgs;
-    where?: FungibleAssetActivitiesBoolExp;
-  };
+  options?: PaginationArgs & WhereArg<FungibleAssetActivitiesBoolExp>;
 }): Promise<GetFungibleAssetActivitiesResponse> {
   const { aptosConfig, options } = args;
 
@@ -72,8 +67,8 @@ export async function getFungibleAssetActivities(args: {
     query: GetFungibleAssetActivities,
     variables: {
       where_condition: options?.where,
-      limit: options?.pagination?.limit,
-      offset: options?.pagination?.offset,
+      limit: options?.limit,
+      offset: options?.offset,
     },
   };
 
@@ -88,10 +83,7 @@ export async function getFungibleAssetActivities(args: {
 
 export async function getCurrentFungibleAssetBalances(args: {
   aptosConfig: AptosConfig;
-  options?: {
-    pagination?: PaginationArgs;
-    where?: CurrentFungibleAssetBalancesBoolExp;
-  };
+  options?: PaginationArgs & WhereArg<CurrentFungibleAssetBalancesBoolExp>;
 }): Promise<GetCurrentFungibleAssetBalancesResponse> {
   const { aptosConfig, options } = args;
 
@@ -99,8 +91,8 @@ export async function getCurrentFungibleAssetBalances(args: {
     query: GetCurrentFungibleAssetBalances,
     variables: {
       where_condition: options?.where,
-      limit: options?.pagination?.limit,
-      offset: options?.pagination?.offset,
+      limit: options?.limit,
+      offset: options?.offset,
     },
   };
 

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -17,7 +17,7 @@ import {
   GetProcessorStatusResponse,
   GraphqlQuery,
   LedgerInfo,
-  LedgerVersion,
+  LedgerVersionArg,
   MoveValue,
   TableItemRequest,
   ViewRequest,
@@ -71,7 +71,7 @@ export async function getTableItem<T>(args: {
   aptosConfig: AptosConfig;
   handle: string;
   data: TableItemRequest;
-  options?: LedgerVersion;
+  options?: LedgerVersionArg;
 }): Promise<T> {
   const { aptosConfig, handle, data, options } = args;
   const response = await postAptosFullNode<TableItemRequest, any>({
@@ -87,7 +87,7 @@ export async function getTableItem<T>(args: {
 export async function view<T extends Array<MoveValue> = Array<MoveValue>>(args: {
   aptosConfig: AptosConfig;
   payload: InputViewRequestData;
-  options?: LedgerVersion;
+  options?: LedgerVersionArg;
 }): Promise<T> {
   const { aptosConfig, payload, options } = args;
   const { data } = await postAptosFullNode<ViewRequest, MoveValue[]>({

--- a/src/internal/staking.ts
+++ b/src/internal/staking.ts
@@ -10,7 +10,7 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import { AccountAddress, AccountAddressInput } from "../core";
-import { GetDelegatedStakingActivitiesResponse, GetNumberOfDelegatorsResponse, OrderBy } from "../types";
+import { GetDelegatedStakingActivitiesResponse, GetNumberOfDelegatorsResponse, OrderByArg } from "../types";
 import { GetDelegatedStakingActivitiesQuery, GetNumberOfDelegatorsQuery } from "../types/generated/operations";
 import { GetDelegatedStakingActivities, GetNumberOfDelegators } from "../types/generated/queries";
 import { queryIndexer } from "./general";
@@ -34,9 +34,7 @@ export async function getNumberOfDelegators(args: {
 
 export async function getNumberOfDelegatorsForAllPools(args: {
   aptosConfig: AptosConfig;
-  options?: {
-    orderBy?: OrderBy<GetNumberOfDelegatorsResponse[0]>;
-  };
+  options?: OrderByArg<GetNumberOfDelegatorsResponse[0]>;
 }): Promise<GetNumberOfDelegatorsResponse> {
   const { aptosConfig, options } = args;
   const query = {

--- a/src/internal/transaction.ts
+++ b/src/internal/transaction.ts
@@ -167,7 +167,7 @@ export async function waitForTransaction(args: {
   }
   if (!lastTxn.success) {
     throw new FailedTransactionError(
-      `Transaction ${transactionHash} failed with an error: ${(lastTxn as any).vm_status}`,
+      `Transaction ${transactionHash} failed with an error: ${lastTxn.vm_status}`,
       lastTxn,
     );
   }

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -286,7 +286,7 @@ export async function publicPackageTransaction(args: {
     },
     options,
   });
-  return transaction as SingleSignerTransaction;
+  return transaction;
 }
 
 /**

--- a/src/transactions/authenticator/account.ts
+++ b/src/transactions/authenticator/account.ts
@@ -29,6 +29,22 @@ export abstract class AccountAuthenticator extends Serializable {
         throw new Error(`Unknown variant index for AccountAuthenticator: ${index}`);
     }
   }
+
+  isEd25519(): this is AccountAuthenticatorEd25519 {
+    return this instanceof AccountAuthenticatorEd25519;
+  }
+
+  isMultiEd25519(): this is AccountAuthenticatorMultiEd25519 {
+    return this instanceof AccountAuthenticatorMultiEd25519;
+  }
+
+  isSingleKey(): this is AccountAuthenticatorSingleKey {
+    return this instanceof AccountAuthenticatorSingleKey;
+  }
+
+  isMultiKey(): this is AccountAuthenticatorMultiKey {
+    return this instanceof AccountAuthenticatorMultiKey;
+  }
 }
 
 /**

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -500,7 +500,7 @@ export function deriveTransactionType(transaction: AnyRawTransaction): AnyRawTra
     return new MultiAgentRawTransaction(transaction.rawTransaction, transaction.secondarySignerAddresses);
   }
 
-  return transaction.rawTransaction as RawTransaction;
+  return transaction.rawTransaction;
 }
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Network } from "../utils/apiEndpoints";
+import { OrderBy, TokenStandard } from "./indexer";
 
 export * from "./indexer";
 
@@ -154,6 +155,17 @@ export interface PaginationArgs {
   limit?: number;
 }
 
+export interface TokenStandardArg {
+  tokenStandard?: TokenStandard;
+}
+export interface OrderByArg<T extends {}> {
+  orderBy?: OrderBy<T>;
+}
+
+export interface WhereArg<T extends {}> {
+  where?: T;
+}
+
 /**
  * QUERY TYPES
  */
@@ -225,7 +237,7 @@ export type AptosRequest = {
 /**
  * Specifies ledger version of transactions. By default latest version will be used
  */
-export type LedgerVersion = {
+export type LedgerVersionArg = {
   ledgerVersion?: AnyNumber;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,6 +158,7 @@ export interface PaginationArgs {
 export interface TokenStandardArg {
   tokenStandard?: TokenStandard;
 }
+
 export interface OrderByArg<T extends {}> {
   orderBy?: OrderBy<T>;
 }
@@ -586,6 +587,28 @@ export type TransactionSignature =
   | TransactionMultiAgentSignature
   | TransactionFeePayerSignature;
 
+export function isEd25519Signature(signature: TransactionSignature): signature is TransactionFeePayerSignature {
+  return "signature" in signature && signature.signature === "ed25519_signature";
+}
+
+export function isSecp256k1Signature(signature: TransactionSignature): signature is TransactionFeePayerSignature {
+  return "signature" in signature && signature.signature === "secp256k1_ecdsa_signature";
+}
+
+export function isMultiAgentSignature(signature: TransactionSignature): signature is TransactionMultiAgentSignature {
+  return signature.type === "multi_agent_signature";
+}
+
+export function isFeePayerSignature(signature: TransactionSignature): signature is TransactionFeePayerSignature {
+  return signature.type === "fee_payer_signature";
+}
+
+export function isMultiEd25519Signature(
+  signature: TransactionSignature,
+): signature is TransactionMultiEd25519Signature {
+  return signature.type === "multi_ed25519_signature";
+}
+
 export type TransactionEd25519Signature = {
   type: string;
   public_key: string;
@@ -646,13 +669,10 @@ export type TransactionFeePayerSignature = {
 /**
  * The union of all single account signatures.
  */
-export type AccountSignature = AccountEd25519Signature | AccountSecp256k1Signature | AccountMultiEd25519Signature;
-
-export type AccountEd25519Signature = TransactionEd25519Signature;
-
-export type AccountSecp256k1Signature = TransactionSecp256k1Signature;
-
-export type AccountMultiEd25519Signature = TransactionMultiEd25519Signature;
+export type AccountSignature =
+  | TransactionEd25519Signature
+  | TransactionSecp256k1Signature
+  | TransactionMultiEd25519Signature;
 
 export type WriteSet = ScriptWriteSet | DirectWriteSet;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -298,6 +298,30 @@ export type CommittedTransactionResponse =
   | BlockMetadataTransactionResponse
   | StateCheckpointTransactionResponse;
 
+export function isPendingTransactionResponse(response: TransactionResponse): response is PendingTransactionResponse {
+  return response.type === TransactionResponseType.Pending;
+}
+
+export function isUserTransactionResponse(response: TransactionResponse): response is UserTransactionResponse {
+  return response.type === TransactionResponseType.User;
+}
+
+export function isGenesisTransactionResponse(response: TransactionResponse): response is GenesisTransactionResponse {
+  return response.type === TransactionResponseType.Genesis;
+}
+
+export function isBlockMetadataTransactionResponse(
+  response: TransactionResponse,
+): response is BlockMetadataTransactionResponse {
+  return response.type === TransactionResponseType.BlockMetadata;
+}
+
+export function isStateCheckpointTransactionResponse(
+  response: TransactionResponse,
+): response is StateCheckpointTransactionResponse {
+  return response.type === TransactionResponseType.StateCheckpoint;
+}
+
 export type PendingTransactionResponse = {
   type: TransactionResponseType.Pending;
   hash: string;

--- a/tests/e2e/ans/ans.test.ts
+++ b/tests/e2e/ans/ans.test.ts
@@ -559,7 +559,7 @@ describe("ANS", () => {
 
       res = await testnet.ans.getAccountNames({
         accountAddress: ACCOUNT_ADDRESS_1,
-        options: { pagination: { limit: 1 } },
+        options: { limit: 1 },
       });
       expect(res.length).toBe(1);
 

--- a/tests/e2e/ans/publishANSContracts.ts
+++ b/tests/e2e/ans/publishANSContracts.ts
@@ -1,8 +1,7 @@
 import { execSync } from "child_process";
 import "dotenv";
-import { AccountAddress, Aptos, Ed25519PrivateKey } from "../../../src";
+import { AccountAddress, Aptos, AptosApiType, Ed25519PrivateKey } from "../../../src";
 import { LOCAL_ANS_ACCOUNT_PK, LOCAL_ANS_ACCOUNT_ADDRESS } from "../../../src/internal/ans";
-import { AptosApiType } from "../../../src/utils/const";
 
 /**
  * TS SDK supports ANS. Since ANS contract is not part of aptos-framework

--- a/tests/e2e/api/coin.test.ts
+++ b/tests/e2e/api/coin.test.ts
@@ -1,6 +1,12 @@
-import { AptosConfig, Network, Aptos, Account, Deserializer } from "../../../src";
-import { waitForTransaction } from "../../../src/internal/transaction";
-import { RawTransaction, TransactionPayloadEntryFunction } from "../../../src/transactions/instances";
+import {
+  AptosConfig,
+  Network,
+  Aptos,
+  Account,
+  Deserializer,
+  RawTransaction,
+  TransactionPayloadEntryFunction,
+} from "../../../src";
 import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
 
 describe("coin", () => {
@@ -83,7 +89,7 @@ describe("coin", () => {
       });
       const pendingTxn = await aptos.signAndSubmitTransaction({ signer: sender, transaction });
 
-      const res = await waitForTransaction({ aptosConfig: config, transactionHash: pendingTxn.hash });
+      const res = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
       const recipientCoins = await aptos.getAccountCoinsData({
         accountAddress: recipient.accountAddress,
         minimumLedgerVersion: BigInt(res.version),

--- a/tests/e2e/api/coin.test.ts
+++ b/tests/e2e/api/coin.test.ts
@@ -1,4 +1,4 @@
-import { AptosConfig, Network, Aptos, Account, Deserializer, TypeTagStruct } from "../../../src";
+import { AptosConfig, Network, Aptos, Account, Deserializer } from "../../../src";
 import { waitForTransaction } from "../../../src/internal/transaction";
 import { RawTransaction, TransactionPayloadEntryFunction } from "../../../src/transactions/instances";
 import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
@@ -19,10 +19,19 @@ describe("coin", () => {
 
     const txnDeserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
     const rawTransaction = RawTransaction.deserialize(txnDeserializer);
-    const typeArgs = (rawTransaction.payload as TransactionPayloadEntryFunction).entryFunction.type_args;
-    expect((typeArgs[0] as TypeTagStruct).value.address.toString()).toBe("0x1");
-    expect((typeArgs[0] as TypeTagStruct).value.moduleName.identifier).toBe("aptos_coin");
-    expect((typeArgs[0] as TypeTagStruct).value.name.identifier).toBe("AptosCoin");
+
+    if (!(rawTransaction.payload instanceof TransactionPayloadEntryFunction)) {
+      throw new Error("Transaction payload is not an entry function");
+    }
+
+    const typeArg = rawTransaction.payload.entryFunction.type_args[0];
+    if (!typeArg.isStruct()) {
+      throw new Error("Transaction payload type arg is not a struct");
+    }
+
+    expect(typeArg.value.address.toString()).toBe("0x1");
+    expect(typeArg.value.moduleName.identifier).toBe("aptos_coin");
+    expect(typeArg.value.name.identifier).toBe("AptosCoin");
   });
 
   test("it generates a transfer coin transaction with a custom coin type", async () => {
@@ -41,10 +50,19 @@ describe("coin", () => {
 
     const txnDeserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
     const rawTransaction = RawTransaction.deserialize(txnDeserializer);
-    const typeArgs = (rawTransaction.payload as TransactionPayloadEntryFunction).entryFunction.type_args;
-    expect((typeArgs[0] as TypeTagStruct).value.address.toString()).toBe("0x1");
-    expect((typeArgs[0] as TypeTagStruct).value.moduleName.identifier).toBe("my_coin");
-    expect((typeArgs[0] as TypeTagStruct).value.name.identifier).toBe("type");
+
+    if (!(rawTransaction.payload instanceof TransactionPayloadEntryFunction)) {
+      throw new Error("Transaction payload is not an entry function");
+    }
+
+    const typeArg = rawTransaction.payload.entryFunction.type_args[0];
+    if (!typeArg.isStruct()) {
+      throw new Error("Transaction payload type arg is not a struct");
+    }
+
+    expect(typeArg.value.address.toString()).toBe("0x1");
+    expect(typeArg.value.moduleName.identifier).toBe("my_coin");
+    expect(typeArg.value.name.identifier).toBe("type");
   });
 
   test(

--- a/tests/e2e/api/collection.test.ts
+++ b/tests/e2e/api/collection.test.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Account, Aptos, AptosConfig, Network } from "../../../src";
-import { waitForTransaction } from "../../../src/internal/transaction";
 import { FUND_AMOUNT } from "../../unit/helper";
 
 // use it here since all tests use the same configuration
@@ -28,7 +27,7 @@ describe("Collection", () => {
     });
     const pendingTxn = await aptos.signAndSubmitTransaction({ signer: creator, transaction });
 
-    const response = await waitForTransaction({ aptosConfig: config, transactionHash: pendingTxn.hash });
+    const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
 
     const data = await aptos.getCollectionData({
       collectionName,

--- a/tests/e2e/api/digitalAsset.test.ts
+++ b/tests/e2e/api/digitalAsset.test.ts
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Account, Aptos, AptosConfig, Network } from "../../../src";
-import { waitForTransaction } from "../../../src/internal/transaction";
 import { FUND_AMOUNT } from "../../unit/helper";
 
 const config = new AptosConfig({ network: Network.LOCAL });
@@ -28,7 +27,7 @@ async function setupCollection(): Promise<string> {
     uri: collectionUri,
   });
   const pendingTxn = await aptos.signAndSubmitTransaction({ signer: creator, transaction });
-  const response = await waitForTransaction({ aptosConfig: config, transactionHash: pendingTxn.hash });
+  const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
   const data = await aptos.getCollectionData({
     collectionName,
     creatorAddress,
@@ -46,7 +45,7 @@ async function setupToken(): Promise<string> {
     uri: tokenUri,
   });
   const pendingTxn = await aptos.signAndSubmitTransaction({ signer: creator, transaction });
-  const response = await waitForTransaction({ aptosConfig: config, transactionHash: pendingTxn.hash });
+  const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
   return (
     await aptos.getOwnedTokens({
       ownerAddress: creator.accountAddress.toString(),

--- a/tests/e2e/api/fungibleAsset.test.ts
+++ b/tests/e2e/api/fungibleAsset.test.ts
@@ -38,9 +38,7 @@ describe("FungibleAsset", () => {
   test("it should fetch fungible asset activities with correct number and asset type ", async () => {
     const data = await aptos.getFungibleAssetActivities({
       options: {
-        pagination: {
-          limit: 2,
-        },
+        limit: 2,
         where: {
           asset_type: { _eq: APTOS_COIN },
         } as FungibleAssetActivitiesBoolExp,

--- a/tests/e2e/api/fungibleAsset.test.ts
+++ b/tests/e2e/api/fungibleAsset.test.ts
@@ -1,8 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account, Aptos, AptosConfig, Network } from "../../../src";
-import { APTOS_COIN } from "../../../src/utils/const";
+import { Account, Aptos, AptosConfig, Network, APTOS_COIN } from "../../../src";
 
 const config = new AptosConfig({ network: Network.LOCAL });
 const aptos = new Aptos(config);

--- a/tests/e2e/api/fungibleAsset.test.ts
+++ b/tests/e2e/api/fungibleAsset.test.ts
@@ -2,11 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Account, Aptos, AptosConfig, Network } from "../../../src";
-import {
-  CurrentFungibleAssetBalancesBoolExp,
-  FungibleAssetActivitiesBoolExp,
-  FungibleAssetMetadataBoolExp,
-} from "../../../src/types/generated/types";
 import { APTOS_COIN } from "../../../src/utils/const";
 
 const config = new AptosConfig({ network: Network.LOCAL });
@@ -18,7 +13,7 @@ describe("FungibleAsset", () => {
       options: {
         where: {
           asset_type: { _eq: APTOS_COIN },
-        } as FungibleAssetMetadataBoolExp,
+        },
       },
     });
     expect(data.length).toEqual(1);
@@ -41,7 +36,7 @@ describe("FungibleAsset", () => {
         limit: 2,
         where: {
           asset_type: { _eq: APTOS_COIN },
-        } as FungibleAssetActivitiesBoolExp,
+        },
       },
     });
     expect(data.length).toEqual(2);
@@ -59,7 +54,7 @@ describe("FungibleAsset", () => {
         where: {
           owner_address: { _eq: userAccount.accountAddress.toString() },
           asset_type: { _eq: APTOS_COIN },
-        } as CurrentFungibleAssetBalancesBoolExp,
+        },
       },
     });
     expect(data.length).toEqual(1);

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -38,22 +38,23 @@ describe("general api", () => {
   test("it fetches table item data", async () => {
     const config = new AptosConfig({ network: Network.LOCAL });
     const aptos = new Aptos(config);
-    const resource = await aptos.getAccountResource({
-      accountAddress: "0x1",
-      resourceType: "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
-    });
-
-    const {
+    type Supply = {
       supply: {
         vec: [
           {
             aggregator: {
-              vec: [{ handle, key }],
-            },
+              vec: [{ handle: string; key: string }];
+            };
           },
-        ],
-      },
-    } = resource as any;
+        ];
+      };
+    };
+    const resource = await aptos.getAccountResource<Supply>({
+      accountAddress: "0x1",
+      resourceType: "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
+    });
+
+    const { handle, key } = resource.supply.vec[0].aggregator.vec[0];
 
     const supply = await aptos.getTableItem<string>({
       handle,

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -1,8 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig, Aptos, Network, GraphqlQuery, InputViewRequestData } from "../../../src";
-import { ProcessorType } from "../../../src/utils/const";
+import { AptosConfig, Aptos, Network, GraphqlQuery, InputViewRequestData, ProcessorType } from "../../../src";
 
 describe("general api", () => {
   test("it fetches ledger info", async () => {

--- a/tests/e2e/api/paginateQuery.test.ts
+++ b/tests/e2e/api/paginateQuery.test.ts
@@ -7,12 +7,12 @@ test("it should paginate correctly on indexer queries", async () => {
   const events = await aptos.getEvents();
   // Expect more than 10 events
   expect(events.length).toBeGreaterThan(10);
-  const firstTenEvents = await aptos.getEvents({ options: { pagination: { limit: 10 } } });
+  const firstTenEvents = await aptos.getEvents({ options: { limit: 10 } });
   // Expect fetch only first 10 events
   expect(firstTenEvents.length).toBe(10);
   // expect last event data is not the same as the last event data from previous call
   expect(firstTenEvents[firstTenEvents.length - 1]).not.toStrictEqual(events[events.length - 1]);
-  const onlyNextTwentyEvents = await aptos.getEvents({ options: { pagination: { offset: 10, limit: 10 } } });
+  const onlyNextTwentyEvents = await aptos.getEvents({ options: { offset: 10, limit: 10 } });
   // expect only next 20 events
   expect(onlyNextTwentyEvents.length).toBe(10);
   // expect first event data is not the same as the first event data from previous call

--- a/tests/e2e/api/token.test.ts
+++ b/tests/e2e/api/token.test.ts
@@ -1,9 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig, Aptos, Account } from "../../../src";
-import { waitForTransaction } from "../../../src/internal/transaction";
-import { Network } from "../../../src/utils/apiEndpoints";
+import { AptosConfig, Aptos, Account, Network } from "../../../src";
 import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
 
 const config = new AptosConfig({ network: Network.LOCAL });
@@ -29,7 +27,7 @@ async function setupCollection() {
     uri: collectionUri,
   });
   const response = await aptos.signAndSubmitTransaction({ signer: creator, transaction });
-  await waitForTransaction({ aptosConfig: config, transactionHash: response.hash });
+  await aptos.waitForTransaction({ transactionHash: response.hash });
 }
 
 async function setupToken(): Promise<string> {
@@ -41,7 +39,7 @@ async function setupToken(): Promise<string> {
     uri: tokenUri,
   });
   const pendingTxn = await aptos.signAndSubmitTransaction({ signer: creator, transaction });
-  const response = await waitForTransaction({ aptosConfig: config, transactionHash: pendingTxn.hash });
+  const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
   return (
     await aptos.getOwnedTokens({
       ownerAddress: creator.accountAddress,

--- a/tests/e2e/api/transaction.test.ts
+++ b/tests/e2e/api/transaction.test.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AptosConfig, Aptos, Network, Account, TransactionResponse, UserTransactionResponse, U64 } from "../../../src";
+import { AptosConfig, Aptos, Network, Account, TransactionResponse, U64 } from "../../../src";
 import { FUND_AMOUNT } from "../../unit/helper";
 
 // use it here since all tests use the same configuration
@@ -69,15 +69,19 @@ describe("transaction api", () => {
     });
 
     test("it queries for transactions by version", async () => {
+      if (!("version" in txn)) {
+        throw new Error("Transaction is still pending!");
+      }
+
       const transaction = await aptos.getTransactionByVersion({
-        ledgerVersion: Number((txn as UserTransactionResponse).version),
+        ledgerVersion: Number(txn.version),
       });
       expect(transaction).toStrictEqual(txn);
     });
 
     test("it queries for transactions by hash", async () => {
       const transaction = await aptos.getTransactionByHash({
-        transactionHash: (txn as UserTransactionResponse).hash,
+        transactionHash: txn.hash,
       });
       expect(transaction).toStrictEqual(txn);
     });

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -9,8 +9,8 @@ import {
   U64,
   GraphqlQuery,
   NetworkToIndexerAPI,
+  generateSignedTransaction,
 } from "../../../src";
-import { generateSignedTransaction } from "../../../src/transactions/transactionBuilder/transactionBuilder";
 import { VERSION } from "../../../src/version";
 import { longTestTimeout } from "../../unit/helper";
 import { singleSignerScriptBytecode } from "../transaction/helper";

--- a/tests/e2e/client/customClient.test.ts
+++ b/tests/e2e/client/customClient.test.ts
@@ -8,8 +8,8 @@ import {
   AccountAddress,
   postAptosFullNode,
   MimeType,
+  generateSignedTransaction,
 } from "../../../src";
-import { generateSignedTransaction } from "../../../src/transactions/transactionBuilder/transactionBuilder";
 import { customClient } from "../../unit/helper";
 
 describe("custom client", () => {

--- a/tests/e2e/client/customClient.test.ts
+++ b/tests/e2e/client/customClient.test.ts
@@ -28,14 +28,18 @@ describe("custom client", () => {
 
   test("it uses custom client for fetch queries", async () => {
     const config = new AptosConfig({ network: Network.LOCAL, client: { provider: customClient } });
-    const response = await getAptosFullNode({ aptosConfig: config, originMethod: "getInfo", path: "accounts/0x1" });
-    expect(((response.request as any).headers as any)?.customClient).toBeTruthy();
+    const response = await getAptosFullNode<{ headers?: { customClient?: any } }, {}>({
+      aptosConfig: config,
+      originMethod: "getInfo",
+      path: "accounts/0x1",
+    });
+    expect(response?.request?.headers?.customClient).toBeTruthy();
   });
 
   test("it uses custom client for post queries", async () => {
     const config = new AptosConfig({ network: Network.LOCAL, client: { provider: customClient } });
     const account = Account.generate();
-    const response = await postAptosFaucet({
+    const response = await postAptosFaucet<{ headers?: { customClient?: any } }, {}>({
       aptosConfig: config,
       path: "fund",
       body: {
@@ -44,7 +48,7 @@ describe("custom client", () => {
       },
       originMethod: "testFundAccount",
     });
-    expect(((response.request as any).headers as any)?.customClient).toBeTruthy();
+    expect(response?.request?.headers?.customClient).toBeTruthy();
   });
 
   test("it uses custom client for transaction submission", async () => {
@@ -60,13 +64,13 @@ describe("custom client", () => {
     });
     const authenticator = aptos.sign.transaction({ signer: account, transaction });
     const signedTransaction = generateSignedTransaction({ transaction, senderAuthenticator: authenticator });
-    const response = await postAptosFullNode({
+    const response = await postAptosFullNode<{ headers?: { customClient?: any } }, {}>({
       aptosConfig: config,
       body: signedTransaction,
       path: "transactions",
       originMethod: "testSubmitTransaction",
       contentType: MimeType.BCS_SIGNED_TRANSACTION,
     });
-    expect(((response.request as any).headers as any)?.customClient).toBeTruthy();
+    expect(response?.request?.headers?.customClient).toBeTruthy();
   });
 });

--- a/tests/e2e/transaction/generateTransaction.test.ts
+++ b/tests/e2e/transaction/generateTransaction.test.ts
@@ -1,10 +1,16 @@
-import { AptosConfig, Network, Aptos, Account, Deserializer, U64, AccountAddress } from "../../../src";
 import {
+  AptosConfig,
+  Network,
+  Aptos,
+  Account,
+  Deserializer,
+  U64,
+  AccountAddress,
   RawTransaction,
   TransactionPayloadScript,
   TransactionPayloadMultisig,
   TransactionPayloadEntryFunction,
-} from "../../../src/transactions/instances";
+} from "../../../src";
 import { longTestTimeout } from "../../unit/helper";
 import { fundAccounts, singleSignerScriptBytecode } from "./helper";
 

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -12,6 +12,7 @@ import {
   SimpleEntryFunctionArgumentTypes,
   MoveVector,
   AnyRawTransaction,
+  isUserTransactionResponse,
 } from "../../../src";
 import { FUND_AMOUNT } from "../../unit/helper";
 
@@ -34,9 +35,16 @@ export async function publishPackage(
     transaction: rawTransaction,
     senderAuthenticator: signedTxn,
   });
-  return (await aptos.waitForTransaction({
+
+  const response = await aptos.waitForTransaction({
     transactionHash: txnHash.hash,
-  })) as UserTransactionResponse;
+  });
+
+  if (!isUserTransactionResponse(response)) {
+    throw new Error("Expected user transaction response");
+  }
+
+  return response;
 }
 
 // Instead of funding each account individually, we fund one twice, then send coins from it to the rest
@@ -73,7 +81,10 @@ export async function fundAccounts(aptos: Aptos, accounts: Array<Account>) {
   const response = await aptos.waitForTransaction({
     transactionHash: transactionResponse.hash,
   });
-  return response as UserTransactionResponse;
+  if (!isUserTransactionResponse(response)) {
+    throw new Error("Expected user transaction response");
+  }
+  return response;
 }
 
 // Transaction builder helpers
@@ -104,7 +115,10 @@ export async function rawTransactionHelper(
   const response = await aptos.waitForTransaction({
     transactionHash: transactionResponse.hash,
   });
-  return response as UserTransactionResponse;
+  if (!isUserTransactionResponse(response)) {
+    throw new Error("Expected user transaction response");
+  }
+  return response;
 }
 
 // multi agent/fee payer
@@ -191,7 +205,10 @@ export const rawTransactionMultiAgentHelper = async (
   const response = await aptos.waitForTransaction({
     transactionHash: transactionResponse.hash,
   });
-  return response as UserTransactionResponse;
+  if (!isUserTransactionResponse(response)) {
+    throw new Error("Expected user transaction response");
+  }
+  return response;
 };
 
 export const PUBLISHER_ACCOUNT_PK = "0xc694948143dea59c195a4918d7fe06c2329624318a073b95f6078ce54940dae9";

--- a/tests/e2e/transaction/signTransaction.test.ts
+++ b/tests/e2e/transaction/signTransaction.test.ts
@@ -1,9 +1,15 @@
-import { AptosConfig, Network, Aptos, Account, Deserializer, U64, SigningSchemeInput } from "../../../src";
 import {
+  AptosConfig,
+  Network,
+  Aptos,
+  Account,
+  Deserializer,
+  U64,
+  SigningSchemeInput,
   AccountAuthenticator,
   AccountAuthenticatorEd25519,
   AccountAuthenticatorSingleKey,
-} from "../../../src/transactions/authenticator/account";
+} from "../../../src";
 import { longTestTimeout } from "../../unit/helper";
 import { fundAccounts, publishTransferPackage, singleSignerScriptBytecode } from "./helper";
 

--- a/tests/e2e/transaction/transactionArguments.test.ts
+++ b/tests/e2e/transaction/transactionArguments.test.ts
@@ -21,6 +21,9 @@ import {
   isMultiAgentSignature,
   isFeePayerSignature,
   isUserTransactionResponse,
+  MoveOption,
+  MoveString,
+  MoveVector,
 } from "../../../src";
 import {
   MAX_U128_BIG_INT,
@@ -30,7 +33,6 @@ import {
   MAX_U64_BIG_INT,
   MAX_U8_NUMBER,
 } from "../../../src/bcs/consts";
-import { MoveOption, MoveString, MoveVector } from "../../../src/bcs/serializable/moveStructs";
 import {
   fundAccounts,
   rawTransactionHelper,

--- a/tests/e2e/transaction/transactionArguments.test.ts
+++ b/tests/e2e/transaction/transactionArguments.test.ts
@@ -21,6 +21,7 @@ import {
   Ed25519PrivateKey,
   UserTransactionResponse,
   parseTypeTag,
+  isMultiAgentSignature,
 } from "../../../src";
 import {
   MAX_U128_BIG_INT,
@@ -351,14 +352,18 @@ describe("various transaction arguments", () => {
         secondarySignerAccounts,
       );
       expect(response.success).toBe(true);
-      const responseSignature = response.signature as TransactionMultiAgentSignature;
+
+      const responseSignature = response.signature;
+      if (responseSignature === undefined || !isMultiAgentSignature(responseSignature)) {
+        throw new Error("Expected multi agent signature");
+      }
+
       const secondarySignerAddressesParsed = responseSignature.secondary_signer_addresses.map((address) =>
         AccountAddress.fromStringRelaxed(address),
       );
       expect(secondarySignerAddressesParsed.map((s) => s.toString())).toEqual(
         secondarySignerAddresses.map((address) => address.toString()),
       );
-      expect((responseSignature as any).fee_payer_address).toBeUndefined();
     });
 
     it("simple inputs successfully submits a multi signer transaction with all argument types", async () => {

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -11,17 +11,14 @@ import {
   AccountAddress,
   EntryFunctionABI,
   parseTypeTag,
-} from "../../../src";
-import { AccountAuthenticator, AccountAuthenticatorEd25519 } from "../../../src/transactions/authenticator/account";
-import {
+  AccountAuthenticator,
+  AccountAuthenticatorEd25519,
   FeePayerRawTransaction,
   MultiAgentRawTransaction,
   RawTransaction,
   TransactionPayloadEntryFunction,
   TransactionPayloadMultisig,
   TransactionPayloadScript,
-} from "../../../src/transactions/instances";
-import {
   buildTransaction,
   deriveTransactionType,
   generateRawTransaction,
@@ -30,8 +27,8 @@ import {
   generateTransactionPayload,
   generateTransactionPayloadWithABI,
   sign,
-} from "../../../src/transactions/transactionBuilder/transactionBuilder";
-import { SignedTransaction } from "../../../src/transactions/instances/signedTransaction";
+  SignedTransaction,
+} from "../../../src";
 import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
 import { fundAccounts, multiSignerScriptBytecode, publishTransferPackage } from "./helper";
 

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -13,10 +13,7 @@ import {
 } from "../../../src";
 import { MultiKey } from "../../../src/core/crypto/multiKey";
 import { waitForTransaction } from "../../../src/internal/transaction";
-import {
-  AccountAuthenticatorMultiKey,
-  AccountAuthenticatorSingleKey,
-} from "../../../src/transactions/authenticator/account";
+import { AccountAuthenticatorMultiKey } from "../../../src/transactions/authenticator/account";
 import { RawTransaction, TransactionPayloadEntryFunction } from "../../../src/transactions/instances";
 import { longTestTimeout } from "../../unit/helper";
 import { fundAccounts, multiSignerScriptBytecode, publishTransferPackage, singleSignerScriptBytecode } from "./helper";
@@ -647,13 +644,13 @@ describe("transaction submission", () => {
       const account1Authenticator = aptos.sign.transaction({ signer: singleSignerED25519SenderAccount, transaction });
       const account3Authenticator = aptos.sign.transaction({ signer: singleSignerSecp256k1Account, transaction });
 
+      if (!(account1Authenticator.isSingleKey() && account3Authenticator.isSingleKey())) {
+        throw new Error("Both AccountAuthenticators should be an instance of AccountAuthenticatorSingleKey");
+      }
+
       const multiKeyAuth = new AccountAuthenticatorMultiKey(
         multiKey,
-        [
-          // TODO find a fix
-          (account1Authenticator as AccountAuthenticatorSingleKey).signature,
-          (account3Authenticator as AccountAuthenticatorSingleKey).signature,
-        ],
+        [account1Authenticator.signature, account3Authenticator.signature],
         bitmap,
       );
 

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -10,11 +10,11 @@ import {
   Deserializer,
   SigningSchemeInput,
   AuthenticationKey,
+  MultiKey,
+  AccountAuthenticatorMultiKey,
+  RawTransaction,
+  TransactionPayloadEntryFunction,
 } from "../../../src";
-import { MultiKey } from "../../../src/core/crypto/multiKey";
-import { waitForTransaction } from "../../../src/internal/transaction";
-import { AccountAuthenticatorMultiKey } from "../../../src/transactions/authenticator/account";
-import { RawTransaction, TransactionPayloadEntryFunction } from "../../../src/transactions/instances";
 import { longTestTimeout } from "../../unit/helper";
 import { fundAccounts, multiSignerScriptBytecode, publishTransferPackage, singleSignerScriptBytecode } from "./helper";
 
@@ -55,8 +55,7 @@ describe("transaction submission", () => {
           transaction,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
 
@@ -74,8 +73,7 @@ describe("transaction submission", () => {
           signer: singleSignerED25519SenderAccount,
           transaction,
         });
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("single_sender");
@@ -107,8 +105,7 @@ describe("transaction submission", () => {
           additionalSignersAuthenticators: [secondarySignerAuthenticator],
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("multi_agent_signature");
@@ -135,8 +132,7 @@ describe("transaction submission", () => {
             additionalSignersAuthenticators: [secondarySignerAuthenticator],
           });
 
-          await waitForTransaction({
-            aptosConfig: config,
+          await aptos.waitForTransaction({
             transactionHash: response.hash,
           });
           expect(response.signature?.type).toBe("multi_agent_signature");
@@ -167,8 +163,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -194,8 +189,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -225,8 +219,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -247,8 +240,7 @@ describe("transaction submission", () => {
           signer: singleSignerSecp256k1Account,
           transaction,
         });
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("single_sender");
@@ -265,8 +257,7 @@ describe("transaction submission", () => {
           signer: singleSignerSecp256k1Account,
           transaction,
         });
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("single_sender");
@@ -298,8 +289,7 @@ describe("transaction submission", () => {
           additionalSignersAuthenticators: [secondarySignerAuthenticator],
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("multi_agent_signature");
@@ -326,8 +316,7 @@ describe("transaction submission", () => {
             additionalSignersAuthenticators: [secondarySignerAuthenticator],
           });
 
-          await waitForTransaction({
-            aptosConfig: config,
+          await aptos.waitForTransaction({
             transactionHash: response.hash,
           });
           expect(response.signature?.type).toBe("multi_agent_signature");
@@ -358,8 +347,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -385,8 +373,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -416,8 +403,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -438,8 +424,7 @@ describe("transaction submission", () => {
           signer: legacyED25519SenderAccount,
           transaction,
         });
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("ed25519_signature");
@@ -456,8 +441,7 @@ describe("transaction submission", () => {
           signer: legacyED25519SenderAccount,
           transaction,
         });
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("ed25519_signature");
@@ -488,8 +472,7 @@ describe("transaction submission", () => {
           additionalSignersAuthenticators: [secondarySignerAuthenticator],
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("multi_agent_signature");
@@ -516,8 +499,7 @@ describe("transaction submission", () => {
             additionalSignersAuthenticators: [secondarySignerAuthenticator],
           });
 
-          await waitForTransaction({
-            aptosConfig: config,
+          await aptos.waitForTransaction({
             transactionHash: response.hash,
           });
           expect(response.signature?.type).toBe("multi_agent_signature");
@@ -547,8 +529,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -574,8 +555,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -605,8 +585,7 @@ describe("transaction submission", () => {
           feePayerAuthenticator: feePayerSignerAuthenticator,
         });
 
-        await waitForTransaction({
-          aptosConfig: config,
+        await aptos.waitForTransaction({
           transactionHash: response.hash,
         });
         expect(response.signature?.type).toBe("fee_payer_signature");
@@ -655,8 +634,7 @@ describe("transaction submission", () => {
       );
 
       const response = await aptos.submit.transaction({ transaction, senderAuthenticator: multiKeyAuth });
-      await waitForTransaction({
-        aptosConfig: config,
+      await aptos.waitForTransaction({
         transactionHash: response.hash,
       });
       expect(response.signature?.type).toBe("single_sender");
@@ -698,8 +676,7 @@ describe("transaction submission", () => {
         signer: account,
         transaction,
       });
-      await waitForTransaction({
-        aptosConfig: config,
+      await aptos.waitForTransaction({
         transactionHash: response.hash,
       });
       const accountModules = await aptos.getAccountModules({ accountAddress: account.accountAddress });

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -53,10 +53,14 @@ describe("Account", () => {
       const accountAddress = AccountAddress.from(address);
       const newAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress, legacy: true });
       expect(newAccount).toBeInstanceOf(Account);
-      expect(newAccount.publicKey).toBeInstanceOf(Ed25519PublicKey);
-      expect(newAccount.privateKey).toBeInstanceOf(Ed25519PrivateKey);
-      expect((newAccount.privateKey as Ed25519PrivateKey).toString()).toEqual(privateKey.toString());
-      expect((newAccount.publicKey as Ed25519PublicKey).toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
+      if (!Ed25519PublicKey.isPublicKey(newAccount.publicKey)) {
+        throw new Error("Public key is not an Ed25519PublicKey");
+      }
+      if (!Ed25519PrivateKey.isPrivateKey(newAccount.privateKey)) {
+        throw new Error("Public key is not an Ed25519PrivateKey");
+      }
+      expect(newAccount.privateKey.toString()).toEqual(privateKey.toString());
+      expect(newAccount.publicKey.toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
       expect(newAccount.accountAddress.toString()).toEqual(address);
     });
 
@@ -66,10 +70,17 @@ describe("Account", () => {
       const accountAddress = AccountAddress.from(address);
       const newAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress, legacy: false });
       expect(newAccount).toBeInstanceOf(Account);
-      expect(newAccount.publicKey).toBeInstanceOf(AnyPublicKey);
-      expect(newAccount.privateKey).toBeInstanceOf(Ed25519PrivateKey);
-      expect((newAccount.privateKey as Ed25519PrivateKey).toString()).toEqual(privateKey.toString());
-      expect((newAccount.publicKey as Ed25519PublicKey).toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
+      if (!AnyPublicKey.isPublicKey(newAccount.publicKey)) {
+        throw new Error("Public key is not an AnyPublicKey");
+      }
+      if (!newAccount.publicKey.isEd25519()) {
+        throw new Error("Public key is not an AnyPublicKey Ed25519PublicKey");
+      }
+      if (!Ed25519PrivateKey.isPrivateKey(newAccount.privateKey)) {
+        throw new Error("Public key is not an Ed25519PrivateKey");
+      }
+      expect(newAccount.privateKey.toString()).toEqual(privateKey.toString());
+      expect(newAccount.publicKey.toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
       expect(newAccount.accountAddress.toString()).toEqual(address);
     });
 
@@ -79,12 +90,17 @@ describe("Account", () => {
       const accountAddress = AccountAddress.from(address);
       const newAccount = Account.fromPrivateKeyAndAddress({ privateKey, address: accountAddress });
       expect(newAccount).toBeInstanceOf(Account);
-      expect(newAccount.publicKey).toBeInstanceOf(AnyPublicKey);
-      expect(newAccount.privateKey).toBeInstanceOf(Secp256k1PrivateKey);
-      expect((newAccount.privateKey as Secp256k1PrivateKey).toString()).toEqual(privateKey.toString());
-      expect((newAccount.publicKey as Secp256k1PublicKey).toString()).toEqual(
-        new Secp256k1PublicKey(publicKey).toString(),
-      );
+      if (!AnyPublicKey.isPublicKey(newAccount.publicKey)) {
+        throw new Error("Public key is not an AnyPublicKey");
+      }
+      if (!newAccount.publicKey.isSecp256k1PublicKey()) {
+        throw new Error("Public key is not a Secp256k1PublicKey");
+      }
+      if (!Secp256k1PrivateKey.isPrivateKey(newAccount.privateKey)) {
+        throw new Error("Public key is not a Secp256k1PrivateKey");
+      }
+      expect(newAccount.privateKey.toString()).toEqual(privateKey.toString());
+      expect(newAccount.publicKey.toString()).toEqual(new Secp256k1PublicKey(publicKey).toString());
       expect(newAccount.accountAddress.toString()).toEqual(address);
     });
   });
@@ -95,10 +111,14 @@ describe("Account", () => {
       const privateKey = new Ed25519PrivateKey(privateKeyBytes);
       const newAccount = Account.fromPrivateKey({ privateKey });
       expect(newAccount).toBeInstanceOf(Account);
-      expect(newAccount.publicKey).toBeInstanceOf(Ed25519PublicKey);
-      expect(newAccount.privateKey).toBeInstanceOf(Ed25519PrivateKey);
-      expect((newAccount.privateKey as Ed25519PrivateKey).toString()).toEqual(privateKey.toString());
-      expect((newAccount.publicKey as Ed25519PublicKey).toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
+      if (!Ed25519PublicKey.isPublicKey(newAccount.publicKey)) {
+        throw new Error("Public key is not an Ed25519PublicKey");
+      }
+      if (!Ed25519PrivateKey.isPrivateKey(newAccount.privateKey)) {
+        throw new Error("Public key is not an Ed25519PrivateKey");
+      }
+      expect(newAccount.privateKey.toString()).toEqual(privateKey.toString());
+      expect(newAccount.publicKey.toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
       expect(newAccount.accountAddress.toString()).toEqual(address);
     });
 
@@ -107,10 +127,17 @@ describe("Account", () => {
       const privateKey = new Ed25519PrivateKey(privateKeyBytes);
       const newAccount = Account.fromPrivateKey({ privateKey, legacy: false });
       expect(newAccount).toBeInstanceOf(Account);
-      expect(newAccount.publicKey).toBeInstanceOf(AnyPublicKey);
-      expect(newAccount.privateKey).toBeInstanceOf(Ed25519PrivateKey);
-      expect((newAccount.privateKey as Ed25519PrivateKey).toString()).toEqual(privateKey.toString());
-      expect((newAccount.publicKey as Ed25519PublicKey).toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
+      if (!AnyPublicKey.isPublicKey(newAccount.publicKey)) {
+        throw new Error("Public key is not an AnyPublicKey");
+      }
+      if (!newAccount.publicKey.isEd25519()) {
+        throw new Error("Public key is not an AnyPublicKey Ed25519PublicKey");
+      }
+      if (!Ed25519PrivateKey.isPrivateKey(newAccount.privateKey)) {
+        throw new Error("Public key is not an Ed25519PrivateKey");
+      }
+      expect(newAccount.privateKey.toString()).toEqual(privateKey.toString());
+      expect(newAccount.publicKey.toString()).toEqual(new Ed25519PublicKey(publicKey).toString());
       expect(newAccount.accountAddress.toString()).toEqual(address);
     });
 
@@ -119,12 +146,17 @@ describe("Account", () => {
       const privateKey = new Secp256k1PrivateKey(privateKeyBytes);
       const newAccount = Account.fromPrivateKey({ privateKey });
       expect(newAccount).toBeInstanceOf(Account);
-      expect(newAccount.publicKey).toBeInstanceOf(AnyPublicKey);
-      expect(newAccount.privateKey).toBeInstanceOf(Secp256k1PrivateKey);
-      expect((newAccount.privateKey as Secp256k1PrivateKey).toString()).toEqual(privateKey.toString());
-      expect((newAccount.publicKey as Secp256k1PublicKey).toString()).toEqual(
-        new Secp256k1PublicKey(publicKey).toString(),
-      );
+      if (!AnyPublicKey.isPublicKey(newAccount.publicKey)) {
+        throw new Error("Public key is not an AnyPublicKey");
+      }
+      if (!newAccount.publicKey.isSecp256k1PublicKey()) {
+        throw new Error("Public key is not an AnyPublicKey Secp256k1PublicKey");
+      }
+      if (!Secp256k1PrivateKey.isPrivateKey(newAccount.privateKey)) {
+        throw new Error("Public key is not an Secp256k1PrivateKey");
+      }
+      expect(newAccount.privateKey.toString()).toEqual(privateKey.toString());
+      expect(newAccount.publicKey.toString()).toEqual(new Secp256k1PublicKey(publicKey).toString());
       expect(newAccount.accountAddress.toString()).toEqual(address);
     });
   });

--- a/tests/unit/account.test.ts
+++ b/tests/unit/account.test.ts
@@ -10,8 +10,8 @@ import {
   Secp256k1PublicKey,
   SigningScheme,
   SigningSchemeInput,
+  AnyPublicKey,
 } from "../../src";
-import { AnyPublicKey } from "../../src/core/crypto/anyPublicKey";
 
 import {
   ed25519,

--- a/tests/unit/aptosConfig.test.ts
+++ b/tests/unit/aptosConfig.test.ts
@@ -8,8 +8,8 @@ import {
   NetworkToFaucetAPI,
   NetworkToNodeAPI,
   NetworkToIndexerAPI,
+  AptosApiType,
 } from "../../src";
-import { AptosApiType } from "../../src/utils/const";
 
 describe("aptos config", () => {
   test("it should set urls based on a local network", async () => {

--- a/tests/unit/bcsHelper.test.ts
+++ b/tests/unit/bcsHelper.test.ts
@@ -18,8 +18,8 @@ import {
   U32,
   U64,
   U8,
+  EntryFunctionArgument,
 } from "../../src";
-import { EntryFunctionArgument } from "../../src/transactions/instances";
 /* eslint-disable @typescript-eslint/no-shadow */
 
 describe("Tests for the Serializable class", () => {

--- a/tests/unit/scriptTransactionArguments.test.ts
+++ b/tests/unit/scriptTransactionArguments.test.ts
@@ -1,7 +1,20 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AccountAddress, Serializer, Deserializer, Bool, MoveVector, U128, U16, U256, U32, U64, U8 } from "../../src";
+import {
+  AccountAddress,
+  Serializer,
+  Deserializer,
+  Bool,
+  MoveVector,
+  U128,
+  U16,
+  U256,
+  U32,
+  U64,
+  U8,
+  TransactionArgument,
+} from "../../src";
 import { ScriptFunctionArgument, deserializeFromScriptArgument } from "../../src/transactions/instances";
 
 describe("Tests for the script transaction argument class", () => {
@@ -49,23 +62,23 @@ describe("Tests for the script transaction argument class", () => {
     validateBytes(MoveVector.U8([1, 2, 3, 4, 5]), scriptVectorU8Bytes);
   });
 
-  const deserializeAsScriptArg = (input: ScriptFunctionArgument) => {
+  const deserializeAsScriptArg = <T extends TransactionArgument>(input: ScriptFunctionArgument): T => {
     serializer = new Serializer();
     input.serializeForScriptFunction(serializer);
     const deserializer = new Deserializer(serializer.toUint8Array());
-    return deserializeFromScriptArgument(deserializer);
+    return deserializeFromScriptArgument(deserializer) as T;
   };
 
   it("should deserialize all types of ScriptTransactionArguments correctly", () => {
-    const scriptArgU8 = deserializeAsScriptArg(new U8(1)) as U8;
-    const scriptArgU16 = deserializeAsScriptArg(new U16(2)) as U16;
-    const scriptArgU32 = deserializeAsScriptArg(new U32(3)) as U32;
-    const scriptArgU64 = deserializeAsScriptArg(new U64(4)) as U64;
-    const scriptArgU128 = deserializeAsScriptArg(new U128(5)) as U128;
-    const scriptArgU256 = deserializeAsScriptArg(new U256(6)) as U256;
-    const scriptArgBool = deserializeAsScriptArg(new Bool(false)) as Bool;
-    const scriptArgAddress = deserializeAsScriptArg(AccountAddress.FOUR) as AccountAddress;
-    const scriptArgU8Vector = deserializeAsScriptArg(MoveVector.U8([1, 2, 3, 4, 5])) as MoveVector<U8>;
+    const scriptArgU8 = deserializeAsScriptArg<U8>(new U8(1));
+    const scriptArgU16 = deserializeAsScriptArg<U16>(new U16(2));
+    const scriptArgU32 = deserializeAsScriptArg<U32>(new U32(3));
+    const scriptArgU64 = deserializeAsScriptArg<U64>(new U64(4));
+    const scriptArgU128 = deserializeAsScriptArg<U128>(new U128(5));
+    const scriptArgU256 = deserializeAsScriptArg<U256>(new U256(6));
+    const scriptArgBool = deserializeAsScriptArg<Bool>(new Bool(false));
+    const scriptArgAddress = deserializeAsScriptArg<AccountAddress>(AccountAddress.FOUR);
+    const scriptArgU8Vector = deserializeAsScriptArg<MoveVector<U8>>(MoveVector.U8([1, 2, 3, 4, 5]));
 
     expect(scriptArgU8.value).toEqual(1);
     expect(scriptArgU16.value).toEqual(2);
@@ -88,7 +101,7 @@ describe("Tests for the script transaction argument class", () => {
     expect(deserializeAsScriptArg(new Bool(false)) instanceof Bool).toBe(true);
     expect(deserializeAsScriptArg(AccountAddress.FOUR) instanceof AccountAddress).toBe(true);
     expect(deserializeAsScriptArg(MoveVector.U8([1, 2, 3, 4, 5])) instanceof MoveVector).toBe(true);
-    const deserializedVectorU8 = deserializeAsScriptArg(MoveVector.U8([1, 2, 3, 4, 5])) as MoveVector<U8>;
+    const deserializedVectorU8 = deserializeAsScriptArg<MoveVector<U8>>(MoveVector.U8([1, 2, 3, 4, 5]));
     expect(deserializedVectorU8.values.every((v) => v instanceof U8)).toBe(true);
   });
 });

--- a/tests/unit/scriptTransactionArguments.test.ts
+++ b/tests/unit/scriptTransactionArguments.test.ts
@@ -14,8 +14,9 @@ import {
   U64,
   U8,
   TransactionArgument,
+  ScriptFunctionArgument,
+  deserializeFromScriptArgument,
 } from "../../src";
-import { ScriptFunctionArgument, deserializeFromScriptArgument } from "../../src/transactions/instances";
 
 describe("Tests for the script transaction argument class", () => {
   let serializer: Serializer;

--- a/tests/unit/typeTag.test.ts
+++ b/tests/unit/typeTag.test.ts
@@ -114,8 +114,10 @@ describe("Deserialize TypeTags", () => {
     const tag = new TypeTagVector(new TypeTagU32());
 
     tag.serialize(serializer);
-    const deserialized = TypeTag.deserialize(new Deserializer(serializer.toUint8Array())) as TypeTagVector;
-    expect(deserialized).toBeInstanceOf(TypeTagVector);
+    const deserialized = TypeTag.deserialize(new Deserializer(serializer.toUint8Array()));
+    if (!deserialized.isVector()) {
+      throw new Error("Expected deserialized value to be a TypeTagVector");
+    }
     expect(deserialized.value).toBeInstanceOf(TypeTagU32);
   });
 
@@ -124,7 +126,10 @@ describe("Deserialize TypeTags", () => {
     const tag = parseTypeTag(expectedTypeTag.string);
 
     tag.serialize(serializer);
-    const deserialized = TypeTag.deserialize(new Deserializer(serializer.toUint8Array())) as TypeTagStruct;
+    const deserialized = TypeTag.deserialize(new Deserializer(serializer.toUint8Array()));
+    if (!deserialized.isStruct()) {
+      throw new Error("Expected deserialized value to be a TypeTagStruct");
+    }
     expect(deserialized).toBeInstanceOf(TypeTagStruct);
     expect(deserialized.value).toBeInstanceOf(StructTag);
     expect(deserialized.value.address.toString()).toEqual(expectedTypeTag.address);

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -25,9 +25,9 @@ import {
   TypeTagParserErrorType,
   TypeTagReference,
   aptosCoinStructTag,
+  Identifier,
+  APTOS_COIN,
 } from "../../src";
-import { Identifier } from "../../src/transactions/instances";
-import { APTOS_COIN } from "../../src/utils/const";
 
 const MODULE_NAME = new Identifier("tag");
 const STRUCT_NAME = new Identifier("Tag");


### PR DESCRIPTION
### Description
This flattens all input arguments to be a single level, which should simplify the workflow without having to decide which one is nested and which one is not.

It also removes all unnecessary casts from tests and everywhere else, to ensure that there aren't any time bomb bugs due to casts.

Cleans up imports, found some more things to export

### Test Plan
All the tests pass locally!

### Related Links
<!-- Please link to any relevant issues or pull requests! -->