### PR TITLE
Add `your_fungible_asset` example and `transferFungibleAsset` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
   - All query functions return epoch milliseconds instead of ISO date strings.
 - [`Breaking`] Flatten options for all functions to be a single level
 - Cleanup internal usage of casting
-- Export AnyPublicKey and AnySignature types
+- Export `AnyPublicKey` and `AnySignature` types
+- Add `transferFungibleAsset` function to easily generate a transaction to transfer a fungible asset from sender's primary store to recipient's primary store
 
 ## 0.0.7 (2023-11-16)
 

--- a/examples/typescript/move/facoin/sources/fa_coin.move
+++ b/examples/typescript/move/facoin/sources/fa_coin.move
@@ -1,0 +1,158 @@
+/// A 2-in-1 module that combines managed_fungible_asset and coin_example into one module that when deployed, the
+/// deployer will be creating a new managed fungible asset with the hardcoded supply config, name, symbol, and decimals.
+/// The address of the asset can be obtained via get_metadata(). As a simple version, it only deals with primary stores.
+module FACoin::fa_coin {
+    use aptos_framework::fungible_asset::{Self, MintRef, TransferRef, BurnRef, Metadata, FungibleAsset};
+    use aptos_framework::object::{Self, Object};
+    use aptos_framework::primary_fungible_store;
+    use std::error;
+    use std::signer;
+    use std::string::utf8;
+    use std::option;
+
+    /// Only fungible asset metadata owner can make changes.
+    const ENOT_OWNER: u64 = 1;
+
+    const ASSET_SYMBOL: vector<u8> = b"FA";
+
+    #[resource_group_member(group = aptos_framework::object::ObjectGroup)]
+    /// Hold refs to control the minting, transfer and burning of fungible assets.
+    struct ManagedFungibleAsset has key {
+        mint_ref: MintRef,
+        transfer_ref: TransferRef,
+        burn_ref: BurnRef,
+    }
+
+    /// Initialize metadata object and store the refs.
+    // :!:>initialize
+    fun init_module(admin: &signer) {
+        let constructor_ref = &object::create_named_object(admin, ASSET_SYMBOL);
+        primary_fungible_store::create_primary_store_enabled_fungible_asset(
+            constructor_ref,
+            option::none(),
+            utf8(b"FA Coin"), /* name */
+            utf8(ASSET_SYMBOL), /* symbol */
+            8, /* decimals */
+            utf8(b"http://example.com/favicon.ico"), /* icon */
+            utf8(b"http://example.com"), /* project */
+        );
+
+        // Create mint/burn/transfer refs to allow creator to manage the fungible asset.
+        let mint_ref = fungible_asset::generate_mint_ref(constructor_ref);
+        let burn_ref = fungible_asset::generate_burn_ref(constructor_ref);
+        let transfer_ref = fungible_asset::generate_transfer_ref(constructor_ref);
+        let metadata_object_signer = object::generate_signer(constructor_ref);
+        move_to(
+            &metadata_object_signer,
+            ManagedFungibleAsset { mint_ref, transfer_ref, burn_ref }
+        )// <:!:initialize
+    }
+
+    #[view]
+    /// Return the address of the managed fungible asset that's created when this module is deployed.
+    public fun get_metadata(): Object<Metadata> {
+        let asset_address = object::create_object_address(&@FACoin, ASSET_SYMBOL);
+        object::address_to_object<Metadata>(asset_address)
+    }
+
+    // :!:>mint
+    /// Mint as the owner of metadata object and deposit to a specific account.
+    public entry fun mint(admin: &signer, to: address, amount: u64) acquires ManagedFungibleAsset {
+        let asset = get_metadata();
+        let managed_fungible_asset = authorized_borrow_refs(admin, asset);
+        let to_wallet = primary_fungible_store::ensure_primary_store_exists(to, asset);
+        let fa = fungible_asset::mint(&managed_fungible_asset.mint_ref, amount);
+        fungible_asset::deposit_with_ref(&managed_fungible_asset.transfer_ref, to_wallet, fa);
+    }// <:!:mint_to
+
+    /// Transfer as the owner of metadata object ignoring `frozen` field.
+    public entry fun transfer(admin: &signer, from: address, to: address, amount: u64) acquires ManagedFungibleAsset {
+        let asset = get_metadata();
+        let transfer_ref = &authorized_borrow_refs(admin, asset).transfer_ref;
+        let from_wallet = primary_fungible_store::primary_store(from, asset);
+        let to_wallet = primary_fungible_store::ensure_primary_store_exists(to, asset);
+        fungible_asset::transfer_with_ref(transfer_ref, from_wallet, to_wallet, amount);
+    }
+
+    /// Burn fungible assets as the owner of metadata object.
+    public entry fun burn(admin: &signer, from: address, amount: u64) acquires ManagedFungibleAsset {
+        let asset = get_metadata();
+        let burn_ref = &authorized_borrow_refs(admin, asset).burn_ref;
+        let from_wallet = primary_fungible_store::primary_store(from, asset);
+        fungible_asset::burn_from(burn_ref, from_wallet, amount);
+    }
+
+    /// Freeze an account so it cannot transfer or receive fungible assets.
+    public entry fun freeze_account(admin: &signer, account: address) acquires ManagedFungibleAsset {
+        let asset = get_metadata();
+        let transfer_ref = &authorized_borrow_refs(admin, asset).transfer_ref;
+        let wallet = primary_fungible_store::ensure_primary_store_exists(account, asset);
+        fungible_asset::set_frozen_flag(transfer_ref, wallet, true);
+    }
+
+    /// Unfreeze an account so it can transfer or receive fungible assets.
+    public entry fun unfreeze_account(admin: &signer, account: address) acquires ManagedFungibleAsset {
+        let asset = get_metadata();
+        let transfer_ref = &authorized_borrow_refs(admin, asset).transfer_ref;
+        let wallet = primary_fungible_store::ensure_primary_store_exists(account, asset);
+        fungible_asset::set_frozen_flag(transfer_ref, wallet, false);
+    }
+
+    /// Withdraw as the owner of metadata object ignoring `frozen` field.
+    public fun withdraw(admin: &signer, amount: u64, from: address): FungibleAsset acquires ManagedFungibleAsset {
+        let asset = get_metadata();
+        let transfer_ref = &authorized_borrow_refs(admin, asset).transfer_ref;
+        let from_wallet = primary_fungible_store::primary_store(from, asset);
+        fungible_asset::withdraw_with_ref(transfer_ref, from_wallet, amount)
+    }
+
+    /// Deposit as the owner of metadata object ignoring `frozen` field.
+    public fun deposit(admin: &signer, to: address, fa: FungibleAsset) acquires ManagedFungibleAsset {
+        let asset = get_metadata();
+        let transfer_ref = &authorized_borrow_refs(admin, asset).transfer_ref;
+        let to_wallet = primary_fungible_store::ensure_primary_store_exists(to, asset);
+        fungible_asset::deposit_with_ref(transfer_ref, to_wallet, fa);
+    }
+
+    /// Borrow the immutable reference of the refs of `metadata`.
+    /// This validates that the signer is the metadata object's owner.
+    inline fun authorized_borrow_refs(
+        owner: &signer,
+        asset: Object<Metadata>,
+    ): &ManagedFungibleAsset acquires ManagedFungibleAsset {
+        assert!(object::is_owner(asset, signer::address_of(owner)), error::permission_denied(ENOT_OWNER));
+        borrow_global<ManagedFungibleAsset>(object::object_address(&asset))
+    }
+
+    #[test(creator = @FACoin)]
+    fun test_basic_flow(
+        creator: &signer,
+    ) acquires ManagedFungibleAsset {
+        init_module(creator);
+        let creator_address = signer::address_of(creator);
+        let aaron_address = @0xface;
+
+        mint(creator, creator_address, 100);
+        let asset = get_metadata();
+        assert!(primary_fungible_store::balance(creator_address, asset) == 100, 4);
+        freeze_account(creator, creator_address);
+        assert!(primary_fungible_store::is_frozen(creator_address, asset), 5);
+        transfer(creator, creator_address, aaron_address, 10);
+        assert!(primary_fungible_store::balance(aaron_address, asset) == 10, 6);
+
+        unfreeze_account(creator, creator_address);
+        assert!(!primary_fungible_store::is_frozen(creator_address, asset), 7);
+        burn(creator, creator_address, 90);
+    }
+
+    #[test(creator = @FACoin, aaron = @0xface)]
+    #[expected_failure(abort_code = 0x50001, location = Self)]
+    fun test_permission_denied(
+        creator: &signer,
+        aaron: &signer
+    ) acquires ManagedFungibleAsset {
+        init_module(creator);
+        let creator_address = signer::address_of(creator);
+        mint(aaron, creator_address, 100);
+    }
+}

--- a/examples/typescript/publish_package_from_filepath.ts
+++ b/examples/typescript/publish_package_from_filepath.ts
@@ -54,7 +54,7 @@ async function main() {
     accountAddress: alice.accountAddress,
   });
   // published 2 modules
-  assert(accountModules.length === 2);
+  assert(accountModules.length === 3);
   // first account's module bytecode equals the published bytecode
   assert(accountModules[0].bytecode === `${Hex.fromHexInput(byteCode[0]).toString()}`);
   // second account's module bytecode equals the published bytecode

--- a/examples/typescript/your_fungible_asset.ts
+++ b/examples/typescript/your_fungible_asset.ts
@@ -1,0 +1,225 @@
+/* eslint-disable no-console */
+/* eslint-disable max-len */
+
+import {
+  Account,
+  AccountAddress,
+  AnyNumber,
+  Aptos,
+  AptosConfig,
+  InputViewRequestData,
+  Network,
+  NetworkToNetworkName,
+} from "@aptos-labs/ts-sdk";
+import { compilePackage, getPackageBytesToPublish } from "./utils";
+/**
+ * This example demonstrate how one can compile, deploy, and mint its own fungible asset (FA)
+ * It uses the fa_coin.move module that can be found in the move folder
+ *
+ * Before running this example, we should compile the package locally:
+ * 1. Acquire the Aptos CLI, see https://aptos.dev/cli-tools/aptos-cli/use-cli/install-aptos-cli
+ * 2. cd `~/aptos-ts-sdk/examples/typescript`
+ * 3. Run `pnpm run your_coin`
+ */
+
+// Setup the client
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const config = new AptosConfig({ network: APTOS_NETWORK });
+const aptos = new Aptos(config);
+
+/** Admin forcefully transfers the newly created coin to the specified receiver address */
+async function transferCoin(
+  admin: Account,
+  fromAddress: AccountAddress,
+  toAddress: AccountAddress,
+  amount: AnyNumber,
+): Promise<string> {
+  const transaction = await aptos.build.transaction({
+    sender: admin.accountAddress,
+    data: {
+      function: `${admin.accountAddress}::fa_coin::transfer`,
+      functionArguments: [fromAddress, toAddress, amount],
+    },
+  });
+
+  const senderAuthenticator = await aptos.sign.transaction({ signer: admin, transaction });
+  const pendingTxn = await aptos.submit.transaction({ transaction, senderAuthenticator });
+
+  return pendingTxn.hash;
+}
+
+/** Admin mint the newly created coin to the specified receiver address */
+async function mintCoin(admin: Account, receiver: Account, amount: AnyNumber): Promise<string> {
+  const transaction = await aptos.build.transaction({
+    sender: admin.accountAddress,
+    data: {
+      function: `${admin.accountAddress}::fa_coin::mint`,
+      functionArguments: [receiver.accountAddress, amount],
+    },
+  });
+
+  const senderAuthenticator = await aptos.sign.transaction({ signer: admin, transaction });
+  const pendingTxn = await aptos.submit.transaction({ transaction, senderAuthenticator });
+
+  return pendingTxn.hash;
+}
+
+/** Admin burns the newly created coin from the specified receiver address */
+async function burnCoin(admin: Account, fromAddress: AccountAddress, amount: AnyNumber): Promise<string> {
+  const transaction = await aptos.build.transaction({
+    sender: admin.accountAddress,
+    data: {
+      function: `${admin.accountAddress}::fa_coin::burn`,
+      functionArguments: [fromAddress, amount],
+    },
+  });
+
+  const senderAuthenticator = await aptos.sign.transaction({ signer: admin, transaction });
+  const pendingTxn = await aptos.submit.transaction({ transaction, senderAuthenticator });
+
+  return pendingTxn.hash;
+}
+
+/** Admin freezes the primary fungible store of the specified account */
+async function freeze(admin: Account, targetAddress: AccountAddress): Promise<string> {
+  const transaction = await aptos.build.transaction({
+    sender: admin.accountAddress,
+    data: {
+      function: `${admin.accountAddress}::fa_coin::freeze_account`,
+      functionArguments: [targetAddress],
+    },
+  });
+
+  const senderAuthenticator = await aptos.sign.transaction({ signer: admin, transaction });
+  const pendingTxn = await aptos.submit.transaction({ transaction, senderAuthenticator });
+
+  return pendingTxn.hash;
+}
+
+/** Admin unfreezes the primary fungible store of the specified account */
+async function unfreeze(admin: Account, targetAddress: AccountAddress): Promise<string> {
+  const transaction = await aptos.build.transaction({
+    sender: admin.accountAddress,
+    data: {
+      function: `${admin.accountAddress}::fa_coin::unfreeze_account`,
+      functionArguments: [targetAddress],
+    },
+  });
+
+  const senderAuthenticator = await aptos.sign.transaction({ signer: admin, transaction });
+  const pendingTxn = await aptos.submit.transaction({ transaction, senderAuthenticator });
+
+  return pendingTxn.hash;
+}
+
+const getFaBalance = async (owner: Account, assetType: string): Promise<number> => {
+  const data = await aptos.getCurrentFungibleAssetBalances({
+    options: {
+      where: {
+        owner_address: { _eq: owner.accountAddress.toStringLong() },
+        asset_type: { _eq: assetType },
+      },
+    },
+  });
+
+  return data[0]?.amount ?? 0;
+};
+
+/** Return the address of the managed fungible asset that's created when this module is deployed */
+async function getMetadata(admin: Account): Promise<string> {
+  const payload: InputViewRequestData = {
+    function: `${admin.accountAddress}::fa_coin::get_metadata`,
+    functionArguments: [],
+  };
+  const res = (await aptos.view<[{ inner: string }]>({ payload }))[0];
+  return res.inner;
+}
+
+async function main() {
+  const alice = Account.generate();
+  const bob = Account.generate();
+  const charlie = Account.generate();
+
+  console.log("\n=== Addresses ===");
+  console.log(`Alice: ${alice.accountAddress.toString()}`);
+  console.log(`Bob: ${bob.accountAddress.toString()}`);
+  console.log(`Charlie: ${charlie.accountAddress.toString()}`);
+
+  await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: 100_000_000 });
+  await aptos.fundAccount({ accountAddress: bob.accountAddress, amount: 100_000_000 });
+
+  console.log("\n=== Compiling MoonCoin package locally ===");
+  compilePackage("facoin", "facoin/facoin.json", [{ name: "FACoin", address: alice.accountAddress }]);
+
+  const { metadataBytes, byteCode } = getPackageBytesToPublish("facoin/facoin.json");
+
+  console.log("\n===Publishing FAcoin package===");
+  const transaction = await aptos.publishPackageTransaction({
+    account: alice.accountAddress,
+    metadataBytes,
+    moduleBytecode: byteCode,
+  });
+  const response = await aptos.signAndSubmitTransaction({
+    signer: alice,
+    transaction,
+  });
+  console.log(`Transaction hash: ${response.hash}`);
+  await aptos.waitForTransaction({
+    transactionHash: response.hash,
+  });
+
+  const metadataAddress = await getMetadata(alice);
+  console.log("metadata address:", metadataAddress);
+
+  console.log("All the balances in this exmaple refer to balance in primary fungible stores of each account.");
+  console.log(`Alice's initial FACoin balance: ${await getFaBalance(alice, metadataAddress)}.`);
+  console.log(`Bob's initial FACoin balance: ${await getFaBalance(bob, metadataAddress)}.`);
+  console.log(`Charlie's initial balance: ${await await getFaBalance(charlie, metadataAddress)}.`);
+
+  console.log("Alice mints Charlie 100 coins.");
+  const mintCoinTransactionHash = await mintCoin(alice, charlie, 100);
+
+  await aptos.waitForTransaction({ transactionHash: mintCoinTransactionHash });
+  console.log(
+    `Charlie's updated FACoin primary fungible store balance: ${await getFaBalance(charlie, metadataAddress)}.`,
+  );
+
+  console.log("Alice freezes Bob's account.");
+  const freezeTransactionHash = await freeze(alice, bob.accountAddress);
+  await aptos.waitForTransaction({ transactionHash: freezeTransactionHash });
+
+  console.log(
+    "Alice as the admin forcefully transfers the newly minted coins of Charlie to Bob ignoring that Bob's account is frozen.",
+  );
+  const transferCoinTransactionHash = await transferCoin(alice, charlie.accountAddress, bob.accountAddress, 100);
+  await aptos.waitForTransaction({ transactionHash: transferCoinTransactionHash });
+  console.log(`Bob's updated FACoin balance: ${await getFaBalance(bob, metadataAddress)}.`);
+
+  console.log("Alice unfreezes Bob's account.");
+  const unfreezeTransactionHash = await unfreeze(alice, bob.accountAddress);
+  await aptos.waitForTransaction({ transactionHash: unfreezeTransactionHash });
+
+  console.log("Alice burns 50 coins from Bob.");
+  const burnCoinTransactionHash = await burnCoin(alice, bob.accountAddress, 50);
+  await aptos.waitForTransaction({ transactionHash: burnCoinTransactionHash });
+  console.log(`Bob's updated FACoin balance: ${await getFaBalance(bob, metadataAddress)}.`);
+
+  /// Normal fungible asset transfer between primary stores
+  console.log("Bob transfers 10 coins to Alice as the owner.");
+  const transferFungibleAssetRawTransaction = await aptos.transferFungibleAsset({
+    sender: bob,
+    fungibleAssetMetadataAddress: AccountAddress.fromRelaxed(metadataAddress),
+    recipient: alice.accountAddress,
+    amount: 10,
+  });
+  const transferFungibleAssetTransaction = await aptos.signAndSubmitTransaction({
+    signer: bob,
+    transaction: transferFungibleAssetRawTransaction,
+  });
+  await aptos.waitForTransaction({ transactionHash: transferFungibleAssetTransaction.hash });
+  console.log(`Alice's updated FACoin balance: ${await getFaBalance(alice, metadataAddress)}.`);
+  console.log(`Bob's updated FACoin balance: ${await getFaBalance(bob, metadataAddress)}.`);
+  console.log("done.");
+}
+
+main();

--- a/src/api/fungibleAsset.ts
+++ b/src/api/fungibleAsset.ts
@@ -13,6 +13,7 @@ import {
   getCurrentFungibleAssetBalances,
   getFungibleAssetActivities,
   getFungibleAssetMetadata,
+  transferFungibleAsset,
 } from "../internal/fungibleAsset";
 import {
   CurrentFungibleAssetBalancesBoolExp,
@@ -22,6 +23,8 @@ import {
 import { ProcessorType } from "../utils/const";
 import { AptosConfig } from "./aptosConfig";
 import { waitForIndexerOnVersion } from "./utils";
+import { Account, AccountAddress } from "../core";
+import { InputGenerateTransactionOptions, SingleSignerTransaction } from "../transactions";
 
 /**
  * A class to query all `FungibleAsset` related queries on Aptos.
@@ -30,13 +33,11 @@ export class FungibleAsset {
   constructor(readonly config: AptosConfig) {}
 
   /**
-   * Queries the current fungible asset metadata.
+   * Queries all fungible asset metadata.
    *
-   * This query returns the fungible asset metadata for all fungible assets.
-   * It can be filtered by creator address and asset type.
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
    *
-   * @returns getFungibleAssetMetadata A list of fungible asset metadata
+   * @returns A list of fungible asset metadata
    */
   async getFungibleAssetMetadata(args?: {
     minimumLedgerVersion?: AnyNumber;
@@ -51,7 +52,7 @@ export class FungibleAsset {
   }
 
   /**
-   * Queries the current specific fungible asset metadata
+   * Queries a fungible asset metadata
    *
    * This query returns the fungible asset metadata for a specific fungible asset.
    *
@@ -61,7 +62,7 @@ export class FungibleAsset {
    * "0x1::aptos_coin::AptosCoin" for Aptos Coin
    * "0xc2948283c2ce03aafbb294821de7ee684b06116bb378ab614fa2de07a99355a8" - address format if this is fungible asset
    *
-   * @returns getFungibleAssetMetadata A fungible asset metadata item
+   * @returns A fungible asset metadata item
    */
   async getFungibleAssetMetadataByAssetType(args: {
     assetType: string;
@@ -85,13 +86,11 @@ export class FungibleAsset {
   }
 
   /**
-   * Queries the fungible asset activities
+   * Queries all fungible asset activities
    *
-   * This query returns the fungible asset activities.
-   * It can be filtered by owner address, asset type, and type.
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
    *
-   * @returns GetFungibleAssetActivitiesResponse A list of fungible asset metadata
+   * @returns A list of fungible asset metadata
    */
   async getFungibleAssetActivities(args?: {
     minimumLedgerVersion?: AnyNumber;
@@ -106,13 +105,11 @@ export class FungibleAsset {
   }
 
   /**
-   * Queries the fungible asset balance
+   * Queries all fungible asset balances
    *
-   * This query returns the fungible asset balance.
-   * It can be filtered by owner address, and asset type
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
    *
-   * @returns GetCurrentFungibleAssetBalancesResponse A list of fungible asset metadata
+   * @returns A list of fungible asset metadata
    */
   async getCurrentFungibleAssetBalances(args?: {
     minimumLedgerVersion?: AnyNumber;
@@ -124,5 +121,28 @@ export class FungibleAsset {
       processorTypes: [ProcessorType.FUNGIBLE_ASSET_PROCESSOR],
     });
     return getCurrentFungibleAssetBalances({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   *  Transfer `amount` of fungible asset from sender's primary store to recipient's primary store.
+   *
+   * Use this method to transfer any fungible asset including fungible token.
+   *
+   * @param sender The sender account
+   * @param fungibleAssetMetadataAddress The fungible asset account address.
+   * For example if you’re transferring USDT this would be the USDT address
+   * @param recipient The recipient account address
+   * @param amount Number of assets to transfer
+   *
+   * @returns A SingleSignerTransaction that can be simulated or submitted to chain.
+   */
+  async transferFungibleAsset(args: {
+    sender: Account;
+    fungibleAssetMetadataAddress: AccountAddress;
+    recipient: AccountAddress;
+    amount: AnyNumber;
+    options?: InputGenerateTransactionOptions;
+  }): Promise<SingleSignerTransaction> {
+    return transferFungibleAsset({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/internal/fungibleAsset.ts
+++ b/src/internal/fungibleAsset.ts
@@ -10,6 +10,7 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import {
+  AnyNumber,
   GetCurrentFungibleAssetBalancesResponse,
   GetFungibleAssetActivitiesResponse,
   GetFungibleAssetMetadataResponse,
@@ -32,6 +33,9 @@ import {
   FungibleAssetActivitiesBoolExp,
   FungibleAssetMetadataBoolExp,
 } from "../types/generated/types";
+import { Account, AccountAddress } from "../core";
+import { InputGenerateTransactionOptions } from "../transactions";
+import { generateTransaction } from "./transactionSubmission";
 
 export async function getFungibleAssetMetadata(args: {
   aptosConfig: AptosConfig;
@@ -103,4 +107,26 @@ export async function getCurrentFungibleAssetBalances(args: {
   });
 
   return data.current_fungible_asset_balances;
+}
+
+export async function transferFungibleAsset(args: {
+  aptosConfig: AptosConfig;
+  sender: Account;
+  fungibleAssetMetadataAddress: AccountAddress;
+  recipient: AccountAddress;
+  amount: AnyNumber;
+  options?: InputGenerateTransactionOptions;
+}) {
+  const { aptosConfig, sender, fungibleAssetMetadataAddress, recipient, amount, options } = args;
+  const transaction = await generateTransaction({
+    aptosConfig,
+    sender: sender.accountAddress,
+    data: {
+      function: "0x1::primary_fungible_store::transfer",
+      typeArguments: ["0x1::fungible_asset::Metadata"],
+      functionArguments: [fungibleAssetMetadataAddress, recipient, amount],
+    },
+    options,
+  });
+  return transaction;
 }


### PR DESCRIPTION
### Description
- Add `your_fungible_asset` example (https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/examples/typescript/your_fungible_asset.ts)
- Add `transferFungibleAsset` function to generate a transaction to transfer a fungible asset from sender's primary store to recipient's primary store

### Test Plan
same output from existing example https://aptos.dev/tutorials/your-first-fungible-asset/#step-32-completing-the-example
```
Transaction hash: 0xc61eb3c2a9d1ac1761fc679a6a70ce595933cc7c2cc1a4ab7335c9ee3e2386cf
All the balances in this exmaple refer to balance in primary fungible stores of each account.
Alice's initial FACoin balance: 0.
Bob's initial FACoin balance: 0.
Charlie's initial balance: 0.
Alice mints Charlie 100 coins.
Charlie's updated FACoin primary fungible store balance: 100.
Alice freezes Bob's account.
Alice as the admin forcefully transfers the newly minted coins of Charlie to Bob ignoring that Bob's account is frozen.
Bob's updated FACoin balance: 100.
Alice unfreezes Bob's account.
Alice burns 50 coins from Bob.
Bob's updated FACoin balance: 50.
Bob transfers 10 coins to Alice as the owner.
Alice's updated FACoin balance: 10.
Bob's updated FACoin balance: 40.
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->