### PR TITLE
Omit `build | simulate | submit` from aptos namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Omit `"build" | "simulate" | "submit"` from `aptos` namespace
+
 # 1.3.0 (2024-01-03)
 
 - [`Breaking`] Capitalize `TransactionPayloadMultiSig` type

--- a/src/api/aptos.ts
+++ b/src/api/aptos.ts
@@ -58,7 +58,8 @@ export class Aptos {
   }
 }
 
-// extends Aptos interface so all the methods and properties from the other classes will be recognized by typescript.
+// extends Aptos interface so all the methods and properties
+// from the other classes will be recognized by typescript.
 export interface Aptos
   extends Account,
     ANS,
@@ -69,7 +70,7 @@ export interface Aptos
     FungibleAsset,
     General,
     Staking,
-    Transaction {}
+    Omit<Transaction, "build" | "simulate" | "submit"> {}
 
 /**
 In TypeScript, we can’t inherit or extend from more than one class,


### PR DESCRIPTION
### Description
Fix https://github.com/aptos-labs/aptos-ts-sdk/issues/243 

`build | simulate | submit` properties are available on `aptos` namespace but they are not functional - that causes confusion for devs that could see those properties on autocomplete under the `aptos` namespace but then their program breaks. Those properties should only be visible under the `aptos.transaction` namespace

### Test Plan
pnpm test

and 

```
const aptos = new Aptos();
aptos. // autocomplete should not show build | simulate | submit
aptos.transaction // autocomplete should show build | simulate | submit
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->