### PR TITLE
[privateKeys] Allow for Base64 encoding on private keys

### DIFF
--- a/src/core/common.ts
+++ b/src/core/common.ts
@@ -38,3 +38,16 @@ export type ParsingResult<T> = {
    */
   invalidReasonMessage?: string;
 };
+
+/**
+ *  Handles conversion of bytes and strings to and from Base64
+ */
+export class Base64 {
+  static toString(bytes: Uint8Array): string {
+    return Buffer.from(bytes).toString("base64");
+  }
+
+  static toBytes(str: string): Uint8Array {
+    return Uint8Array.from(Buffer.from(str, "base64"));
+  }
+}

--- a/src/core/crypto/asymmetricCrypto.ts
+++ b/src/core/crypto/asymmetricCrypto.ts
@@ -50,6 +50,11 @@ export abstract class PrivateKey extends Serializable {
    */
   abstract toString(): string;
 
+  /**
+   * Get the private key as a base64 string e.g. Ab2fs3e4==
+   */
+  abstract toBase64(): string;
+
   abstract serialize(serializer: Serializer): void;
 
   /**

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -179,6 +179,19 @@ describe("PrivateKey", () => {
     expect(key).toBeInstanceOf(Ed25519PrivateKey);
     expect(privateKey).toEqual(key.toString());
   });
+
+  it("should serialize to base64 and deserialize correctly", () => {
+    const { privateKeyBase64, privateKey } = wallet;
+    const key1 = new Ed25519PrivateKey(privateKey);
+    const key2 = new Ed25519PrivateKey(privateKeyBase64);
+    expect(key1).toEqual(key2);
+
+    const keyString = key2.toBase64();
+    expect(keyString).toEqual(privateKeyBase64);
+
+    const key3 = new Ed25519PrivateKey(keyString);
+    expect(key3).toEqual(key2);
+  });
 });
 
 describe("Signature", () => {

--- a/tests/unit/helper.ts
+++ b/tests/unit/helper.ts
@@ -11,6 +11,7 @@ export const wallet = {
   mnemonic: "shoot island position soft burden budget tooth cruel issue economy destroy above",
   path: "m/44'/637'/0'/0'/0'",
   privateKey: "0x5d996aa76b3212142792d9130796cd2e11e3c445a93118c08414df4f66bc60ec",
+  privateKeyBase64: "XZlqp2syEhQnktkTB5bNLhHjxEWpMRjAhBTfT2a8YOw=",
   publicKey: "0xea526ba1710343d953461ff68641f1b7df5f23b9042ffa2d2a798d3adb3f3d6c",
 };
 
@@ -27,6 +28,7 @@ export const secp256k1WalletTestObject = {
   mnemonic: "shoot island position soft burden budget tooth cruel issue economy destroy above",
   path: "m/44'/637'/0'/0/0",
   privateKey: "0x1eec55afc2f72c4ab7b46c84d761739035ac420a2b6b22cef3411adaf91ce1f7",
+  privateKeyBase64: "HuxVr8L3LEq3tGyE12FzkDWsQgorayLO80Ea2vkc4fc=",
   publicKey:
     "0x04913871f1d6cb7b867e8671cf63cf7b4c43819539fa0074ff933434bf20bab825b335535251f720fff72fd8b567e414af84aacf2f26ec804562081f2e0b0c9478",
 };

--- a/tests/unit/secp256k1.test.ts
+++ b/tests/unit/secp256k1.test.ts
@@ -2,8 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { secp256k1 } from "@noble/curves/secp256k1";
-import { secp256k1TestObject, secp256k1WalletTestObject } from "./helper";
-import { Deserializer, Hex, Secp256k1PrivateKey, Secp256k1PublicKey, Secp256k1Signature, Serializer } from "../../src";
+import { secp256k1TestObject, secp256k1WalletTestObject, wallet } from "./helper";
+import {
+  Deserializer,
+  Ed25519PrivateKey,
+  Hex,
+  Secp256k1PrivateKey,
+  Secp256k1PublicKey,
+  Secp256k1Signature,
+  Serializer,
+} from "../../src";
 
 /* eslint-disable max-len */
 describe("Secp256k1PublicKey", () => {
@@ -139,6 +147,19 @@ describe("Secp256k1PrivateKey", () => {
     const key = Secp256k1PrivateKey.fromDerivationPath(path, mnemonic);
     expect(key).toBeInstanceOf(Secp256k1PrivateKey);
     expect(key.toString()).toEqual(privateKey);
+  });
+
+  it("should serialize to base64 and deserialize correctly", () => {
+    const { privateKeyBase64, privateKey } = secp256k1WalletTestObject;
+    const key1 = new Secp256k1PrivateKey(privateKey);
+    const key2 = new Secp256k1PrivateKey(privateKeyBase64);
+    expect(key1).toEqual(key2);
+
+    const keyString = key2.toBase64();
+    expect(keyString).toEqual(privateKeyBase64);
+
+    const key3 = new Secp256k1PrivateKey(keyString);
+    expect(key3).toEqual(key2);
   });
 });
 


### PR DESCRIPTION
### Description
Part of an experiment to change private key encoding to base64 rather than using hex.

### Test Plan
Added tests for conversion to and from base64.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->