### PR TITLE
[deps] Move event emitter to runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Move eventemitter3 to runtime dependency
+
 # 1.5.0 (2024-01-24)
 
 - Remove request URLs forward slash append

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "@scure/bip32": "^1.3.3",
     "@scure/bip39": "^1.2.1",
     "form-data": "^4.0.0",
-    "tweetnacl": "^1.0.3"
+    "tweetnacl": "^1.0.3",
+    "eventemitter3": "^5.0.1"
   },
   "devDependencies": {
     "@aptos-labs/aptos-cli": "^0.1.2",
@@ -66,7 +67,6 @@
     "@typescript-eslint/eslint-plugin": "^6.14.0",
     "@typescript-eslint/parser": "^6.14.0",
     "dotenv": "^16.3.1",
-    "eventemitter3": "^5.0.1",
     "eslint": "^8.55.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-airbnb-typescript": "^17.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ dependencies:
   '@scure/bip39':
     specifier: ^1.2.1
     version: 1.2.1
+  eventemitter3:
+    specifier: ^5.0.1
+    version: 5.0.1
   form-data:
     specifier: ^4.0.0
     version: 4.0.0
@@ -79,9 +82,6 @@ devDependencies:
   eslint-plugin-import:
     specifier: ^2.29.0
     version: 2.29.0(@typescript-eslint/parser@6.14.0)(eslint@8.55.0)
-  eventemitter3:
-    specifier: ^5.0.1
-    version: 5.0.1
   graphql:
     specifier: ^16.8.1
     version: 16.8.1
@@ -4208,7 +4208,7 @@ packages:
 
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
-    dev: true
+    dev: false
 
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}


### PR DESCRIPTION
Without this, it will fail to run with
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'eventemitter3' imported from /opt/git/aptos-playground/node_modules/.pnpm/@aptos-labs+ts-sdk@1.5.0/node_modules/@aptos-labs/ts-sdk/dist/esm/chunk-27YNIEGN.mjs

### Description
<!-- Please describe your change and its motivation. -->

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->