### PR TITLE
[transaction] Allow local ABI instead of remote ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Add ability to provide ABI to skip ABI fetch, and get roughly 50% performance improvement
+
 # 1.6.0 (2024-02-08)
 
 - Add optional `options` param to `getAccountEventsByCreationNumber` query for paginations and order by

--- a/examples/typescript-esm/package.json
+++ b/examples/typescript-esm/package.json
@@ -6,14 +6,15 @@
   "type": "module",
   "scripts": {
     "build": "pnpm _build:esm",
-    "_build:esm": "tsup simple_transfer.ts sponsored_transactions/simple_sponsored_transaction.ts sponsored_transactions/server_as_sponsor.ts simple_digital_asset.ts multisig_v2.ts sponsored_transactions/server_signs_and_submit.ts --platform node --format esm --dts --out-dir dist",
+    "_build:esm": "tsup *.ts sponsored_transactions/*.ts --platform node --format esm --dts --out-dir dist",
     "simple_transfer": "ts-node --esm dist/simple_transfer.js",
     "simple_sponsored_transaction": "ts-node --esm dist/sponsored_transactions/simple_sponsored_transaction.js",
-    "simple_digital_asset": "pnpm run build && ts-node --esm dist/simple_digital_asset.js",
-    "multisig_v2": "pnpm run build && ts-node --esm dist/multisig_v2.js",
-    "server_signs_and_submit": "pnpm run build && ts-node dist/sponsored_transactions/server_signs_and_submit.js",
-    "server_as_sponsor": "pnpm run build && ts-node dist/sponsored_transactions/server_as_sponsor.js",
-    "test": "run-s build simple_transfer simple_sponsored_transaction"
+    "simple_digital_asset": "ts-node --esm dist/simple_digital_asset.js",
+    "multisig_v2": "ts-node --esm dist/multisig_v2.js",
+    "server_signs_and_submit": "ts-node dist/sponsored_transactions/server_signs_and_submit.js",
+    "server_as_sponsor": "ts-node dist/sponsored_transactions/server_as_sponsor.js",
+    "transaction_with_predefined_abi": "ts-node dist/transaction_with_predefined_abi.js",
+    "test": "run-s build simple_transfer simple_sponsored_transaction simple_digital_asset multisig_v2 server_signs_and_submit server_as_sponsor transaction_with_predefined_abi"
   },
   "keywords": [],
   "author": "",

--- a/examples/typescript-esm/transaction_with_predefined_abi.ts
+++ b/examples/typescript-esm/transaction_with_predefined_abi.ts
@@ -1,0 +1,203 @@
+/* eslint-disable no-console */
+
+/**
+ * This example shows how to use the Aptos client to create accounts, fund them, and transfer between them.
+ */
+
+import {
+  Account,
+  AccountAddress,
+  Aptos,
+  APTOS_COIN,
+  AptosConfig,
+  EntryFunctionABI,
+  Network,
+  NetworkToNetworkName,
+  parseTypeTag,
+  SimpleTransaction,
+  TypeTagAddress,
+  TypeTagU64,
+  U64,
+} from "@aptos-labs/ts-sdk";
+
+const APTOS_COIN_TYPE = parseTypeTag(APTOS_COIN);
+const COIN_STORE = "0x1::coin::CoinStore<0x1::aptos_coin::AptosCoin>";
+const ALICE_INITIAL_BALANCE = 100_000_000;
+const BOB_INITIAL_BALANCE = 100;
+const TRANSFER_AMOUNT = 100;
+
+// Default to devnet, but allow for overriding
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+
+/**
+ * Prints the balance of an account
+ * @param aptos
+ * @param name
+ * @param address
+ * @returns {Promise<*>}
+ *
+ */
+const balance = async (aptos: Aptos, name: string, address: AccountAddress) => {
+  type Coin = { coin: { value: string } };
+  const resource = await aptos.getAccountResource<Coin>({
+    accountAddress: address,
+    resourceType: COIN_STORE,
+  });
+  const amount = Number(resource.coin.value);
+
+  console.log(`${name}'s balance is: ${amount}`);
+  return amount;
+};
+
+async function timeSubmission(
+  aptos: Aptos,
+  signer: Account,
+  buildTxn: () => Promise<SimpleTransaction>,
+): Promise<void> {
+  const start = Date.now();
+  const rawTxn = await buildTxn();
+  const buildTime = Date.now();
+  const submittedTxn = await aptos.signAndSubmitTransaction({ signer, transaction: rawTxn });
+  const submitTime = Date.now();
+  await aptos.waitForTransaction({ transactionHash: submittedTxn.hash });
+  const endTime = Date.now();
+  const builtLatency = buildTime - start;
+  const submitLatency = submitTime - start;
+  const e2eLatency = endTime - start;
+
+  console.log(`Time for building: ${builtLatency}ms | submission: ${submitLatency}ms | total E2E: ${e2eLatency}ms`);
+}
+
+const example = async () => {
+  console.log("This example will show you how to increase performance of known entry functions");
+
+  // Setup the client
+  const config = new AptosConfig({ network: APTOS_NETWORK });
+  const aptos = new Aptos(config);
+
+  // Create two accounts
+  const alice = Account.generate();
+  const bob = Account.generate();
+
+  console.log("=== Addresses ===\n");
+  console.log(`Alice's address is: ${alice.accountAddress}`);
+  console.log(`Bob's address is: ${bob.accountAddress}`);
+
+  // Fund the accounts
+  console.log("\n=== Funding accounts ===\n");
+
+  await aptos.faucet.fundAccount({
+    accountAddress: alice.accountAddress,
+    amount: ALICE_INITIAL_BALANCE,
+  });
+
+  await aptos.faucet.fundAccount({
+    accountAddress: bob.accountAddress,
+    amount: BOB_INITIAL_BALANCE,
+  });
+
+  // Show the balances
+  console.log("\n=== Balances ===\n");
+  const aliceBalance = await balance(aptos, "Alice", alice.accountAddress);
+  const bobBalance = await balance(aptos, "Bob", bob.accountAddress);
+
+  if (aliceBalance !== ALICE_INITIAL_BALANCE) throw new Error("Alice's balance is incorrect");
+  if (bobBalance !== BOB_INITIAL_BALANCE) throw new Error("Bob's balance is incorrect");
+
+  // At this point, we'll time transfers with and without ABI, and with or without BCS encoded
+  const transferAbi: EntryFunctionABI = {
+    typeParameters: [{ constraints: [] }],
+    parameters: [new TypeTagAddress(), new TypeTagU64()],
+  };
+  // Transfer between users
+
+  console.log("\n=== Remote ABI, normal inputs ===\n");
+  const aliceAddressString = alice.accountAddress.toString();
+  const bobAddressString = alice.accountAddress.toString();
+  await timeSubmission(aptos, alice, async () =>
+    aptos.transaction.build.simple({
+      sender: aliceAddressString,
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: [APTOS_COIN_TYPE],
+        functionArguments: [bobAddressString, TRANSFER_AMOUNT],
+      },
+    }),
+  );
+
+  console.log("\n=== Remote ABI, BCS inputs ===\n");
+  await timeSubmission(aptos, alice, async () =>
+    aptos.transaction.build.simple({
+      sender: alice.accountAddress,
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: [APTOS_COIN_TYPE],
+        functionArguments: [bob.accountAddress, new U64(TRANSFER_AMOUNT)],
+      },
+    }),
+  );
+
+  console.log("\n=== Local ABI, normal inputs ===\n");
+  await timeSubmission(aptos, alice, async () =>
+    aptos.transaction.build.simple({
+      sender: alice.accountAddress,
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: [APTOS_COIN_TYPE],
+        functionArguments: [bobAddressString, TRANSFER_AMOUNT],
+        abi: transferAbi,
+      },
+    }),
+  );
+
+  console.log("\n=== Local ABI, BCS inputs ===\n");
+  await timeSubmission(aptos, alice, async () =>
+    aptos.transaction.build.simple({
+      sender: alice.accountAddress,
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: [APTOS_COIN_TYPE],
+        functionArguments: [bob.accountAddress, new U64(TRANSFER_AMOUNT)],
+        abi: transferAbi,
+      },
+    }),
+  );
+
+  console.log("\n=== Local ABI, BCS inputs, sequence number already cached ===\n");
+  const accountData = await aptos.account.getAccountInfo({ accountAddress: alice.accountAddress });
+  const sequenceNumber = BigInt(accountData.sequence_number);
+  await timeSubmission(aptos, alice, async () =>
+    aptos.transaction.build.simple({
+      sender: alice.accountAddress,
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: [APTOS_COIN_TYPE],
+        functionArguments: [bob.accountAddress, new U64(TRANSFER_AMOUNT)],
+        abi: transferAbi,
+      },
+      options: {
+        accountSequenceNumber: sequenceNumber,
+      },
+    }),
+  );
+
+  console.log("\n=== Local ABI, BCS inputs, sequence number and gas already cached ===\n");
+  await timeSubmission(aptos, alice, async () =>
+    aptos.transaction.build.simple({
+      sender: alice.accountAddress,
+      data: {
+        function: "0x1::coin::transfer",
+        typeArguments: [APTOS_COIN_TYPE],
+        functionArguments: [bob.accountAddress, new U64(TRANSFER_AMOUNT)],
+        abi: transferAbi,
+      },
+      options: {
+        accountSequenceNumber: sequenceNumber + 1n,
+        gasUnitPrice: 100,
+        maxGasAmount: 1000,
+      },
+    }),
+  );
+};
+
+example();

--- a/src/api/digitalAsset.ts
+++ b/src/api/digitalAsset.ts
@@ -21,7 +21,7 @@ import {
   burnDigitalAssetTransaction,
   CreateCollectionOptions,
   createCollectionTransaction,
-  freezeDigitalAssetTransaferTransaction,
+  freezeDigitalAssetTransferTransaction,
   getCollectionData,
   getCollectionId,
   getCurrentDigitalAssetOwnership,
@@ -37,7 +37,7 @@ import {
   setDigitalAssetNameTransaction,
   setDigitalAssetURITransaction,
   transferDigitalAssetTransaction,
-  unfreezeDigitalAssetTransaferTransaction,
+  unfreezeDigitalAssetTransferTransaction,
   updateDigitalAssetPropertyTransaction,
   updateDigitalAssetTypedPropertyTransaction,
 } from "../internal/digitalAsset";
@@ -331,7 +331,7 @@ export class DigitalAsset {
     digitalAssetType?: MoveStructId;
     options?: InputGenerateTransactionOptions;
   }) {
-    return freezeDigitalAssetTransaferTransaction({ aptosConfig: this.config, ...args });
+    return freezeDigitalAssetTransferTransaction({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -348,7 +348,7 @@ export class DigitalAsset {
     digitalAssetType?: MoveStructId;
     options?: InputGenerateTransactionOptions;
   }) {
-    return unfreezeDigitalAssetTransaferTransaction({ aptosConfig: this.config, ...args });
+    return unfreezeDigitalAssetTransferTransaction({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -1,9 +1,15 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { AccountAddressInput } from "../core";
-import { InputGenerateTransactionOptions, SimpleTransaction } from "../transactions/types";
+import { EntryFunctionABI, InputGenerateTransactionOptions, SimpleTransaction } from "../transactions/types";
 import { AnyNumber, MoveStructId } from "../types";
 import { APTOS_COIN } from "../utils/const";
 import { generateTransaction } from "./transactionSubmission";
+import { TypeTagAddress, TypeTagU64 } from "../transactions";
+
+const coinTransferAbi: EntryFunctionABI = {
+  typeParameters: [{ constraints: [] }],
+  parameters: [new TypeTagAddress(), new TypeTagU64()],
+};
 
 export async function transferCoinTransaction(args: {
   aptosConfig: AptosConfig;
@@ -15,16 +21,15 @@ export async function transferCoinTransaction(args: {
 }): Promise<SimpleTransaction> {
   const { aptosConfig, sender, recipient, amount, coinType, options } = args;
   const coinStructType = coinType ?? APTOS_COIN;
-  const transaction = await generateTransaction({
+  return generateTransaction({
     aptosConfig,
     sender,
     data: {
       function: "0x1::aptos_account::transfer_coins",
       typeArguments: [coinStructType],
       functionArguments: [recipient, amount],
+      abi: coinTransferAbi,
     },
     options,
   });
-
-  return transaction;
 }

--- a/src/internal/fungibleAsset.ts
+++ b/src/internal/fungibleAsset.ts
@@ -34,7 +34,14 @@ import {
   FungibleAssetMetadataBoolExp,
 } from "../types/generated/types";
 import { Account, AccountAddress } from "../core";
-import { InputGenerateTransactionOptions, SimpleTransaction } from "../transactions";
+import {
+  EntryFunctionABI,
+  InputGenerateTransactionOptions,
+  parseTypeTag,
+  SimpleTransaction,
+  TypeTagAddress,
+  TypeTagU64,
+} from "../transactions";
 import { generateTransaction } from "./transactionSubmission";
 
 export async function getFungibleAssetMetadata(args: {
@@ -109,6 +116,11 @@ export async function getCurrentFungibleAssetBalances(args: {
   return data.current_fungible_asset_balances;
 }
 
+const faTransferAbi: EntryFunctionABI = {
+  typeParameters: [],
+  parameters: [parseTypeTag("0x1::object::Object"), new TypeTagAddress(), new TypeTagU64()],
+};
+
 export async function transferFungibleAsset(args: {
   aptosConfig: AptosConfig;
   sender: Account;
@@ -118,15 +130,15 @@ export async function transferFungibleAsset(args: {
   options?: InputGenerateTransactionOptions;
 }): Promise<SimpleTransaction> {
   const { aptosConfig, sender, fungibleAssetMetadataAddress, recipient, amount, options } = args;
-  const transaction = await generateTransaction({
+  return generateTransaction({
     aptosConfig,
     sender: sender.accountAddress,
     data: {
       function: "0x1::primary_fungible_store::transfer",
       typeArguments: ["0x1::fungible_asset::Metadata"],
       functionArguments: [fungibleAssetMetadataAddress, recipient, amount],
+      abi: faTransferAbi,
     },
     options,
   });
-  return transaction;
 }

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -55,7 +55,6 @@ import {
   AnyTransactionPayloadInstance,
   AnyRawTransactionInstance,
   EntryFunctionArgumentTypes,
-  EntryFunctionABI,
   InputGenerateMultiAgentRawTransactionArgs,
   InputGenerateRawTransactionArgs,
   InputGenerateSingleSignerRawTransactionArgs,
@@ -64,13 +63,13 @@ import {
   MultiAgentTransaction,
   InputScriptData,
   InputSimulateTransactionData,
-  InputGenerateTransactionPayloadData,
-  InputEntryFunctionData,
-  InputMultiSigData,
   InputMultiSigDataWithRemoteABI,
   InputEntryFunctionDataWithRemoteABI,
   InputGenerateTransactionPayloadDataWithRemoteABI,
   InputSubmitTransactionData,
+  InputGenerateTransactionPayloadDataWithABI,
+  InputEntryFunctionDataWithABI,
+  InputMultiSigDataWithABI,
 } from "../types";
 import { convertArgument, fetchEntryFunctionAbi, standardizeTypeTags } from "./remoteAbi";
 import { memoizeAsync } from "../../utils/memoize";
@@ -117,25 +116,16 @@ export async function generateTransactionPayload(
     1000 * 60 * 5, // 5 minutes
   )();
 
-  return generateTransactionPayloadWithABI(args, functionAbi);
+  // Fill in the ABI
+  return generateTransactionPayloadWithABI({ abi: functionAbi, ...args });
 }
 
+export function generateTransactionPayloadWithABI(args: InputEntryFunctionDataWithABI): TransactionPayloadEntryFunction;
+export function generateTransactionPayloadWithABI(args: InputMultiSigDataWithABI): TransactionPayloadMultiSig;
 export function generateTransactionPayloadWithABI(
-  args: InputEntryFunctionData,
-  functionAbi: EntryFunctionABI,
-): TransactionPayloadEntryFunction;
-export function generateTransactionPayloadWithABI(
-  args: InputMultiSigData,
-  functionAbi: EntryFunctionABI,
-): TransactionPayloadMultiSig;
-export function generateTransactionPayloadWithABI(
-  args: InputGenerateTransactionPayloadData,
-  functionAbi: EntryFunctionABI,
+  args: InputGenerateTransactionPayloadDataWithABI,
 ): AnyTransactionPayloadInstance {
-  if (isScriptDataInput(args)) {
-    return generateTransactionPayloadScript(args);
-  }
-
+  const functionAbi = args.abi;
   const { moduleAddress, moduleName, functionName } = getFunctionParts(args.function);
 
   // Ensure that all type arguments are typed properly

--- a/src/transactions/typeTag/index.ts
+++ b/src/transactions/typeTag/index.ts
@@ -277,6 +277,10 @@ export class TypeTagVector extends TypeTag {
     super();
   }
 
+  static u8(): TypeTagVector {
+    return new TypeTagVector(new TypeTagU8());
+  }
+
   serialize(serializer: Serializer): void {
     serializer.serializeU32AsUleb128(TypeTagVariants.Vector);
     this.value.serialize(serializer);

--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -275,7 +275,7 @@ function parseTypeTagInner(str: string, types: Array<TypeTag>, allowGenerics: bo
       }
 
       // If the value doesn't contain a colon, then we'll assume it isn't trying to be a struct
-      if (!str.match(/.*:.*/)) {
+      if (!str.match(/:/)) {
         throw new TypeTagParserError(str, TypeTagParserErrorType.InvalidTypeTag);
       }
 

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -109,7 +109,18 @@ export type InputEntryFunctionData = {
   function: MoveFunctionId;
   typeArguments?: Array<TypeTag | string>;
   functionArguments: Array<EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes>;
+  abi?: EntryFunctionABI;
 };
+
+export type InputGenerateTransactionPayloadDataWithABI = InputEntryFunctionDataWithABI | InputMultiSigDataWithABI;
+
+export type InputEntryFunctionDataWithABI = Omit<InputEntryFunctionData, "abi"> & {
+  abi: EntryFunctionABI;
+};
+
+export type InputMultiSigDataWithABI = {
+  multisigAddress: AccountAddressInput;
+} & InputEntryFunctionDataWithABI;
 
 export type InputEntryFunctionDataWithRemoteABI = InputEntryFunctionData & { aptosConfig: AptosConfig };
 /**

--- a/tests/e2e/transaction/generateTransaction.test.ts
+++ b/tests/e2e/transaction/generateTransaction.test.ts
@@ -10,6 +10,8 @@ import {
   TransactionPayloadScript,
   TransactionPayloadMultiSig,
   TransactionPayloadEntryFunction,
+  TypeTagU64,
+  TypeTagAddress,
 } from "../../../src";
 import { longTestTimeout } from "../../unit/helper";
 import { fundAccounts, singleSignerScriptBytecode } from "./helper";
@@ -62,6 +64,25 @@ describe("generate transaction", () => {
         data: {
           function: "0x1::aptos_account::transfer",
           functionArguments: [recieverAccounts[0].accountAddress, 1],
+        },
+      });
+      expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();
+      const deserializer = new Deserializer(transaction.rawTransaction.bcsToBytes());
+      const deserializedTransaction = RawTransaction.deserialize(deserializer);
+      expect(deserializedTransaction instanceof RawTransaction).toBeTruthy();
+      expect(deserializedTransaction.payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
+    });
+
+    test("it generates an entry function transaction with local ABI", async () => {
+      const transaction = await aptos.transaction.build.simple({
+        sender: senderAccount.accountAddress,
+        data: {
+          function: "0x1::aptos_account::transfer",
+          functionArguments: [recieverAccounts[0].accountAddress, 1],
+          abi: {
+            typeParameters: [],
+            parameters: [new TypeTagAddress(), new TypeTagU64()],
+          },
         },
       });
       expect(transaction.rawTransaction instanceof RawTransaction).toBeTruthy();

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -103,42 +103,34 @@ describe("transaction builder", () => {
     };
 
     test("it generates a multi sig transaction payload", async () => {
-      const payload = generateTransactionPayloadWithABI(
-        {
-          multisigAddress: Account.generate().accountAddress,
-          function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-          functionArguments: ["0x1", "0x1"],
-        },
-        functionAbi,
-      );
+      const payload = generateTransactionPayloadWithABI({
+        multisigAddress: Account.generate().accountAddress,
+        function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+        functionArguments: ["0x1", "0x1"],
+        abi: functionAbi,
+      });
       expect(payload instanceof TransactionPayloadMultiSig).toBeTruthy();
     });
     test("it generates an entry function transaction payload", async () => {
-      const payload = generateTransactionPayloadWithABI(
-        {
-          function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-          functionArguments: ["0x1", "0x1"],
-        },
-        functionAbi,
-      );
+      const payload = generateTransactionPayloadWithABI({
+        function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+        functionArguments: ["0x1", "0x1"],
+        abi: functionAbi,
+      });
       expect(payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
     });
     test("it generates an entry function transaction payload with mixed arguments", async () => {
-      const payload = generateTransactionPayloadWithABI(
-        {
-          function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-          functionArguments: [AccountAddress.ONE, "0x1"],
-        },
-        functionAbi,
-      );
+      const payload = generateTransactionPayloadWithABI({
+        function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+        functionArguments: [AccountAddress.ONE, "0x1"],
+        abi: functionAbi,
+      });
       expect(payload instanceof TransactionPayloadEntryFunction).toBeTruthy();
-      const payload2 = generateTransactionPayloadWithABI(
-        {
-          function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-          functionArguments: ["0x1", AccountAddress.ONE],
-        },
-        functionAbi,
-      );
+      const payload2 = generateTransactionPayloadWithABI({
+        function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+        functionArguments: ["0x1", AccountAddress.ONE],
+        abi: functionAbi,
+      });
       expect(payload2 instanceof TransactionPayloadEntryFunction).toBeTruthy();
     });
   });


### PR DESCRIPTION
### Description
In testing, removing remote ABI and fetching the sequence number
 and gas can reduce submission latency by roughly 50%

### Test Plan
E2E example to test

Using Devnet:

From Aptos labs:
```
=== Remote ABI, normal inputs ===

Time for building: 127ms | submission: 178ms | total E2E: 452ms

=== Remote ABI, BCS inputs ===

Time for building: 75ms | submission: 117ms | total E2E: 396ms

=== Local ABI, normal inputs ===

Time for building: 69ms | submission: 113ms | total E2E: 387ms

=== Local ABI, BCS inputs ===

Time for building: 67ms | submission: 108ms | total E2E: 381ms

=== Local ABI, BCS inputs, sequence number already cached ===

Time for building: 41ms | submission: 84ms | total E2E: 361ms

=== Local ABI, BCS inputs, sequence number and gas already cached ===

Time for building: 35ms | submission: 74ms | total E2E: 360ms
```

I ran these via my gigabit internet at home:
```
=== Remote ABI, normal inputs ===

Took for submission: 136ms | E2E: 398ms

=== Remote ABI, BCS inputs ===

Took for submission: 98ms | E2E: 356ms

=== Local ABI, normal inputs ===

Took for submission: 93ms | E2E: 353ms

=== Local ABI, BCS inputs ===

Took for submission: 99ms | E2E: 364ms

=== Local ABI, BCS inputs, sequence number already cached ===

Took for submission: 61ms | E2E: 319ms

=== Local ABI, BCS inputs, sequence number and gas already cached ===

Took for submission: 61ms | E2E: 325ms
```

I ran these via Argentina via Switzerland on VPN:
```
=== Remote ABI, normal inputs ===

Took for submission: 2438ms | E2E: 2821ms

=== Remote ABI, BCS inputs ===

Took for submission: 1792ms | E2E: 2460ms

=== Local ABI, normal inputs ===

Took for submission: 2117ms | E2E: 2789ms

=== Local ABI, BCS inputs ===

Took for submission: 1726ms | E2E: 2396ms

=== Local ABI, BCS inputs, sequence number already cached ===

Took for submission: 1146ms | E2E: 1756ms

=== Local ABI, BCS inputs, sequence number and gas already cached ===

Took for submission: 1132ms | E2E: 1730ms
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->