### PR TITLE
Add rotate key example

### DIFF
--- a/examples/typescript/rotate_key.ts
+++ b/examples/typescript/rotate_key.ts
@@ -1,0 +1,55 @@
+import { Account, AccountAddress, Aptos, AptosConfig, Network, NetworkToNetworkName } from "@aptos-labs/ts-sdk";
+
+const WIDTH = 16;
+
+// Setup the client
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const config = new AptosConfig({ network: APTOS_NETWORK });
+const aptos = new Aptos(config);
+
+function truncate(address: AccountAddress): string {
+  return `${address.toString().substring(0, 6)}...${address
+    .toString()
+    .substring(address.toString().length - 4, address.toString().length)}`;
+}
+
+function formatAccountInfo(account: Account): string {
+  const vals: any[] = [
+    account.accountAddress,
+    Account.authKey({ publicKey: account.publicKey }),
+    account.privateKey,
+    account.publicKey,
+  ];
+
+  return vals
+    .map((v) => {
+      return truncate(v).padEnd(WIDTH);
+    })
+    .join(" ");
+}
+
+(async () => {
+  const alice = Account.generate();
+  const bob = Account.generate();
+
+  await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: 1000000000 });
+  await aptos.fundAccount({ accountAddress: bob.accountAddress, amount: 1000000000 });
+
+  console.log(
+    `\n${"Account".padEnd(WIDTH)} ${"Address".padEnd(WIDTH)} ${"Auth Key".padEnd(WIDTH)} ${"Private Key".padEnd(
+      WIDTH,
+    )} ${"Public Key".padEnd(WIDTH)}`,
+  );
+  console.log(`---------------------------------------------------------------------------------`);
+  console.log(`${"alice".padEnd(WIDTH)} ${formatAccountInfo(alice)}`);
+  console.log(`${"bob".padEnd(WIDTH)} ${formatAccountInfo(bob)}`);
+  console.log("\n...rotating...".padStart(WIDTH));
+
+  // Rotate the key!
+  await aptos.rotateAuthKey({ fromAccount: alice, toNewPrivateKey: bob.privateKey });
+
+  const aliceNew = Account.fromPrivateKeyAndAddress({ privateKey: bob.privateKey, address: alice.accountAddress });
+
+  console.log(`\n${"alice".padEnd(WIDTH)} ${formatAccountInfo(aliceNew)}`);
+  console.log(`${"bob".padEnd(WIDTH)} ${formatAccountInfo(bob)}\n`);
+})();


### PR DESCRIPTION
### Description
Add rotate key example

### Test Plan
same output as https://aptos.dev/guides/account-management/key-rotation/
```
Account          Address          Auth Key         Private Key      Public Key      
---------------------------------------------------------------------------------
alice            0x8b9d...2b6a    0x8b9d...2b6a    0x1ba4...cf59    0xed41...c6fc   
bob              0x0737...4246    0x0737...4246    0x1eac...e3ca    0x5979...a27d   
 
...rotating...

alice            0x8b9d...2b6a    0x0737...4246    0x1eac...e3ca    0x5979...a27d   
bob              0x0737...4246    0x0737...4246    0x1eac...e3ca    0x5979...a27d  
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->