### PR TITLE
Remove request url forward slash append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Remove request URLs forward slash append
+
 # 1.4.0 (2024-01-08)
 
 - Omit `"build" | "simulate" | "submit"` from `aptos` namespace

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -68,7 +68,7 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
   aptosConfig: AptosConfig,
 ): Promise<AptosResponse<Req, Res>> {
   const { url, path } = options;
-  const fullUrl = `${url}/${path ?? ""}`;
+  const fullUrl = path ? `${url}/${path}` : url;
   const response = await request<Req, Res>({ ...options, url: fullUrl }, aptosConfig.client);
 
   const result: AptosResponse<Req, Res> = {

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -338,7 +338,7 @@ describe("aptos request", () => {
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);
-            expect(error.url).toBe(`${NetworkToIndexerAPI[config.network]}/`);
+            expect(error.url).toBe(`${NetworkToIndexerAPI[config.network]}`);
             expect(error.status).toBe(200);
             expect(error.statusText).toBe("OK");
             expect(error.data).toHaveProperty("errors");


### PR DESCRIPTION
### Description
For custom URLs, users might define a url with a forward slash (`/`). The SDK appends a forward slash be default and it can lead to errors.

```
https://www.domain.com/v1/ -> SDK will change it to https://www.domain.com/v1//
```

This PR remove the default forward slash append so URLs stay the same

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->