### PR TITLE
[remoteAbi] Cleaned up behavior for strings as Vector<u8>

### DIFF
--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -30,6 +30,7 @@ export type SimpleEntryFunctionArgumentTypes =
   | null // To support optional empty
   | undefined // To support optional empty
   | Uint8Array
+  | ArrayBuffer
   | Array<SimpleEntryFunctionArgumentTypes | EntryFunctionArgumentTypes>;
 
 /**


### PR DESCRIPTION
### Description
To support old SDK compatibility, we've done following breaking changes:
* Remove Hex string as an input for simple args, this needs to be converted prior
* String as an input will be directly converted to UTF-8 bytes
* ArrayBuffer is also a valid input, and will be parsed similarly to Uint8array

We could in the future plan to support other inputs like 
* Uint16array
* Uint32array
* BigUint64array

### Test Plan
Added more unit tests appropriately

### Related Links
Resolves https://github.com/aptos-labs/aptos-ts-sdk/issues/202