### PR TITLE
Rename custom metric header

### DIFF
--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -28,7 +28,7 @@ export async function request<Req, Res>(options: ClientRequest<Req>, client: Cli
   const { url, method, body, contentType, params, overrides } = options;
   const headers: Record<string, string | AnyNumber | boolean | undefined> = {
     ...overrides?.HEADERS,
-    "x-aptos-client": `aptos-ts-sdk/${VERSION}`,
+    "x-aptos-client": `aptos-new-ts-sdk/${VERSION}`,
     "content-type": contentType ?? MimeType.JSON,
   };
 

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -51,7 +51,7 @@ describe("aptos request", () => {
             },
             config,
           );
-          expect(response.config.headers).toHaveProperty("x-aptos-client", `aptos-ts-sdk/${VERSION}`);
+          expect(response.config.headers).toHaveProperty("x-aptos-client", `aptos-new-ts-sdk/${VERSION}`);
           expect(response.config.headers).toHaveProperty("my", "header");
           expect(response.config.headers).toHaveProperty("content-type", "application/x.aptos.signed_transaction+bcs");
         } catch (error: any) {


### PR DESCRIPTION
### Description
Rename custom metric header to "aptos-new-ts-sdk" to distinguish between the legacy and the new sdk

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->