### PR TITLE
fix zero account sequence number

### DIFF
--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -209,9 +209,10 @@ export async function generateRawTransaction(args: {
 }): Promise<RawTransaction> {
   const { aptosConfig, sender, payload, options } = args;
 
-  const getSequenceNumber = options?.accountSequenceNumber
-    ? Promise.resolve({ sequence_number: options.accountSequenceNumber })
-    : getInfo({ aptosConfig, accountAddress: sender });
+  const getSequenceNumber =
+    options?.accountSequenceNumber !== undefined
+      ? Promise.resolve({ sequence_number: options.accountSequenceNumber })
+      : getInfo({ aptosConfig, accountAddress: sender });
 
   const getChainId = NetworkToChainId[aptosConfig.network]
     ? Promise.resolve({ chain_id: NetworkToChainId[aptosConfig.network] })

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -226,6 +226,30 @@ describe("transaction builder", () => {
       });
       expect(rawTxnWithDefaultMaxGasAmount.max_gas_amount).toBe(200000n);
     });
+
+    test("it generates a raw transaction with account not on chain and account sequence number set to 0", async () => {
+      const alice = Account.generate();
+      const bob = Account.generate();
+      const payload = await generateTransactionPayload({
+        aptosConfig: config,
+        function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+        functionArguments: [1, bob.accountAddress],
+      });
+      const rawTransaction = await generateRawTransaction({
+        aptosConfig: config,
+        sender: alice.accountAddress,
+        payload,
+        options: { accountSequenceNumber: 0 },
+      });
+      expect(rawTransaction.sequence_number).toBe(0n);
+      expect(() =>
+        generateRawTransaction({
+          aptosConfig: config,
+          sender: alice.accountAddress,
+          payload,
+        }),
+      ).rejects.toThrow();
+    });
   });
   describe("generate transaction", () => {
     test("it returns a serialized raw transaction", async () => {


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

This pull request addresses an issue in the `generateRawTransaction` function where the `getInfo` function throws an error when the account is not on the chain, and manually setting the account sequence number to 0 was ineffective due to the falsy nature of this value. The proposed solution involves a minor adjustment to ensure more robust handling of the account sequence number. This modification replaces the falsy check with a comparison to `undefined`, providing a more accurate and reliable method for handling the account sequence number.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
A new test case has been added to verify the behavior when generating a raw transaction with an account not on the chain and the account sequence number set to 0. Additionally, an error scenario has been tested where an attempt is made to generate a raw transaction without specifying the account sequence number, expecting an error to be thrown.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->