### PR TITLE
Support automated account creation for sponsored transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - Add optional `options` param to `getAccountEventsByCreationNumber` query for paginations and order by
 - Add more meaningful API error messages
+- Support automated account creation for sponsored transactions
 
 # 1.5.1 (2024-01-24)
 

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -254,7 +254,11 @@ describe("transaction builder", () => {
   describe("generate transaction", () => {
     test("it returns a serialized raw transaction", async () => {
       const alice = Account.generate();
-      await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: FUND_AMOUNT });
+      await aptos.fundAccount({
+        accountAddress: alice.accountAddress,
+        amount: FUND_AMOUNT,
+        options: { waitForIndexer: true },
+      });
       const payload = await generateTransactionPayload({
         bytecode: multiSignerScriptBytecode,
         functionArguments: [


### PR DESCRIPTION
### Description
[AIP-52](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-52.md) introduced automated account creation for sponsored transactions. This PR supports this change by if the transaction is a sponsored transaction, check the main signer chain info. If it is not found, assign the sequence number to 0.

### Test Plan
`pnpm test`

### Related Links
<!-- Please link to any relevant issues or pull requests! -->