### PR TITLE
[coin] transferCoinTransaction sender type change to AccountAddressInput

### DIFF
--- a/examples/typescript/transfer_coin.ts
+++ b/examples/typescript/transfer_coin.ts
@@ -66,7 +66,7 @@ const example = async () => {
   // Transfer between users
   console.log(`\n=== Transfer ${TRANSFER_AMOUNT} from Alice to Bob ===\n`);
   const transaction = await aptos.transferCoinTransaction({
-    sender: alice,
+    sender: alice.accountAddress,
     recipient: bob.accountAddress,
     amount: TRANSFER_AMOUNT,
   });

--- a/src/api/coin.ts
+++ b/src/api/coin.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account, AccountAddressInput } from "../core";
+import { AccountAddressInput } from "../core";
 import { transferCoinTransaction } from "../internal/coin";
 import { SimpleTransaction, InputGenerateTransactionOptions } from "../transactions/types";
 import { AnyNumber, MoveStructId } from "../types";
@@ -24,7 +24,7 @@ export class Coin {
    * @returns SimpleTransaction
    */
   async transferCoinTransaction(args: {
-    sender: Account;
+    sender: AccountAddressInput;
     recipient: AccountAddressInput;
     amount: AnyNumber;
     coinType?: MoveStructId;

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -1,5 +1,5 @@
 import { AptosConfig } from "../api/aptosConfig";
-import { Account, AccountAddressInput } from "../core";
+import { AccountAddressInput } from "../core";
 import { InputGenerateTransactionOptions, SimpleTransaction } from "../transactions/types";
 import { AnyNumber, MoveStructId } from "../types";
 import { APTOS_COIN } from "../utils/const";
@@ -7,7 +7,7 @@ import { generateTransaction } from "./transactionSubmission";
 
 export async function transferCoinTransaction(args: {
   aptosConfig: AptosConfig;
-  sender: Account;
+  sender: AccountAddressInput;
   recipient: AccountAddressInput;
   amount: AnyNumber;
   coinType?: MoveStructId;
@@ -17,7 +17,7 @@ export async function transferCoinTransaction(args: {
   const coinStructType = coinType ?? APTOS_COIN;
   const transaction = await generateTransaction({
     aptosConfig,
-    sender: sender.accountAddress,
+    sender,
     data: {
       function: "0x1::aptos_account::transfer_coins",
       typeArguments: [coinStructType],

--- a/tests/e2e/api/coin.test.ts
+++ b/tests/e2e/api/coin.test.ts
@@ -18,7 +18,7 @@ describe("coin", () => {
     await aptos.fundAccount({ accountAddress: sender.accountAddress, amount: FUND_AMOUNT });
 
     const transaction = await aptos.transferCoinTransaction({
-      sender,
+      sender: sender.accountAddress,
       recipient: recipient.accountAddress,
       amount: 10,
     });
@@ -48,7 +48,7 @@ describe("coin", () => {
     await aptos.fundAccount({ accountAddress: sender.accountAddress, amount: FUND_AMOUNT });
 
     const transaction = await aptos.transferCoinTransaction({
-      sender,
+      sender: sender.accountAddress,
       recipient: recipient.accountAddress,
       amount: 10,
       coinType: "0x1::my_coin::type",
@@ -83,7 +83,7 @@ describe("coin", () => {
       const senderCoinsBefore = await aptos.getAccountCoinsData({ accountAddress: sender.accountAddress });
 
       const transaction = await aptos.transferCoinTransaction({
-        sender,
+        sender: sender.accountAddress,
         recipient: recipient.accountAddress,
         amount: 10,
       });

--- a/tests/e2e/client/customClient.test.ts
+++ b/tests/e2e/client/customClient.test.ts
@@ -58,7 +58,7 @@ describe("custom client", () => {
     const recipient = Account.generate();
     await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100_000_000 });
     const transaction = await aptos.transferCoinTransaction({
-      sender: account,
+      sender: account.accountAddress,
       recipient: recipient.accountAddress,
       amount: 10,
     });


### PR DESCRIPTION
### Description
Follow up on [slack thread](https://aptos-org.slack.com/archives/C05NLAKJM9U/p1704496831185589) sender does not need to be an `Account` type, it can just be an `AccountAddressInput`. It's helpful to change it to an address in the event you don't have access to the user's private key.

### Test Plan
```bash
pnpm lint && pnpm unit-test && pnpm fmt && pnpm build
```