### PR TITLE
Add support to Array in digital asset property map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - [`Breaking`] Capitalize `TransactionPayloadMultiSig` type
+- Add support to Array value in digital asset property map
 
 # 1.2.0 (2023-12-14)
 

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -53,14 +53,14 @@ const PropertyTypeMap = {
   U256: "u256",
   ADDRESS: "address",
   STRING: "0x1::string::String",
-  // TODO support array/vector property types and values
-  // ARRAY: "vector<u8>",
+  ARRAY: "vector<u8>",
 };
 
 export type PropertyType = keyof typeof PropertyTypeMap;
 
 // Accepted property value types for user input
-export type PropertyValue = boolean | number | bigint | string | AccountAddress | Array<PropertyValue>;
+// To pass in an Array, use Uint8Array type - for example `new MoveVector([new MoveString("hello"), new MoveString("world")]).bcsToBytes()`
+export type PropertyValue = boolean | number | bigint | string | AccountAddress | Uint8Array;
 
 // The default digital asset type to use if non provided
 const defaultDigitalAssetType = "0x4::token::Token";
@@ -696,7 +696,6 @@ export async function updateDigitalAssetTypedPropertyTransaction(args: {
 
 function getPropertyValueRaw(propertyValues: Array<PropertyValue>, propertyTypes: Array<string>): Array<Uint8Array> {
   const results = new Array<Uint8Array>();
-
   propertyTypes.forEach((typ, index) => {
     results.push(getSinglePropertyValueRaw(propertyValues[index], typ));
   });

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -59,7 +59,8 @@ const PropertyTypeMap = {
 export type PropertyType = keyof typeof PropertyTypeMap;
 
 // Accepted property value types for user input
-// To pass in an Array, use Uint8Array type - for example `new MoveVector([new MoveString("hello"), new MoveString("world")]).bcsToBytes()`
+// To pass in an Array, use Uint8Array type
+// for example `new MoveVector([new MoveString("hello"), new MoveString("world")]).bcsToBytes()`
 export type PropertyValue = boolean | number | bigint | string | AccountAddress | Uint8Array;
 
 // The default digital asset type to use if non provided

--- a/tests/e2e/api/digitalAsset.test.ts
+++ b/tests/e2e/api/digitalAsset.test.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account, Aptos, AptosConfig, Network } from "../../../src";
+import { Account, Aptos, AptosConfig, Bool, MoveString, MoveVector, Network, U8 } from "../../../src";
 import { FUND_AMOUNT } from "../../unit/helper";
 
 const config = new AptosConfig({ network: Network.LOCAL });
@@ -43,6 +43,9 @@ async function setupToken(): Promise<string> {
     description: tokenDescription,
     name: tokenName,
     uri: tokenUri,
+    propertyKeys: ["my bool key", "my array key"],
+    propertyTypes: ["BOOLEAN", "ARRAY"],
+    propertyValues: [false, "[value]"],
   });
   const pendingTxn = await aptos.signAndSubmitTransaction({ signer: creator, transaction });
   const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
@@ -252,9 +255,21 @@ describe("DigitalAsset", () => {
         "U256 key",
         "ADDRESS key",
         "STRING key",
+        "ARRAY of bytes key",
       ],
-      propertyTypes: ["BOOLEAN", "U8", "U16", "U32", "U64", "U128", "U256", "ADDRESS", "STRING"],
-      propertyValues: [true, 1, 1, 1, 1, 1, 1, bob.accountAddress, "hi"],
+      propertyTypes: ["BOOLEAN", "U8", "U16", "U32", "U64", "U128", "U256", "ADDRESS", "STRING", "ARRAY"],
+      propertyValues: [
+        true,
+        1,
+        1,
+        1,
+        1,
+        1,
+        1,
+        bob.accountAddress,
+        "hi",
+        new MoveVector([new MoveString("hello"), new U8(1), new Bool(true), new MoveString("world")]).bcsToBytes(),
+      ],
     });
     await aptos.signAndSubmitTransaction({ signer: creator, transaction });
   });


### PR DESCRIPTION
### Description
Following https://github.com/aptos-labs/aptos-ts-sdk/pull/238, we can now support an array value in digital asset property map
To pass in an array value, use a string type - i.e `"[hello, 1, true, world]"`

### Test Plan
pnpm run test

### Related Links
<!-- Please link to any relevant issues or pull requests! -->