### PR TITLE
[faucet] Remove waitForIndexer for faucet fundAccount

### DIFF
--- a/src/api/faucet.ts
+++ b/src/api/faucet.ts
@@ -5,7 +5,6 @@ import { fundAccount } from "../internal/faucet";
 import { UserTransactionResponse, WaitForTransactionOptions } from "../types";
 import { AccountAddressInput } from "../core";
 import { AptosConfig } from "./aptosConfig";
-import { waitForIndexer } from "../internal/transaction";
 
 /**
  * A class to query all `Faucet` related queries on Aptos.
@@ -28,11 +27,6 @@ export class Faucet {
     options?: WaitForTransactionOptions;
   }): Promise<UserTransactionResponse> {
     const fundTxn = await fundAccount({ aptosConfig: this.config, ...args });
-
-    if (args.options?.waitForIndexer !== false) {
-      await waitForIndexer({ aptosConfig: this.config, minimumLedgerVersion: BigInt(fundTxn.version) });
-    }
-
     return fundTxn;
   }
 }


### PR DESCRIPTION
### Description
Unneeded waitForIndexer call for faucet.

### Test Plan
`pnpm lint && pnpm unit-test`
Got the same number of errors locally (before and after any changes) running `pnpm api-test` 🤷 