### PR TITLE
[docs] Add redirects for latest page

### DIFF
--- a/docs/@aptos-labs/.nojekyll
+++ b/docs/@aptos-labs/.nojekyll
@@ -1,1 +1,0 @@
-TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/@aptos-labs/index.html
+++ b/docs/@aptos-labs/index.html
@@ -1,5 +1,0 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to ts-sdk-latest</title>
-<meta http-equiv="refresh" content="0; URL../ts-sdk-latest">
-<link rel="canonical" href="../ts-sdk-latest">

--- a/docs/@aptos-labs/index.md
+++ b/docs/@aptos-labs/index.md
@@ -1,0 +1,5 @@
+---
+permalink: /@aptos-labs
+redirect_to:
+  - ./ts-sdk-latest
+---

--- a/docs/@aptos-labs/ts-sdk-latest/.nojekyll
+++ b/docs/@aptos-labs/ts-sdk-latest/.nojekyll
@@ -1,1 +1,0 @@
-TypeDoc added this file to prevent GitHub Pages from using Jekyll. You can turn off this behavior by setting the `githubPages` option to false.

--- a/docs/@aptos-labs/ts-sdk-latest/index.html
+++ b/docs/@aptos-labs/ts-sdk-latest/index.html
@@ -1,5 +1,0 @@
-<!DOCTYPE html>
-<meta charset="utf-8">
-<title>Redirecting to ts-sdk-1.7.0</title>
-<meta http-equiv="refresh" content="0; URL../ts-sdk-1.7.0">
-<link rel="canonical" href="../ts-sdk-1.7.0">

--- a/docs/@aptos-labs/ts-sdk-latest/index.md
+++ b/docs/@aptos-labs/ts-sdk-latest/index.md
@@ -1,0 +1,5 @@
+---
+permalink: /ts-sdk-latest
+redirect_to:
+  - ../ts-sdk-1.7.0
+---

--- a/scripts/generateDocs.sh
+++ b/scripts/generateDocs.sh
@@ -43,6 +43,6 @@ else
 fi
 
 # Now update the redirect
-REDIRECT_FILE='docs/@aptos-labs/ts-sdk-latest/index.html';
+REDIRECT_FILE='docs/@aptos-labs/ts-sdk-latest/index.md';
 $(sed -i.bak "s/- ts-sdk-.*/- ts-sdk-$npm_package_version/" $REDIRECT_FILE)
 echo "Updated redirect $REDIRECT_FILE with version $npm_package_version for latest";


### PR DESCRIPTION
### Description
Finally tested locally on my local repo

https://gregnazario.github.io/aptos-ts-sdk/


https://gregnazario.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-latest

That will allow us to have a "latest" link properly, and we'll probably later have to deal with something fancier to select which version of the docs is wanted.