### PR TITLE
`TransactionWorker` to fire events a dapp can listen to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - Remove request URLs forward slash append
+- Add events to `TransactionWorker` module that dapps can listen to
+- Introduce `aptos.transaction.batch` namespace to handle batch transactions
+- Support `aptos.transaction.batch.forSingleAccount()` to send batch transactions for a single account
+- Label `aptos.batchTransactionsForSingleAccount()` as `deprecated` to prefer using `aptos.transaction.batch.forSingleAccount()`
 
 # 1.4.0 (2024-01-08)
 

--- a/examples/typescript/batch_funds.ts
+++ b/examples/typescript/batch_funds.ts
@@ -26,7 +26,7 @@ import {
   InputGenerateTransactionPayloadData,
   Network,
   NetworkToNetworkName,
-  TransactionWorkerEvents,
+  TransactionWorkerEventsEnum,
   UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 
@@ -100,9 +100,14 @@ async function main() {
   // emit batch transactions
   senders.map((sender) => aptos.transaction.batch.forSingleAccount({ sender, data: payloads }));
 
-  aptos.transaction.batch.on(TransactionWorkerEvents.ExecutionFinish, async (data: any) => {
+  aptos.transaction.batch.on(TransactionWorkerEventsEnum.TransactionSent, async (data) => {
+    console.log("message:", data.message);
+    console.log("transaction hash:", data.transactionHash);
+  });
+
+  aptos.transaction.batch.on(TransactionWorkerEventsEnum.ExecutionFinish, async (data) => {
     // log event output
-    console.log(data);
+    console.log(data.message);
 
     // verify accounts sequence number
     const accounts = senders.map((sender) => aptos.getAccountInfo({ accountAddress: sender.accountAddress }));

--- a/examples/typescript/batch_funds.ts
+++ b/examples/typescript/batch_funds.ts
@@ -30,7 +30,7 @@ import {
   UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.LOCAL;
 
 const config = new AptosConfig({ network: APTOS_NETWORK });
 const aptos = new Aptos(config);
@@ -119,7 +119,8 @@ async function main() {
         }`,
       );
     });
-
+    // worker finished execution, we can now unsubscribe from event listeners
+    aptos.transaction.batch.removeAllListeners();
     process.exit(0);
   });
 }

--- a/examples/typescript/batch_mint.ts
+++ b/examples/typescript/batch_mint.ts
@@ -25,8 +25,8 @@ import {
   InputGenerateTransactionPayloadData,
   Network,
   NetworkToNetworkName,
-  TransactionWorkerEvents,
   UserTransactionResponse,
+  TransactionWorkerEventsEnum,
 } from "@aptos-labs/ts-sdk";
 
 const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
@@ -80,7 +80,7 @@ async function main() {
   // batch mint token transactions
   aptos.transaction.batch.forSingleAccount({ sender, data: payloads });
 
-  aptos.transaction.batch.on(TransactionWorkerEvents.ExecutionFinish, async (data: any) => {
+  aptos.transaction.batch.on(TransactionWorkerEventsEnum.ExecutionFinish, async (data) => {
     // log event output
     console.log(data);
 
@@ -88,6 +88,8 @@ async function main() {
     const account = await aptos.getAccountInfo({ accountAddress: sender.accountAddress });
     console.log(`account sequence number is 101: ${account.sequence_number === "101"}`);
 
+    // worker finished execution, we can now unsubscribe from event listeners
+    aptos.transaction.batch.removeAllListeners();
     process.exit(0);
   });
 }

--- a/examples/typescript/batch_mint.ts
+++ b/examples/typescript/batch_mint.ts
@@ -25,6 +25,7 @@ import {
   InputGenerateTransactionPayloadData,
   Network,
   NetworkToNetworkName,
+  TransactionWorkerEvents,
   UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 
@@ -77,7 +78,18 @@ async function main() {
   }
 
   // batch mint token transactions
-  aptos.batchTransactionsForSingleAccount({ sender, data: payloads });
+  aptos.transaction.batch.forSingleAccount({ sender, data: payloads });
+
+  aptos.transaction.batch.on(TransactionWorkerEvents.ExecutionFinish, async (data: any) => {
+    // log event output
+    console.log(data);
+
+    // verify account sequence number
+    const account = await aptos.getAccountInfo({ accountAddress: sender.accountAddress });
+    console.log(`account sequence number is 101: ${account.sequence_number === "101"}`);
+
+    process.exit(0);
+  });
 }
 
 main();

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "dotenv": "^16.3.1",
+    "eventemitter3": "^5.0.1",
     "eslint": "^8.55.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,6 +79,9 @@ devDependencies:
   eslint-plugin-import:
     specifier: ^2.29.0
     version: 2.29.0(@typescript-eslint/parser@6.14.0)(eslint@8.55.0)
+  eventemitter3:
+    specifier: ^5.0.1
+    version: 5.0.1
   graphql:
     specifier: ^16.8.1
     version: 16.8.1
@@ -4201,6 +4204,10 @@ packages:
   /esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /eventemitter3@5.0.1:
+    resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
     dev: true
 
   /events@3.3.0:

--- a/src/api/aptos.ts
+++ b/src/api/aptos.ts
@@ -70,7 +70,7 @@ export interface Aptos
     FungibleAsset,
     General,
     Staking,
-    Omit<Transaction, "build" | "simulate" | "submit"> {}
+    Omit<Transaction, "build" | "simulate" | "submit" | "batch"> {}
 
 /**
 In TypeScript, we can’t inherit or extend from more than one class,

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -35,10 +35,10 @@ import {
   SimpleTransaction,
 } from "../transactions";
 import { AccountAddressInput, Account, PrivateKey } from "../core";
-import { TransactionWorker } from "../transactions/management";
 import { Build } from "./transactionSubmission/build";
 import { Simulate } from "./transactionSubmission/simulate";
 import { Submit } from "./transactionSubmission/submit";
+import { TransactionManagement } from "./transactionSubmission/management";
 
 export class Transaction {
   readonly config: AptosConfig;
@@ -49,11 +49,14 @@ export class Transaction {
 
   readonly submit: Submit;
 
+  readonly batch: TransactionManagement;
+
   constructor(config: AptosConfig) {
     this.config = config;
     this.build = new Build(this.config);
     this.simulate = new Simulate(this.config);
     this.submit = new Submit(this.config);
+    this.batch = new TransactionManagement(this.config);
   }
 
   /**
@@ -263,6 +266,8 @@ export class Transaction {
   // TRANSACTION SUBMISSION //
 
   /**
+   * @deprecated Prefer to use `aptos.transaction.batch.forSingleAccount()`
+   *
    * Batch transactions for a single account.
    *
    * This function uses a transaction worker that receives payloads to be processed
@@ -285,14 +290,7 @@ export class Transaction {
   }): Promise<void> {
     try {
       const { sender, data, options } = args;
-      const transactionWorker = new TransactionWorker(this.config, sender);
-
-      transactionWorker.start();
-
-      for (const d of data) {
-        /* eslint-disable no-await-in-loop */
-        await transactionWorker.push(d, options);
-      }
+      this.batch.forSingleAccount({ sender, data, options });
     } catch (error: any) {
       throw new Error(`failed to submit transactions with error: ${error}`);
     }

--- a/src/api/transactionSubmission/management.ts
+++ b/src/api/transactionSubmission/management.ts
@@ -1,5 +1,5 @@
 import EventEmitter from "eventemitter3";
-import { TransactionWorker, TransactionWorkerEvents } from "../../transactions/management";
+import { TransactionWorkerEvents, TransactionWorker, TransactionWorkerEventsEnum } from "../../transactions/management";
 import { InputGenerateTransactionPayloadData, InputGenerateTransactionOptions } from "../../transactions";
 import { AptosConfig } from "../aptosConfig";
 import { Account } from "../../core";
@@ -56,20 +56,20 @@ export class TransactionManagement extends EventEmitter<TransactionWorkerEvents>
    * TODO - should we ask events to listen to as an input?
    */
   private registerToEvents() {
-    this.transactionWorker.on(TransactionWorkerEvents.TransactionSent, async (data) => {
-      this.emit(TransactionWorkerEvents.TransactionSent, data);
+    this.transactionWorker.on(TransactionWorkerEventsEnum.TransactionSent, async (data) => {
+      this.emit(TransactionWorkerEventsEnum.TransactionSent, data);
     });
-    this.transactionWorker.on(TransactionWorkerEvents.TransactionSendFailed, async (data) => {
-      this.emit(TransactionWorkerEvents.TransactionSendFailed, data);
+    this.transactionWorker.on(TransactionWorkerEventsEnum.TransactionSendFailed, async (data) => {
+      this.emit(TransactionWorkerEventsEnum.TransactionSendFailed, data);
     });
-    this.transactionWorker.on(TransactionWorkerEvents.TransactionExecuted, async (data) => {
-      this.emit(TransactionWorkerEvents.TransactionExecuted, data);
+    this.transactionWorker.on(TransactionWorkerEventsEnum.TransactionExecuted, async (data) => {
+      this.emit(TransactionWorkerEventsEnum.TransactionExecuted, data);
     });
-    this.transactionWorker.on(TransactionWorkerEvents.TransactionExecutionFailed, async (data) => {
-      this.emit(TransactionWorkerEvents.TransactionExecutionFailed, data);
+    this.transactionWorker.on(TransactionWorkerEventsEnum.TransactionExecutionFailed, async (data) => {
+      this.emit(TransactionWorkerEventsEnum.TransactionExecutionFailed, data);
     });
-    this.transactionWorker.on(TransactionWorkerEvents.ExecutionFinish, async (data) => {
-      this.emit(TransactionWorkerEvents.ExecutionFinish, data);
+    this.transactionWorker.on(TransactionWorkerEventsEnum.ExecutionFinish, async (data) => {
+      this.emit(TransactionWorkerEventsEnum.ExecutionFinish, data);
     });
   }
 

--- a/src/api/transactionSubmission/management.ts
+++ b/src/api/transactionSubmission/management.ts
@@ -1,0 +1,106 @@
+import EventEmitter from "eventemitter3";
+import { TransactionWorker, TransactionWorkerEvents } from "../../transactions/management";
+import { InputGenerateTransactionPayloadData, InputGenerateTransactionOptions } from "../../transactions";
+import { AptosConfig } from "../aptosConfig";
+import { Account } from "../../core";
+
+export class TransactionManagement extends EventEmitter<TransactionWorkerEvents> {
+  account!: Account;
+
+  transactionWorker!: TransactionWorker;
+
+  readonly config: AptosConfig;
+
+  constructor(config: AptosConfig) {
+    super();
+    this.config = config;
+  }
+
+  /**
+   * Internal function to start the transaction worker and
+   * listen to worker events
+   *
+   * @param args.sender The sender account to sign and submit the transaction
+   */
+  private start(args: { sender: Account }): void {
+    const { sender } = args;
+    this.account = sender;
+    this.transactionWorker = new TransactionWorker(this.config, sender);
+
+    this.transactionWorker.start();
+    this.registerToEvents();
+  }
+
+  /**
+   * Internal function to push transaction data to the transaction worker.
+   *
+   * @param args.data An array of transaction payloads
+   * @param args.options optional. Transaction generation configurations (excluding accountSequenceNumber)
+   *
+   * TODO - make this public once worker supports adding transactions to existing queue
+   */
+  private push(args: {
+    data: InputGenerateTransactionPayloadData[];
+    options?: Omit<InputGenerateTransactionOptions, "accountSequenceNumber">;
+  }): void {
+    const { data, options } = args;
+
+    for (const d of data) {
+      this.transactionWorker.push(d, options);
+    }
+  }
+
+  /**
+   * Internal function to start listening to transaction worker events
+   *
+   * TODO - should we ask events to listen to as an input?
+   */
+  private registerToEvents() {
+    this.transactionWorker.on(TransactionWorkerEvents.TransactionSent, async (data) => {
+      this.emit(TransactionWorkerEvents.TransactionSent, data);
+    });
+    this.transactionWorker.on(TransactionWorkerEvents.TransactionSendFailed, async (data) => {
+      this.emit(TransactionWorkerEvents.TransactionSendFailed, data);
+    });
+    this.transactionWorker.on(TransactionWorkerEvents.TransactionExecuted, async (data) => {
+      this.emit(TransactionWorkerEvents.TransactionExecuted, data);
+    });
+    this.transactionWorker.on(TransactionWorkerEvents.TransactionExecutionFailed, async (data) => {
+      this.emit(TransactionWorkerEvents.TransactionExecutionFailed, data);
+    });
+    this.transactionWorker.on(TransactionWorkerEvents.ExecutionFinish, async (data) => {
+      this.emit(TransactionWorkerEvents.ExecutionFinish, data);
+    });
+  }
+
+  /**
+   * Send batch transactions for a single account.
+   *
+   * This function uses a transaction worker that receives payloads to be processed
+   * and submitted to chain.
+   * Note that this process is best for submitting multiple transactions that
+   * dont rely on each other, i.e batch funds, batch token mints, etc.
+   *
+   * If any worker failure, the functions throws an error.
+   *
+   * @param args.sender The sender account to sign and submit the transaction
+   * @param args.data An array of transaction payloads
+   * @param args.options optional. Transaction generation configurations (excluding accountSequenceNumber)
+   *
+   * @return void. Throws if any error
+   */
+  forSingleAccount(args: {
+    sender: Account;
+    data: InputGenerateTransactionPayloadData[];
+    options?: Omit<InputGenerateTransactionOptions, "accountSequenceNumber">;
+  }): void {
+    try {
+      const { sender, data, options } = args;
+      this.start({ sender });
+
+      this.push({ data, options });
+    } catch (error: any) {
+      throw new Error(`failed to submit transactions with error: ${error}`);
+    }
+  }
+}


### PR DESCRIPTION
### Description
The transaction management is a send-and-forget process in a way that once transactions are sent to worker, the dapp is not aware of what is going on unless a potential error happens.

This PR adds logic for the `TransactionWorker` module to fire events during a worker task and dapp can listen to these events.

```
aptos.transaction.batch.on(TransactionWorkerEvents.ExecutionFinish, async (data) => {
   console.log("execution finish", data);
});
```

Note:
Currently, dapp uses `aptos.batchTransactionsForSingleAccount()` to start the worker. We now introduce a dedicated namespace under `aptos.transaction.batch` where one can use `aptos.transaction.batch.forSingleAccount()` same as before. This is for potential future enhancement of the worker and to conform with the sdk design.

### Test Plan
`pnpm test`
`batch_mint` and `batch_funds` for examples
### Related Links
<!-- Please link to any relevant issues or pull requests! -->