### PR TITLE
[config] Ensure custom indexer URLs errors work properly / document how to use custom URLs

### DIFF
--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -8,13 +8,29 @@ import { AptosApiType, DEFAULT_NETWORK } from "../utils/const";
 
 /**
  * This class holds the config information for the SDK client instance.
+ *
+ * @example To use Aptos Labs endpoints, simply set the `network` property to the desired network.
+ * ```typescript
+ *   const config = new AptosConfig({ network: Network.DEVNET });
+ * ```
+ *
+ * @example To use custom endpoints, set the `network` property to the desired network, and the appropriate URLs. The URL
+ * must contain the full path and will not have a `/v1` added.
+ * ```typescript
+ *   const config = new AptosConfig({
+ *     network: Network.TESTNET,
+ *     fullnode: "https://my-testnet-fullnode.com/v1",
+ *   });
+ * ```
  */
 export class AptosConfig {
-  /** The Network that this SDK is associated with. Defaults to DEVNET */
+  /**
+   * The Network that this SDK is associated with. Defaults to `Network.DEVNET`
+   */
   readonly network: Network;
 
   /**
-   * The client instance the SDK uses. Defaults to `@aptos-labs/aptos-client
+   * The client instance the SDK uses. Defaults to `@aptos-labs/aptos-client`
    */
   readonly client: Client;
 
@@ -71,14 +87,5 @@ export class AptosConfig {
       default:
         throw Error(`apiType ${apiType} is not supported`);
     }
-  }
-
-  /**
-   * Checks if the URL is a known indexer endpoint
-   *
-   * @internal
-   * */
-  isIndexerRequest(url: string): boolean {
-    return NetworkToIndexerAPI[this.network] === url;
   }
 }

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -4,7 +4,8 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { AptosApiError, AptosResponse } from "./types";
 import { VERSION } from "../version";
-import { AptosRequest, MimeType, ClientRequest, ClientResponse, Client, AnyNumber } from "../types";
+import { AnyNumber, AptosRequest, Client, ClientRequest, ClientResponse, MimeType } from "../types";
+import { AptosApiType } from "../utils";
 
 /**
  * Meaningful errors map
@@ -61,11 +62,13 @@ export async function request<Req, Res>(options: ClientRequest<Req>, client: Cli
  *
  * @param options AptosRequest
  * @param aptosConfig The config information for the SDK client instance
+ * @param type The type of API endpoint to call e.g. fullnode, indexer, etc
  * @returns the response or AptosApiError
  */
 export async function aptosRequest<Req extends {}, Res extends {}>(
   options: AptosRequest,
   aptosConfig: AptosConfig,
+  type: AptosApiType,
 ): Promise<AptosResponse<Req, Res>> {
   const { url, path } = options;
   const fullUrl = `${url}/${path ?? ""}`;
@@ -83,7 +86,7 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
 
   // to support both fullnode and indexer responses,
   // check if it is an indexer query, and adjust response.data
-  if (aptosConfig.isIndexerRequest(url)) {
+  if (type === AptosApiType.INDEXER) {
     const indexerResponse = result.data as any;
     // errors from indexer
     if (indexerResponse.errors) {

--- a/src/client/get.ts
+++ b/src/client/get.ts
@@ -68,6 +68,7 @@ export async function get<Req extends {}, Res extends {}>(
       },
     },
     aptosConfig,
+    type,
   );
 }
 

--- a/src/client/post.ts
+++ b/src/client/post.ts
@@ -76,6 +76,7 @@ export async function post<Req extends {}, Res extends {}>(
       },
     },
     aptosConfig,
+    type,
   );
 }
 

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -1,15 +1,16 @@
 import {
-  aptosRequest,
-  AptosApiError,
-  AptosConfig,
-  Network,
-  NetworkToNodeAPI,
-  Aptos,
   Account,
-  U64,
-  GraphqlQuery,
-  NetworkToIndexerAPI,
+  Aptos,
+  AptosApiError,
+  AptosApiType,
+  AptosConfig,
+  aptosRequest,
   generateSignedTransaction,
+  GraphqlQuery,
+  Network,
+  NetworkToIndexerAPI,
+  NetworkToNodeAPI,
+  U64,
 } from "../../../src";
 import { VERSION } from "../../../src/version";
 import { longTestTimeout } from "../../unit/helper";
@@ -50,6 +51,7 @@ describe("aptos request", () => {
               overrides: { HEADERS: { my: "header" } },
             },
             config,
+            AptosApiType.FULLNODE,
           );
           expect(response.config.headers).toHaveProperty("x-aptos-client", `aptos-typescript-sdk/${VERSION}`);
           expect(response.config.headers).toHaveProperty("my", "header");
@@ -77,6 +79,7 @@ describe("aptos request", () => {
               originMethod: "test when token is set",
             },
             config,
+            AptosApiType.FULLNODE,
           );
           expect(response.config.headers).not.toHaveProperty("authorization", "Bearer my-token");
         } catch (error: any) {
@@ -99,6 +102,7 @@ describe("aptos request", () => {
               originMethod: "test when token is not set",
             },
             config,
+            AptosApiType.FULLNODE,
           );
           expect(response.config.headers).not.toHaveProperty("authorization", "Bearer my-token");
         } catch (error: any) {
@@ -124,6 +128,7 @@ describe("aptos request", () => {
               originMethod: "test when token is set",
             },
             config,
+            AptosApiType.FULLNODE,
           );
           expect(response.config.headers).toHaveProperty("authorization", "Bearer my-api-key");
         } catch (error: any) {
@@ -149,6 +154,7 @@ describe("aptos request", () => {
                 originMethod: "test fullnode 200 status",
               },
               config,
+              AptosApiType.FULLNODE,
             );
             expect(response).toHaveProperty("data", {
               sequence_number: "0",
@@ -176,6 +182,7 @@ describe("aptos request", () => {
                 originMethod: "test 400 status",
               },
               config,
+              AptosApiType.FULLNODE,
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);
@@ -211,6 +218,7 @@ describe("aptos request", () => {
                 originMethod: "test 404 status",
               },
               config,
+              AptosApiType.FULLNODE,
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);
@@ -252,6 +260,7 @@ describe("aptos request", () => {
                 contentType: "application/x.aptos.signed_transaction+bcs",
               },
               config,
+              AptosApiType.FULLNODE,
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);
@@ -299,6 +308,7 @@ describe("aptos request", () => {
                 originMethod: "test indexer 200 status",
               },
               config,
+              AptosApiType.INDEXER,
             );
             expect(response).toHaveProperty("data", {
               ledger_infos: [
@@ -335,6 +345,7 @@ describe("aptos request", () => {
                 originMethod: "test indexer 400 status",
               },
               config,
+              AptosApiType.INDEXER,
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);


### PR DESCRIPTION
### Description
There's two things here:
1. We were parsing Indexer URLs to tell how to handle errors, though a user could have a custom URL.  Since, this custom URL basically has to work the same as the Aptos labs indexer, I removed the "check it it's an indexer by URL", and moved it to use the API type instead.
2. Documentation around how to provide a config directly was straightforward, but needed to be more explicit around `/v1` paths, since the old SDK handled it slightly differently.

### Test Plan
`pnpm test` still passes

### Related Links
<!-- Please link to any relevant issues or pull requests! -->