### PR TITLE
[accountAddress] Make strict mode optional, and relaxed default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Cleanup internal usage of casting
 - Export `AnyPublicKey` and `AnySignature` types
 - Add `transferFungibleAsset` function to easily generate a transaction to transfer a fungible asset from sender's primary store to recipient's primary store
+- [`Breaking`] AccountAddress.fromRelaxed is now AccountAddress.from, and a new AccountAddress.fromStrict has the old functionality.
 
 ## 0.0.7 (2023-11-16)
 

--- a/examples/typescript/multi_agent_transfer.ts
+++ b/examples/typescript/multi_agent_transfer.ts
@@ -121,7 +121,7 @@ const example = async () => {
     data: {
       bytecode: TRANSFER_SCRIPT,
       typeArguments: [parseTypeTag(APTOS_COIN)],
-      functionArguments: [AccountAddress.fromStringRelaxed(objectAddress), new U64(TRANSFER_AMOUNT)],
+      functionArguments: [AccountAddress.fromString(objectAddress), new U64(TRANSFER_AMOUNT)],
     },
   });
 

--- a/examples/typescript/your_fungible_asset.ts
+++ b/examples/typescript/your_fungible_asset.ts
@@ -208,7 +208,7 @@ async function main() {
   console.log("Bob transfers 10 coins to Alice as the owner.");
   const transferFungibleAssetRawTransaction = await aptos.transferFungibleAsset({
     sender: bob,
-    fungibleAssetMetadataAddress: AccountAddress.fromRelaxed(metadataAddress),
+    fungibleAssetMetadataAddress: AccountAddress.from(metadataAddress),
     recipient: alice.accountAddress,
     amount: 10,
   });

--- a/src/bcs/deserializer.ts
+++ b/src/bcs/deserializer.ts
@@ -222,10 +222,10 @@ export class Deserializer {
    * @example
    * // serialize a vector of addresses
    * const addresses = new Array<AccountAddress>(
-   *   AccountAddress.fromRelaxed("0x1"),
-   *   AccountAddress.fromRelaxed("0x2"),
-   *   AccountAddress.fromRelaxed("0xa"),
-   *   AccountAddress.fromRelaxed("0xb"),
+   *   AccountAddress.from("0x1"),
+   *   AccountAddress.from("0x2"),
+   *   AccountAddress.from("0xa"),
+   *   AccountAddress.from("0xb"),
    * );
    * const serializer = new Serializer();
    * serializer.serializeVector(addresses);

--- a/src/bcs/serializer.ts
+++ b/src/bcs/serializer.ts
@@ -298,10 +298,10 @@ export class Serializer {
    * @param values The array of BCS Serializable values
    * @example
    * const addresses = new Array<AccountAddress>(
-   *   AccountAddress.fromRelaxed("0x1"),
-   *   AccountAddress.fromRelaxed("0x2"),
-   *   AccountAddress.fromRelaxed("0xa"),
-   *   AccountAddress.fromRelaxed("0xb"),
+   *   AccountAddress.from("0x1"),
+   *   AccountAddress.from("0x2"),
+   *   AccountAddress.from("0xa"),
+   *   AccountAddress.from("0xb"),
    * );
    * const serializer = new Serializer();
    * serializer.serializeVector(addresses);

--- a/src/core/accountAddress.ts
+++ b/src/core/accountAddress.ts
@@ -218,7 +218,7 @@ export class AccountAddress extends Serializable implements TransactionArgument 
 
   /**
    * NOTE: This function has strict parsing behavior. For relaxed behavior, please use
-   * the `fromStringRelaxed` function.
+   * the `fromString` function.
    *
    * Creates an instance of AccountAddress from a hex string.
    *
@@ -243,13 +243,13 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    *
    * @returns An instance of AccountAddress.
    */
-  static fromString(input: string): AccountAddress {
+  static fromStringStrict(input: string): AccountAddress {
     // Assert the string starts with 0x.
     if (!input.startsWith("0x")) {
       throw new ParsingError("Hex string must start with a leading 0x.", AddressInvalidReason.LEADING_ZERO_X_REQUIRED);
     }
 
-    const address = AccountAddress.fromStringRelaxed(input);
+    const address = AccountAddress.fromString(input);
 
     // Check if the address is in LONG form. If it is not, this is only allowed for
     // special addresses, in which case we check it is in proper SHORT form.
@@ -274,8 +274,8 @@ export class AccountAddress extends Serializable implements TransactionArgument 
 
   /**
    * NOTE: This function has relaxed parsing behavior. For strict behavior, please use
-   * the `fromString` function. Where possible use `fromString` rather than this
-   * function, `fromStringRelaxed` is only provided for backwards compatibility.
+   * the `fromStringStrict` function. Where possible use `fromStringStrict` rather than this
+   * function, `fromString` is only provided for backwards compatibility.
    *
    * Creates an instance of AccountAddress from a hex string.
    *
@@ -297,7 +297,7 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    *
    * @returns An instance of AccountAddress.
    */
-  static fromStringRelaxed(input: string): AccountAddress {
+  static fromString(input: string): AccountAddress {
     let parsedInput = input;
     // Remove leading 0x for parsing.
     if (input.startsWith("0x")) {
@@ -341,22 +341,6 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    * This handles, Uint8array, string, and AccountAddress itself
    * @param input
    */
-  static fromRelaxed(input: AccountAddressInput): AccountAddress {
-    if (input instanceof AccountAddress) {
-      return input;
-    }
-    if (input instanceof Uint8Array) {
-      return new AccountAddress(input);
-    }
-    return AccountAddress.fromStringRelaxed(input);
-  }
-
-  /**
-   * Convenience method for creating an AccountAddress from all known inputs.
-   *
-   * This handles, Uint8array, string, and AccountAddress itself
-   * @param input
-   */
   static from(input: AccountAddressInput): AccountAddress {
     if (input instanceof AccountAddress) {
       return input;
@@ -367,6 +351,22 @@ export class AccountAddress extends Serializable implements TransactionArgument 
     return AccountAddress.fromString(input);
   }
 
+  /**
+   * Convenience method for creating an AccountAddress from all known inputs.
+   *
+   * This handles, Uint8array, string, and AccountAddress itself
+   * @param input
+   */
+  static fromStrict(input: AccountAddressInput): AccountAddress {
+    if (input instanceof AccountAddress) {
+      return input;
+    }
+    if (input instanceof Uint8Array) {
+      return new AccountAddress(input);
+    }
+    return AccountAddress.fromStringStrict(input);
+  }
+
   // ===
   // Methods for checking validity.
   // ===
@@ -375,15 +375,15 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    * Check if the string is a valid AccountAddress.
    *
    * @param args.input A hex string representing an account address.
-   * @param args.relaxed If true, use relaxed parsing behavior. If false, use strict parsing behavior.
+   * @param args.strict If true, use strict parsing behavior. If false, use relaxed parsing behavior.
    *
    * @returns valid = true if the string is valid, valid = false if not. If the string
    * is not valid, invalidReason will be set explaining why it is invalid.
    */
-  static isValid(args: { input: AccountAddressInput; relaxed?: boolean }): ParsingResult<AddressInvalidReason> {
+  static isValid(args: { input: AccountAddressInput; strict?: boolean }): ParsingResult<AddressInvalidReason> {
     try {
-      if (args.relaxed) {
-        AccountAddress.fromRelaxed(args.input);
+      if (args.strict) {
+        AccountAddress.fromStrict(args.input);
       } else {
         AccountAddress.from(args.input);
       }

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -113,7 +113,7 @@ export async function getOwnerAddress(args: { aptosConfig: AptosConfig; name: st
 
   const owner = unwrapOption<MoveAddressType>(res[0]);
 
-  return owner ? AccountAddress.fromRelaxed(owner).toString() : undefined;
+  return owner ? AccountAddress.from(owner).toString() : undefined;
 }
 
 export interface RegisterNameParameters {
@@ -240,7 +240,7 @@ export async function getPrimaryName(args: {
     aptosConfig,
     payload: {
       function: `${routerAddress}::router::get_primary_name`,
-      functionArguments: [AccountAddress.fromRelaxed(address).toString()],
+      functionArguments: [AccountAddress.from(address).toString()],
     },
   });
 
@@ -307,7 +307,7 @@ export async function getTargetAddress(args: {
   });
 
   const target = unwrapOption<MoveAddressType>(res[0]);
-  return target ? AccountAddress.fromRelaxed(target).toString() : undefined;
+  return target ? AccountAddress.from(target).toString() : undefined;
 }
 
 export async function setTargetAddress(args: {

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -39,7 +39,7 @@ export async function getAccountEventsByEventType(args: {
   options?: PaginationArgs & OrderByArg<GetEventsResponse[0]>;
 }): Promise<GetEventsResponse> {
   const { accountAddress, aptosConfig, eventType, options } = args;
-  const address = AccountAddress.fromRelaxed(accountAddress).toStringLong();
+  const address = AccountAddress.from(accountAddress).toStringLong();
 
   const whereCondition: EventsBoolExp = {
     account_address: { _eq: address },

--- a/src/internal/faucet.ts
+++ b/src/internal/faucet.ts
@@ -27,7 +27,7 @@ export async function fundAccount(args: {
     aptosConfig,
     path: "fund",
     body: {
-      address: AccountAddress.fromRelaxed(accountAddress).toString(),
+      address: AccountAddress.from(accountAddress).toString(),
       amount,
     },
     originMethod: "fundAccount",

--- a/src/internal/staking.ts
+++ b/src/internal/staking.ts
@@ -20,7 +20,7 @@ export async function getNumberOfDelegators(args: {
   poolAddress: AccountAddressInput;
 }): Promise<number> {
   const { aptosConfig, poolAddress } = args;
-  const address = AccountAddress.fromRelaxed(poolAddress).toStringLong();
+  const address = AccountAddress.from(poolAddress).toStringLong();
   const query = {
     query: GetNumberOfDelegators,
     variables: { where_condition: { pool_address: { _eq: address } } },
@@ -57,8 +57,8 @@ export async function getDelegatedStakingActivities(args: {
   const query = {
     query: GetDelegatedStakingActivities,
     variables: {
-      delegatorAddress: AccountAddress.fromRelaxed(delegatorAddress).toStringLong(),
-      poolAddress: AccountAddress.fromRelaxed(poolAddress).toStringLong(),
+      delegatorAddress: AccountAddress.from(delegatorAddress).toStringLong(),
+      poolAddress: AccountAddress.from(poolAddress).toStringLong(),
     },
   };
   const data = await queryIndexer<GetDelegatedStakingActivitiesQuery>({ aptosConfig, query });

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -279,7 +279,7 @@ export async function publicPackageTransaction(args: {
 
   const transaction = await generateTransaction({
     aptosConfig,
-    sender: AccountAddress.fromRelaxed(account),
+    sender: AccountAddress.from(account),
     data: {
       function: "0x1::code::publish_package_txn",
       functionArguments: [MoveVector.U8(metadataBytes), new MoveVector(totalByteCode)],

--- a/src/transactions/instances/moduleId.ts
+++ b/src/transactions/instances/moduleId.ts
@@ -37,7 +37,7 @@ export class ModuleId extends Serializable {
     if (parts.length !== 2) {
       throw new Error("Invalid module id.");
     }
-    return new ModuleId(AccountAddress.fromStringRelaxed(parts[0]), new Identifier(parts[1]));
+    return new ModuleId(AccountAddress.fromString(parts[0]), new Identifier(parts[1]));
   }
 
   serialize(serializer: Serializer): void {

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -150,7 +150,7 @@ function parseArg(
   // TODO: support uint8array?
   if (param.isAddress()) {
     if (isString(arg)) {
-      return AccountAddress.fromStringRelaxed(arg);
+      return AccountAddress.fromString(arg);
     }
     throwTypeMismatch("string", position);
   }
@@ -227,7 +227,7 @@ function parseArg(
     if (param.isObject()) {
       // The inner type of Object doesn't matter, since it's just syntactic sugar
       if (isString(arg)) {
-        return AccountAddress.fromStringRelaxed(arg);
+        return AccountAddress.fromString(arg);
       }
       throwTypeMismatch("string", position);
     }

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -234,7 +234,7 @@ export async function generateRawTransaction(args: {
   };
 
   return new RawTransaction(
-    AccountAddress.fromRelaxed(sender),
+    AccountAddress.from(sender),
     BigInt(sequenceNumber),
     payload,
     BigInt(maxGasAmount),
@@ -290,18 +290,18 @@ export async function buildTransaction(args: InputGenerateRawTransactionArgs): P
   // if multi agent transaction
   if ("secondarySignerAddresses" in args) {
     const signers: Array<AccountAddress> =
-      args.secondarySignerAddresses?.map((signer) => AccountAddress.fromRelaxed(signer)) ?? [];
+      args.secondarySignerAddresses?.map((signer) => AccountAddress.from(signer)) ?? [];
 
     return {
       rawTransaction: rawTxn,
       secondarySignerAddresses: signers,
-      feePayerAddress: args.feePayerAddress ? AccountAddress.fromRelaxed(args.feePayerAddress) : undefined,
+      feePayerAddress: args.feePayerAddress ? AccountAddress.from(args.feePayerAddress) : undefined,
     };
   }
   // return the raw transaction
   return {
     rawTransaction: rawTxn,
-    feePayerAddress: args.feePayerAddress ? AccountAddress.fromRelaxed(args.feePayerAddress) : undefined,
+    feePayerAddress: args.feePayerAddress ? AccountAddress.from(args.feePayerAddress) : undefined,
   };
 }
 

--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -296,7 +296,7 @@ function parseTypeTagInner(str: string, types: Array<TypeTag>, allowGenerics: bo
 
       return new TypeTagStruct(
         new StructTag(
-          AccountAddress.fromStringRelaxed(structParts[0]),
+          AccountAddress.fromString(structParts[0]),
           new Identifier(structParts[1]),
           new Identifier(structParts[2]),
           types,

--- a/tests/e2e/ans/publishANSContracts.ts
+++ b/tests/e2e/ans/publishANSContracts.ts
@@ -32,7 +32,7 @@ export async function publishAnsContract(
   aptos: Aptos,
 ): Promise<{ address: AccountAddress; privateKey: Ed25519PrivateKey }> {
   const ret = {
-    address: AccountAddress.fromStringRelaxed(LOCAL_ANS_ACCOUNT_ADDRESS),
+    address: AccountAddress.fromString(LOCAL_ANS_ACCOUNT_ADDRESS),
     privateKey: new Ed25519PrivateKey(LOCAL_ANS_ACCOUNT_PK),
   };
   try {

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -15,27 +15,6 @@ import {
 describe("account api", () => {
   const FUND_AMOUNT = 100_000_000;
 
-  describe("throws when account address in invalid", () => {
-    test("it throws with a short account address", async () => {
-      const config = new AptosConfig({ network: Network.LOCAL });
-      const aptos = new Aptos(config);
-      await expect(async () =>
-        aptos.getAccountInfo({
-          accountAddress: "ca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0",
-        }),
-      ).rejects.toThrow("Hex string must start with a leading 0x.");
-    });
-
-    test("it throws when invalid account address", async () => {
-      const config = new AptosConfig({ network: Network.LOCAL });
-      const aptos = new Aptos(config);
-      await expect(async () => aptos.getAccountInfo({ accountAddress: "0x123" })).rejects.toThrow(
-        // eslint-disable-next-line max-len
-        "The given hex string 0x123 is not a special address, it must be represented as 0x + 64 chars.",
-      );
-    });
-  });
-
   describe("fetch data", () => {
     test("it fetches account data", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });

--- a/tests/e2e/transaction/transactionArguments.test.ts
+++ b/tests/e2e/transaction/transactionArguments.test.ts
@@ -86,9 +86,9 @@ describe("various transaction arguments", () => {
       resourceType: `${senderAccount.accountAddress}::tx_args_module::SetupData`,
     });
 
-    moduleObjects.push(AccountAddress.fromStringRelaxed(setupData.empty_object_1.inner));
-    moduleObjects.push(AccountAddress.fromStringRelaxed(setupData.empty_object_2.inner));
-    moduleObjects.push(AccountAddress.fromStringRelaxed(setupData.empty_object_3.inner));
+    moduleObjects.push(AccountAddress.fromString(setupData.empty_object_1.inner));
+    moduleObjects.push(AccountAddress.fromString(setupData.empty_object_2.inner));
+    moduleObjects.push(AccountAddress.fromString(setupData.empty_object_3.inner));
 
     transactionArguments = [
       new Bool(true),
@@ -110,12 +110,12 @@ describe("various transaction arguments", () => {
       MoveVector.U128([0, 1, 2, MAX_U128_BIG_INT - BigInt(2), MAX_U128_BIG_INT - BigInt(1), MAX_U128_BIG_INT]),
       MoveVector.U256([0, 1, 2, MAX_U256_BIG_INT - BigInt(2), MAX_U256_BIG_INT - BigInt(1), MAX_U256_BIG_INT]),
       new MoveVector([
-        AccountAddress.fromStringRelaxed("0x0"),
-        AccountAddress.fromStringRelaxed("0xabc"),
-        AccountAddress.fromStringRelaxed("0xdef"),
-        AccountAddress.fromStringRelaxed("0x123"),
-        AccountAddress.fromStringRelaxed("0x456"),
-        AccountAddress.fromStringRelaxed("0x789"),
+        AccountAddress.fromString("0x0"),
+        AccountAddress.fromString("0xabc"),
+        AccountAddress.fromString("0xdef"),
+        AccountAddress.fromString("0x123"),
+        AccountAddress.fromString("0x456"),
+        AccountAddress.fromString("0x789"),
       ]),
       EXPECTED_VECTOR_STRING,
       new MoveVector(moduleObjects),
@@ -360,7 +360,7 @@ describe("various transaction arguments", () => {
       }
 
       const secondarySignerAddressesParsed = responseSignature.secondary_signer_addresses.map((address) =>
-        AccountAddress.fromStringRelaxed(address),
+        AccountAddress.fromString(address),
       );
       expect(secondarySignerAddressesParsed.map((s) => s.toString())).toEqual(
         secondarySignerAddresses.map((address) => address.toString()),
@@ -386,7 +386,7 @@ describe("various transaction arguments", () => {
       }
       const responseSignature = response.signature;
       const secondarySignerAddressesParsed = responseSignature.secondary_signer_addresses.map((address) =>
-        AccountAddress.fromStringRelaxed(address),
+        AccountAddress.fromString(address),
       );
       expect(secondarySignerAddressesParsed.map((s) => s.toString())).toEqual(
         secondarySignerAddresses.map((address) => address.toString()),
@@ -411,7 +411,7 @@ describe("various transaction arguments", () => {
       }
       const responseSignature = response.signature;
       expect(responseSignature.secondary_signer_addresses.length).toEqual(0);
-      expect(AccountAddress.fromStringRelaxed(responseSignature.fee_payer_address).toString()).toEqual(
+      expect(AccountAddress.fromString(responseSignature.fee_payer_address).toString()).toEqual(
         feePayerAccount.accountAddress.toString(),
       );
     });
@@ -436,12 +436,12 @@ describe("various transaction arguments", () => {
       }
       const responseSignature = response.signature;
       const secondarySignerAddressesParsed = responseSignature.secondary_signer_addresses.map((address) =>
-        AccountAddress.fromStringRelaxed(address),
+        AccountAddress.fromString(address),
       );
       expect(secondarySignerAddressesParsed.map((s) => s.toString())).toEqual(
         secondarySignerAddresses.map((address) => address.toString()),
       );
-      expect(AccountAddress.fromStringRelaxed(responseSignature.fee_payer_address).toString()).toEqual(
+      expect(AccountAddress.fromString(responseSignature.fee_payer_address).toString()).toEqual(
         feePayerAccount.accountAddress.toString(),
       );
     });
@@ -462,7 +462,7 @@ describe("various transaction arguments", () => {
       }
       const responseSignature = response.signature;
       expect(responseSignature.secondary_signer_addresses.length).toEqual(0);
-      expect(AccountAddress.fromStringRelaxed(responseSignature.fee_payer_address).toString()).toEqual(
+      expect(AccountAddress.fromString(responseSignature.fee_payer_address).toString()).toEqual(
         feePayerAccount.accountAddress.toString(),
       );
     });
@@ -487,12 +487,12 @@ describe("various transaction arguments", () => {
       }
       const responseSignature = response.signature;
       const secondarySignerAddressesParsed = responseSignature.secondary_signer_addresses.map((address) =>
-        AccountAddress.fromStringRelaxed(address),
+        AccountAddress.fromString(address),
       );
       expect(secondarySignerAddressesParsed.map((s) => s.toString())).toEqual(
         secondarySignerAddresses.map((address) => address.toString()),
       );
-      expect(AccountAddress.fromStringRelaxed(responseSignature.fee_payer_address).toString()).toEqual(
+      expect(AccountAddress.fromString(responseSignature.fee_payer_address).toString()).toEqual(
         feePayerAccount.accountAddress.toString(),
       );
     });

--- a/tests/unit/accountAddress.test.ts
+++ b/tests/unit/accountAddress.test.ts
@@ -110,66 +110,64 @@ const ADDRESS_OTHER: Addresses = {
 // These tests show that fromStringRelaxed works happily parses all formats.
 describe("AccountAddress fromStringRelaxed", () => {
   it("parses special address: 0x0", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_ZERO.longWith0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_ZERO.longWithout0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_ZERO.shortWith0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_ZERO.shortWithout0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_ZERO.longWith0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_ZERO.longWithout0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_ZERO.shortWith0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_ZERO.shortWithout0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
   });
 
   it("parses special address: 0x1", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_ONE.longWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_ONE.shortWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_ONE.longWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_ONE.shortWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
   });
 
   it("parses special address: 0x2", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_TWO.longWith0x).toString()).toBe(ADDRESS_TWO.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_TWO.longWithout0x).toString()).toBe(ADDRESS_TWO.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_TWO.shortWith0x).toString()).toBe(ADDRESS_TWO.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_TWO.shortWithout0x).toString()).toBe(ADDRESS_TWO.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_TWO.longWith0x).toString()).toBe(ADDRESS_TWO.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_TWO.longWithout0x).toString()).toBe(ADDRESS_TWO.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_TWO.shortWith0x).toString()).toBe(ADDRESS_TWO.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_TWO.shortWithout0x).toString()).toBe(ADDRESS_TWO.shortWith0x);
   });
 
   it("parses special address: 0x3", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_THREE.longWith0x).toString()).toBe(ADDRESS_THREE.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_THREE.longWithout0x).toString()).toBe(ADDRESS_THREE.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_THREE.shortWith0x).toString()).toBe(ADDRESS_THREE.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_THREE.shortWithout0x).toString()).toBe(ADDRESS_THREE.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_THREE.longWith0x).toString()).toBe(ADDRESS_THREE.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_THREE.longWithout0x).toString()).toBe(ADDRESS_THREE.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_THREE.shortWith0x).toString()).toBe(ADDRESS_THREE.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_THREE.shortWithout0x).toString()).toBe(ADDRESS_THREE.shortWith0x);
   });
 
   it("parses special address: 0x4", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_FOUR.longWith0x).toString()).toBe(ADDRESS_FOUR.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_FOUR.longWithout0x).toString()).toBe(ADDRESS_FOUR.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_FOUR.shortWith0x).toString()).toBe(ADDRESS_FOUR.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_FOUR.shortWithout0x).toString()).toBe(ADDRESS_FOUR.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_FOUR.longWith0x).toString()).toBe(ADDRESS_FOUR.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_FOUR.longWithout0x).toString()).toBe(ADDRESS_FOUR.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_FOUR.shortWith0x).toString()).toBe(ADDRESS_FOUR.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_FOUR.shortWithout0x).toString()).toBe(ADDRESS_FOUR.shortWith0x);
   });
 
   it("parses special address: 0xf", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_F.longWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_F.longWithout0x).toString()).toBe(ADDRESS_F.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_F.shortWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_F.shortWithout0x).toString()).toBe(ADDRESS_F.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_F.longWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_F.longWithout0x).toString()).toBe(ADDRESS_F.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_F.shortWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_F.shortWithout0x).toString()).toBe(ADDRESS_F.shortWith0x);
   });
 
   it("parses special address with padded short form: 0x0f", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_F_PADDED_SHORT_FORM.shortWith0x).toString()).toBe(
-      ADDRESS_F.shortWith0x,
-    );
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x).toString()).toBe(
+    expect(AccountAddress.fromString(ADDRESS_F_PADDED_SHORT_FORM.shortWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
+    expect(AccountAddress.fromString(ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x).toString()).toBe(
       ADDRESS_F.shortWith0x,
     );
   });
 
   it("parses non-special address: 0x10", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_TEN.longWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_TEN.shortWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_TEN.shortWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromString(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromString(ADDRESS_TEN.longWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromString(ADDRESS_TEN.shortWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromString(ADDRESS_TEN.shortWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
   });
 
   it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(AccountAddress.fromStringRelaxed(ADDRESS_OTHER.longWithout0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(AccountAddress.fromString(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(AccountAddress.fromString(ADDRESS_OTHER.longWithout0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
   });
 });
 
@@ -186,137 +184,137 @@ describe("AccountAddress static special addresses", () => {
 // SHORT if it is a special address.
 describe("AccountAddress fromString", () => {
   it("parses special address: 0x0", () => {
-    expect(AccountAddress.fromString(ADDRESS_ZERO.longWith0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
-    expect(() => AccountAddress.fromString(ADDRESS_ZERO.longWithout0x)).toThrow();
-    expect(AccountAddress.fromString(ADDRESS_ZERO.shortWith0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
-    expect(() => AccountAddress.fromString(ADDRESS_ZERO.shortWithout0x)).toThrow();
+    expect(AccountAddress.fromStringStrict(ADDRESS_ZERO.longWith0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_ZERO.longWithout0x)).toThrow();
+    expect(AccountAddress.fromStringStrict(ADDRESS_ZERO.shortWith0x).toString()).toBe(ADDRESS_ZERO.shortWith0x);
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_ZERO.shortWithout0x)).toThrow();
   });
 
   it("parses special address: 0x1", () => {
-    expect(AccountAddress.fromString(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(() => AccountAddress.fromString(ADDRESS_ONE.longWithout0x)).toThrow();
-    expect(AccountAddress.fromString(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(() => AccountAddress.fromString(ADDRESS_ONE.shortWithout0x)).toThrow();
+    expect(AccountAddress.fromStringStrict(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_ONE.longWithout0x)).toThrow();
+    expect(AccountAddress.fromStringStrict(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_ONE.shortWithout0x)).toThrow();
   });
 
   it("parses special address: 0xf", () => {
-    expect(AccountAddress.fromString(ADDRESS_F.longWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
-    expect(() => AccountAddress.fromString(ADDRESS_F.longWithout0x)).toThrow();
-    expect(AccountAddress.fromString(ADDRESS_F.shortWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
-    expect(() => AccountAddress.fromString(ADDRESS_F.shortWithout0x)).toThrow();
+    expect(AccountAddress.fromStringStrict(ADDRESS_F.longWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_F.longWithout0x)).toThrow();
+    expect(AccountAddress.fromStringStrict(ADDRESS_F.shortWith0x).toString()).toBe(ADDRESS_F.shortWith0x);
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_F.shortWithout0x)).toThrow();
   });
 
   it("throws when parsing special address with padded short form: 0x0f", () => {
-    expect(() => AccountAddress.fromString(ADDRESS_F_PADDED_SHORT_FORM.shortWith0x)).toThrow();
-    expect(() => AccountAddress.fromString(ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x)).toThrow();
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_F_PADDED_SHORT_FORM.shortWith0x)).toThrow();
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_F_PADDED_SHORT_FORM.shortWithout0x)).toThrow();
   });
 
   it("parses non-special address: 0x10", () => {
-    expect(AccountAddress.fromString(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(() => AccountAddress.fromString(ADDRESS_TEN.longWithout0x)).toThrow();
-    expect(() => AccountAddress.fromString(ADDRESS_TEN.shortWith0x)).toThrow();
-    expect(() => AccountAddress.fromString(ADDRESS_TEN.shortWithout0x)).toThrow();
+    expect(AccountAddress.fromStringStrict(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_TEN.longWithout0x)).toThrow();
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_TEN.shortWith0x)).toThrow();
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_TEN.shortWithout0x)).toThrow();
   });
 
   it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
-    expect(AccountAddress.fromString(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(() => AccountAddress.fromString(ADDRESS_OTHER.longWithout0x)).toThrow();
+    expect(AccountAddress.fromStringStrict(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(() => AccountAddress.fromStringStrict(ADDRESS_OTHER.longWithout0x)).toThrow();
   });
 });
 
 describe("AccountAddress from", () => {
   it("parses special address: 0x1", () => {
-    expect(AccountAddress.from(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(() => AccountAddress.from(ADDRESS_ONE.longWithout0x)).toThrow();
-    expect(AccountAddress.from(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(() => AccountAddress.from(ADDRESS_ONE.shortWithout0x)).toThrow();
-    expect(AccountAddress.from(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.fromStrict(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(() => AccountAddress.fromStrict(ADDRESS_ONE.longWithout0x)).toThrow();
+    expect(AccountAddress.fromStrict(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(() => AccountAddress.fromStrict(ADDRESS_ONE.shortWithout0x)).toThrow();
+    expect(AccountAddress.fromStrict(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
   });
 
   it("parses non-special address: 0x10", () => {
-    expect(AccountAddress.from(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(() => AccountAddress.from(ADDRESS_TEN.longWithout0x)).toThrow();
-    expect(() => AccountAddress.from(ADDRESS_TEN.shortWith0x)).toThrow();
-    expect(() => AccountAddress.from(ADDRESS_TEN.shortWithout0x)).toThrow();
-    expect(AccountAddress.from(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.fromStrict(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(() => AccountAddress.fromStrict(ADDRESS_TEN.longWithout0x)).toThrow();
+    expect(() => AccountAddress.fromStrict(ADDRESS_TEN.shortWith0x)).toThrow();
+    expect(() => AccountAddress.fromStrict(ADDRESS_TEN.shortWithout0x)).toThrow();
+    expect(AccountAddress.fromStrict(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
   });
   it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
-    expect(AccountAddress.from(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(() => AccountAddress.from(ADDRESS_OTHER.longWithout0x)).toThrow();
-    expect(AccountAddress.from(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.shortWith0x);
+    expect(AccountAddress.fromStrict(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(() => AccountAddress.fromStrict(ADDRESS_OTHER.longWithout0x)).toThrow();
+    expect(AccountAddress.fromStrict(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.shortWith0x);
   });
 });
 
 describe("AccountAddress fromRelaxed", () => {
   it("parses special address: 0x1", () => {
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.longWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.shortWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.from(ADDRESS_ONE.longWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.from(ADDRESS_ONE.longWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.from(ADDRESS_ONE.shortWith0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.from(ADDRESS_ONE.shortWithout0x).toString()).toBe(ADDRESS_ONE.shortWith0x);
+    expect(AccountAddress.from(ADDRESS_ONE.bytes).toString()).toBe(ADDRESS_ONE.shortWith0x);
   });
 
   it("parses non-special address: 0x10", () => {
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.longWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.shortWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.shortWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.from(ADDRESS_TEN.longWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.from(ADDRESS_TEN.longWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.from(ADDRESS_TEN.shortWith0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.from(ADDRESS_TEN.shortWithout0x).toString()).toBe(ADDRESS_TEN.longWith0x);
+    expect(AccountAddress.from(ADDRESS_TEN.bytes).toString()).toBe(ADDRESS_TEN.longWith0x);
   });
 
   it("parses non-special address: 0xca843279e3427144cead5e4d5999a3d0ca843279e3427144cead5e4d5999a3d0", () => {
-    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.longWithout0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
-    expect(AccountAddress.fromRelaxed(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(AccountAddress.from(ADDRESS_OTHER.longWith0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(AccountAddress.from(ADDRESS_OTHER.longWithout0x).toString()).toBe(ADDRESS_OTHER.longWith0x);
+    expect(AccountAddress.from(ADDRESS_OTHER.bytes).toString()).toBe(ADDRESS_OTHER.longWith0x);
   });
 });
 
 describe("AccountAddress toUint8Array", () => {
   it("correctly returns bytes for special address: 0x1", () => {
-    expect(AccountAddress.from(ADDRESS_ONE.longWith0x).toUint8Array()).toEqual(ADDRESS_ONE.bytes);
+    expect(AccountAddress.fromStrict(ADDRESS_ONE.longWith0x).toUint8Array()).toEqual(ADDRESS_ONE.bytes);
   });
 
   it("correctly returns bytes for  non-special address: 0x10", () => {
-    expect(AccountAddress.from(ADDRESS_TEN.longWith0x).toUint8Array()).toEqual(ADDRESS_TEN.bytes);
+    expect(AccountAddress.fromStrict(ADDRESS_TEN.longWith0x).toUint8Array()).toEqual(ADDRESS_TEN.bytes);
   });
 
   it("correctly returns bytes for  non-special address: 0xca84...a3d0", () => {
-    expect(AccountAddress.from(ADDRESS_OTHER.longWith0x).toUint8Array()).toEqual(ADDRESS_OTHER.bytes);
+    expect(AccountAddress.fromStrict(ADDRESS_OTHER.longWith0x).toUint8Array()).toEqual(ADDRESS_OTHER.bytes);
   });
 });
 
 describe("AccountAddress toStringWithoutPrefix", () => {
   it("formats special address correctly: 0x0", () => {
-    const addr = AccountAddress.fromString(ADDRESS_ZERO.shortWith0x);
+    const addr = AccountAddress.fromStringStrict(ADDRESS_ZERO.shortWith0x);
     expect(addr.toStringWithoutPrefix()).toBe(ADDRESS_ZERO.shortWithout0x);
   });
 
   it("formats non-special address correctly: 0x10", () => {
-    const addr = AccountAddress.fromString(ADDRESS_TEN.longWith0x);
+    const addr = AccountAddress.fromStringStrict(ADDRESS_TEN.longWith0x);
     expect(addr.toStringWithoutPrefix()).toBe(ADDRESS_TEN.longWithout0x);
   });
 });
 
 describe("AccountAddress toStringLong", () => {
   it("formats special address correctly: 0x0", () => {
-    const addr = AccountAddress.fromString(ADDRESS_ZERO.shortWith0x);
+    const addr = AccountAddress.fromStringStrict(ADDRESS_ZERO.shortWith0x);
     expect(addr.toStringLong()).toBe(ADDRESS_ZERO.longWith0x);
   });
 
   it("formats non-special address correctly: 0x10", () => {
-    const addr = AccountAddress.fromString(ADDRESS_TEN.longWith0x);
+    const addr = AccountAddress.fromStringStrict(ADDRESS_TEN.longWith0x);
     expect(addr.toStringLong()).toBe(ADDRESS_TEN.longWith0x);
   });
 });
 
 describe("AccountAddress toStringLongWithoutPrefix", () => {
   it("formats special address correctly: 0x0", () => {
-    const addr = AccountAddress.fromString(ADDRESS_ZERO.shortWith0x);
+    const addr = AccountAddress.fromStringStrict(ADDRESS_ZERO.shortWith0x);
     expect(addr.toStringLongWithoutPrefix()).toBe(ADDRESS_ZERO.longWithout0x);
   });
 
   it("formats non-special address correctly: 0x10", () => {
-    const addr = AccountAddress.fromString(ADDRESS_TEN.longWith0x);
+    const addr = AccountAddress.fromStringStrict(ADDRESS_TEN.longWith0x);
     expect(addr.toStringLongWithoutPrefix()).toBe(ADDRESS_TEN.longWithout0x);
   });
 });
@@ -324,26 +322,27 @@ describe("AccountAddress toStringLongWithoutPrefix", () => {
 describe("AccountAddress other parsing", () => {
   it("throws exception when initiating from too long hex string", () => {
     expect(() => {
-      AccountAddress.fromString(`${ADDRESS_ONE.longWith0x}1`);
+      AccountAddress.fromStringStrict(`${ADDRESS_ONE.longWith0x}1`);
     }).toThrow("Hex string is too long, must be 1 to 64 chars long, excluding the leading 0x.");
   });
 
   test("throws when parsing invalid hex char", () => {
-    expect(() => AccountAddress.fromString("0xxyz")).toThrow();
+    expect(() => AccountAddress.fromStringStrict("0xxyz")).toThrow();
   });
 
   test("throws when parsing account address of length zero", () => {
-    expect(() => AccountAddress.fromString("0x")).toThrow();
-    expect(() => AccountAddress.fromString("")).toThrow();
+    expect(() => AccountAddress.fromStringStrict("0x")).toThrow();
+    expect(() => AccountAddress.fromStringStrict("")).toThrow();
   });
 
   test("throws when parsing invalid prefix", () => {
-    expect(() => AccountAddress.fromString("0za")).toThrow();
+    expect(() => AccountAddress.fromStringStrict("0za")).toThrow();
   });
 
   it("isValid is false if too long with 0xf", () => {
     const { valid, invalidReason, invalidReasonMessage } = AccountAddress.isValid({
       input: `0x00${ADDRESS_F.longWithout0x}`,
+      strict: true,
     });
     expect(valid).toBe(false);
     expect(invalidReason).toBe(AddressInvalidReason.TOO_LONG);
@@ -351,15 +350,18 @@ describe("AccountAddress other parsing", () => {
   });
 
   it("isValid is true if account address string is valid", () => {
-    const { valid, invalidReason, invalidReasonMessage } = AccountAddress.isValid({ input: ADDRESS_F.longWith0x });
+    const { valid, invalidReason, invalidReasonMessage } = AccountAddress.isValid({
+      input: ADDRESS_F.longWith0x,
+      strict: true,
+    });
     expect(valid).toBe(true);
     expect(invalidReason).toBeUndefined();
     expect(invalidReasonMessage).toBeUndefined();
   });
 
   it("compares equality with equals as expected", () => {
-    const addressOne = AccountAddress.fromStringRelaxed("0x123");
-    const addressTwo = AccountAddress.fromStringRelaxed("0x123");
+    const addressOne = AccountAddress.fromString("0x123");
+    const addressTwo = AccountAddress.fromString("0x123");
     expect(addressOne.equals(addressTwo)).toBeTruthy();
   });
 });
@@ -373,9 +375,9 @@ describe("AccountAddress serialization and deserialization", () => {
   };
 
   it("serializes an unpadded, full, and reserved address correctly", () => {
-    const address1 = AccountAddress.fromStringRelaxed("0x0102030a0b0c");
-    const address2 = AccountAddress.fromStringRelaxed(ADDRESS_OTHER.longWith0x);
-    const address3 = AccountAddress.fromStringRelaxed(ADDRESS_ZERO.shortWithout0x);
+    const address1 = AccountAddress.fromString("0x0102030a0b0c");
+    const address2 = AccountAddress.fromString(ADDRESS_OTHER.longWith0x);
+    const address3 = AccountAddress.fromString(ADDRESS_ZERO.shortWithout0x);
     serializeAndCheckEquality(address1);
     serializeAndCheckEquality(address2);
     serializeAndCheckEquality(address3);
@@ -390,9 +392,9 @@ describe("AccountAddress serialization and deserialization", () => {
 
   it("deserializes an unpadded, full, and reserved address correctly", () => {
     const serializer = new Serializer();
-    const address1 = AccountAddress.fromStringRelaxed("0x123abc");
-    const address2 = AccountAddress.fromStringRelaxed(ADDRESS_OTHER.longWith0x);
-    const address3 = AccountAddress.fromStringRelaxed(ADDRESS_ZERO.shortWithout0x);
+    const address1 = AccountAddress.fromString("0x123abc");
+    const address2 = AccountAddress.fromString(ADDRESS_OTHER.longWith0x);
+    const address3 = AccountAddress.fromString(ADDRESS_ZERO.shortWithout0x);
     serializer.serialize(address1);
     serializer.serialize(address2);
     serializer.serialize(address3);
@@ -406,7 +408,7 @@ describe("AccountAddress serialization and deserialization", () => {
   });
 
   it("serializes and deserializes an address correctly", () => {
-    const address = AccountAddress.fromStringRelaxed("0x0102030a0b0c");
+    const address = AccountAddress.fromString("0x0102030a0b0c");
     const serializer = new Serializer();
     serializer.serialize(address);
     const deserializer = new Deserializer(serializer.toUint8Array());

--- a/tests/unit/deserializer.test.ts
+++ b/tests/unit/deserializer.test.ts
@@ -132,9 +132,9 @@ describe("BCS Deserializer", () => {
 
   it("deserializes a vector of Deserializable types correctly", () => {
     const addresses = new Array<AccountAddress>(
-      AccountAddress.fromRelaxed("0x1"),
-      AccountAddress.fromRelaxed("0xa"),
-      AccountAddress.fromRelaxed("0x0123456789abcdef"),
+      AccountAddress.from("0x1"),
+      AccountAddress.from("0xa"),
+      AccountAddress.from("0x0123456789abcdef"),
     );
     const serializer = new Serializer();
     serializer.serializeVector(addresses);

--- a/tests/unit/serializer.test.ts
+++ b/tests/unit/serializer.test.ts
@@ -266,9 +266,9 @@ describe("BCS Serializer", () => {
 
   it("serializes a vector of Serializable types correctly", () => {
     const addresses = new Array<AccountAddress>(
-      AccountAddress.fromRelaxed("0x1"),
-      AccountAddress.fromRelaxed("0xa"),
-      AccountAddress.fromRelaxed("0x0123456789abcdef"),
+      AccountAddress.from("0x1"),
+      AccountAddress.from("0xa"),
+      AccountAddress.from("0x0123456789abcdef"),
     );
     const serializer = new Serializer();
     serializer.serializeVector(addresses);


### PR DESCRIPTION
### Description
More often than not the SDK receives addresses that are shortened.  This is very possible to occur, and it should be allowed as an input as default.  Strictness should only be applied if wanted, and until there is a different address standard, it should accept any output from the API.  Otherwise, strings won't be easily converted.

We can disable this once we add full type bindings to do on the fly struct conversion rather than use JSON intermediaries.

### Test Plan
I simply flipped relaxed to normal, and added a strict.  The CI should run enough tests to cover it.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->