### PR TITLE
Update transaction option `maxGasAmount, gasUnitPrice, expireTimestamp` properties to use `number` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - [`Breaking`] Capitalize `TransactionPayloadMultiSig` type
 - Add support to Array value in digital asset property map
+- [`Breaking`] Change `maxGasAmount, gasUnitPrice and expireTimestamp` properties in `InputGenerateTransactionOptions` type to `number` type
 
 # 1.2.0 (2023-12-14)
 

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -77,9 +77,9 @@ export type AnyRawTransactionInstance = RawTransaction | MultiAgentRawTransactio
  * Optional options to set when generating a transaction
  */
 export type InputGenerateTransactionOptions = {
-  maxGasAmount?: AnyNumber;
-  gasUnitPrice?: AnyNumber;
-  expireTimestamp?: AnyNumber;
+  maxGasAmount?: number;
+  gasUnitPrice?: number;
+  expireTimestamp?: number;
   accountSequenceNumber?: AnyNumber;
 };
 


### PR DESCRIPTION
### Description
`maxGasAmount, gasUnitPrice, expireTimestamp` properties should be represented as `number` type.
First,`bigint` causes serialization issues for dapps and wallets and second these property values fall within the JS number type range. 
https://aptos-org.slack.com/archives/C06BFEMLAKT/p1703193020312399

Next - once this PR lands, wallet adapter should be updated to use the new sdk version and types.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->