### PR TITLE
[remoteAbi] Allow MoveString for vector<u8>

### DIFF
--- a/tests/unit/remoteAbi.test.ts
+++ b/tests/unit/remoteAbi.test.ts
@@ -52,7 +52,7 @@ describe("Remote ABI", () => {
       expect(checkOrConvertArgument(MAX_U256.toString(), parseTypeTag("u256"), 0, [])).toEqual(new U256(MAX_U256));
     });
 
-    it("should parse a typed arguments", () => {
+    it("should parse typed arguments", () => {
       expect(checkOrConvertArgument(AccountAddress.ONE, parseTypeTag("address"), 0, [])).toEqual(AccountAddress.ONE);
       expect(checkOrConvertArgument(new Bool(true), parseTypeTag("bool"), 0, [])).toEqual(new Bool(true));
       expect(checkOrConvertArgument(new U8(MAX_U8), parseTypeTag("u8"), 0, [])).toEqual(new U8(MAX_U8));
@@ -145,6 +145,10 @@ describe("Remote ABI", () => {
 
       expect(checkOrConvertArgument(MoveVector.U8([0, 255]), parseTypeTag("vector<u8>"), 0, [])).toEqual(
         MoveVector.U8([0, 255]),
+      );
+      // String also supported for move vector
+      expect(checkOrConvertArgument(new MoveString("hello"), parseTypeTag("vector<u8>"), 0, [])).toEqual(
+        MoveVector.U8(new MoveString("hello").bcsToBytes()),
       );
       expect(
         checkOrConvertArgument(


### PR DESCRIPTION
### Description
This is a feature that kind of worked in the last SDK, but it's debatable if it's desirable.  This behavior definitely causes overhead for all BCS vector checks, that it didn't have to do before.

### Test Plan
Wrote a test, plus the existing tests helped check.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->