### PR TITLE
Add more meaningful API error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - Add optional `options` param to `getAccountEventsByCreationNumber` query for paginations and order by
+- Add more meaningful API error messages
 
 # 1.5.1 (2024-01-24)
 

--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -81,4 +81,22 @@ export class AptosConfig {
   isIndexerRequest(url: string): boolean {
     return NetworkToIndexerAPI[this.network] === url;
   }
+
+  /**
+   * Checks if the URL is a known fullnode endpoint
+   *
+   * @internal
+   * */
+  isFullnodeRequest(url: string): boolean {
+    return NetworkToNodeAPI[this.network] === url;
+  }
+
+  /**
+   * Checks if the URL is a known faucet endpoint
+   *
+   * @internal
+   * */
+  isFaucetRequest(url: string): boolean {
+    return NetworkToFaucetAPI[this.network] === url;
+  }
 }

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -90,7 +90,8 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
       throw new AptosApiError(
         options,
         result,
-        indexerResponse.errors[0].message ?? `Unhandled Error ${response.status} : ${response.statusText}`,
+        `Indexer error: ${indexerResponse.errors[0].message}` ??
+          `Indexer unhandled Error ${response.status} : ${response.statusText}`,
       );
     }
     result.data = indexerResponse.data as Res;
@@ -112,5 +113,11 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
     errorMessage = `Unhandled Error ${result.status} : ${result.statusText}`;
   }
 
-  throw new AptosApiError(options, result, errorMessage);
+  // Since we already checked if it is an Indexer request, here we can be sure
+  // it either Fullnode or Faucet request
+  throw new AptosApiError(
+    options,
+    result,
+    `${aptosConfig.isFullnodeRequest(url) ? "Fullnode" : "Faucet"} error: ${errorMessage}`,
+  );
 }


### PR DESCRIPTION
### Description
When having API errors it is hard to understand what server errors out and most likely we get something like
```
AptosApiError: database query error
```
![Screenshot 2024-01-31 at 4 18 56 PM](https://github.com/aptos-labs/aptos-ts-sdk/assets/29798064/e0b69be9-b2c5-463d-b780-ac5eff00e30a)

That is not really helpful in understanding WHAT service is down between the 3 - indexer, fullnode, faucet

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->