### PR TITLE
[consts] Make upper bound numbers hardcoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Update BigInt constants to be hardcoded rather than use Math.pow
 - [`Breaking`] Capitalize `TransactionPayloadMultiSig` type
 - Add support to Array value in digital asset property map
 - [`Breaking`] Change `maxGasAmount, gasUnitPrice and expireTimestamp` properties in `InputGenerateTransactionOptions` type to `number` type

--- a/src/bcs/consts.ts
+++ b/src/bcs/consts.ts
@@ -4,9 +4,11 @@
 import { Uint8, Uint16, Uint32, Uint64, Uint128, Uint256 } from "../types";
 
 // Upper bound values for uint8, uint16, uint64 and uint128
-export const MAX_U8_NUMBER: Uint8 = 2 ** 8 - 1;
-export const MAX_U16_NUMBER: Uint16 = 2 ** 16 - 1;
-export const MAX_U32_NUMBER: Uint32 = 2 ** 32 - 1;
-export const MAX_U64_BIG_INT: Uint64 = BigInt(2) ** BigInt(64) - BigInt(1);
-export const MAX_U128_BIG_INT: Uint128 = BigInt(2) ** BigInt(128) - BigInt(1);
-export const MAX_U256_BIG_INT: Uint256 = BigInt(2) ** BigInt(256) - BigInt(1);
+export const MAX_U8_NUMBER: Uint8 = 255;
+export const MAX_U16_NUMBER: Uint16 = 65535;
+export const MAX_U32_NUMBER: Uint32 = 4294967295;
+export const MAX_U64_BIG_INT: Uint64 = BigInt("18446744073709551615");
+export const MAX_U128_BIG_INT: Uint128 = BigInt("340282366920938463463374607431768211455");
+export const MAX_U256_BIG_INT: Uint256 = BigInt(
+  "115792089237316195423570985008687907853269984665640564039457584007913129639935",
+);

--- a/src/bcs/consts.ts
+++ b/src/bcs/consts.ts
@@ -3,12 +3,12 @@
 
 import { Uint8, Uint16, Uint32, Uint64, Uint128, Uint256 } from "../types";
 
-// Upper bound values for uint8, uint16, uint64 and uint128
+// Upper bound values for uint8, uint16, uint64 etc.  These are all derived as
+// 2^N - 1, where N is the number of bits in the type.
 export const MAX_U8_NUMBER: Uint8 = 255;
 export const MAX_U16_NUMBER: Uint16 = 65535;
 export const MAX_U32_NUMBER: Uint32 = 4294967295;
-export const MAX_U64_BIG_INT: Uint64 = BigInt("18446744073709551615");
-export const MAX_U128_BIG_INT: Uint128 = BigInt("340282366920938463463374607431768211455");
-export const MAX_U256_BIG_INT: Uint256 = BigInt(
-  "115792089237316195423570985008687907853269984665640564039457584007913129639935",
-);
+export const MAX_U64_BIG_INT: Uint64 = 18446744073709551615n;
+export const MAX_U128_BIG_INT: Uint128 = 340282366920938463463374607431768211455n;
+export const MAX_U256_BIG_INT: Uint256 =
+  115792089237316195423570985008687907853269984665640564039457584007913129639935n;

--- a/tests/unit/deserializer.test.ts
+++ b/tests/unit/deserializer.test.ts
@@ -74,20 +74,20 @@ describe("BCS Deserializer", () => {
 
   it("deserializes a uint64", () => {
     let deserializer = new Deserializer(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
-    expect(deserializer.deserializeU64()).toEqual(BigInt("18446744073709551615"));
+    expect(deserializer.deserializeU64()).toEqual(18446744073709551615n);
     deserializer = new Deserializer(new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12]));
-    expect(deserializer.deserializeU64()).toEqual(BigInt("1311768467750121216"));
+    expect(deserializer.deserializeU64()).toEqual(1311768467750121216n);
   });
 
   it("deserializes a uint128", () => {
     let deserializer = new Deserializer(
       new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
     );
-    expect(deserializer.deserializeU128()).toEqual(BigInt("340282366920938463463374607431768211455"));
+    expect(deserializer.deserializeU128()).toEqual(340282366920938463463374607431768211455n);
     deserializer = new Deserializer(
       new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
     );
-    expect(deserializer.deserializeU128()).toEqual(BigInt("1311768467750121216"));
+    expect(deserializer.deserializeU128()).toEqual(1311768467750121216n);
   });
   it("deserializes a uint256", () => {
     const deserializer = new Deserializer(

--- a/tests/unit/serializer.test.ts
+++ b/tests/unit/serializer.test.ts
@@ -130,18 +130,18 @@ describe("BCS Serializer", () => {
   });
 
   it("serializes a uint64", () => {
-    serializer.serializeU64(BigInt("18446744073709551615"));
+    serializer.serializeU64(18446744073709551615n);
     expect(serializer.toUint8Array()).toEqual(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]));
 
     serializer = new Serializer();
-    serializer.serializeU64(BigInt("1311768467750121216"));
+    serializer.serializeU64(1311768467750121216n);
     expect(serializer.toUint8Array()).toEqual(new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12]));
   });
 
   it("throws when serializing uint64 with out of range value", () => {
     expect(() => {
-      serializer.serializeU64(BigInt("18446744073709551616"));
-    }).toThrow(outOfRangeErrorMessage(BigInt("18446744073709551616"), 0, MAX_U64_BIG_INT));
+      serializer.serializeU64(18446744073709551616n);
+    }).toThrow(outOfRangeErrorMessage(18446744073709551616n, 0, MAX_U64_BIG_INT));
 
     expect(() => {
       serializer = new Serializer();
@@ -150,13 +150,13 @@ describe("BCS Serializer", () => {
   });
 
   it("serializes a uint128", () => {
-    serializer.serializeU128(BigInt("340282366920938463463374607431768211455"));
+    serializer.serializeU128(340282366920938463463374607431768211455n);
     expect(serializer.toUint8Array()).toEqual(
       new Uint8Array([0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff]),
     );
 
     serializer = new Serializer();
-    serializer.serializeU128(BigInt("1311768467750121216"));
+    serializer.serializeU128(1311768467750121216n);
     expect(serializer.toUint8Array()).toEqual(
       new Uint8Array([0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
     );
@@ -164,8 +164,8 @@ describe("BCS Serializer", () => {
 
   it("throws when serializing uint128 with out of range value", () => {
     expect(() => {
-      serializer.serializeU128(BigInt("340282366920938463463374607431768211456"));
-    }).toThrow(outOfRangeErrorMessage(BigInt("340282366920938463463374607431768211456"), 0, MAX_U128_BIG_INT));
+      serializer.serializeU128(340282366920938463463374607431768211456n);
+    }).toThrow(outOfRangeErrorMessage(340282366920938463463374607431768211456n, 0, MAX_U128_BIG_INT));
 
     expect(() => {
       serializer = new Serializer();
@@ -174,7 +174,7 @@ describe("BCS Serializer", () => {
   });
 
   it("serializes a uint256", () => {
-    serializer.serializeU256(BigInt(MAX_U256_BIG_INT));
+    serializer.serializeU256(MAX_U256_BIG_INT);
     expect(serializer.toUint8Array()).toEqual(
       new Uint8Array([
         0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
@@ -183,7 +183,7 @@ describe("BCS Serializer", () => {
     );
 
     serializer = new Serializer();
-    serializer.serializeU256(BigInt("1311768467750121216"));
+    serializer.serializeU256(1311768467750121216n);
     expect(serializer.toUint8Array()).toEqual(
       new Uint8Array([
         0x00, 0xef, 0xcd, 0xab, 0x78, 0x56, 0x34, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -194,8 +194,8 @@ describe("BCS Serializer", () => {
 
   it("throws when serializing uint256 with out of range value", () => {
     expect(() => {
-      serializer.serializeU256(MAX_U256_BIG_INT + BigInt(1));
-    }).toThrow(outOfRangeErrorMessage(MAX_U256_BIG_INT + BigInt(1), 0, MAX_U256_BIG_INT));
+      serializer.serializeU256(MAX_U256_BIG_INT + 1n);
+    }).toThrow(outOfRangeErrorMessage(MAX_U256_BIG_INT + 1n, 0, MAX_U256_BIG_INT));
 
     expect(() => {
       serializer = new Serializer();
@@ -230,10 +230,10 @@ describe("BCS Serializer", () => {
     serializer.serializeU16(4660);
     serializer.serializeU32(4294967295);
     serializer.serializeU32(305419896);
-    serializer.serializeU64(BigInt("18446744073709551615"));
-    serializer.serializeU64(BigInt("1311768467750121216"));
-    serializer.serializeU128(BigInt("340282366920938463463374607431768211455"));
-    serializer.serializeU128(BigInt("1311768467750121216"));
+    serializer.serializeU64(18446744073709551615n);
+    serializer.serializeU64(1311768467750121216n);
+    serializer.serializeU128(340282366920938463463374607431768211455n);
+    serializer.serializeU128(1311768467750121216n);
     const serializedBytes = serializer.toUint8Array();
     expect(serializedBytes).toEqual(
       new Uint8Array([


### PR DESCRIPTION
### Description
Doing powers of bigints doesn't work on older versions of node, and it seems to be hard to reproduce, but still occurs.  Hardcoding these should have the same behavior, without these quirks.

Fixes https://github.com/aptos-labs/aptos-wallet-adapter/issues/223

### Test Plan
TBD, making a test now with an older version of node to check

### Related Links
Related https://github.com/aptos-labs/aptos-core/pull/11540
