### PR TITLE
Use node API via API Gateway

### DIFF
--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -108,7 +108,7 @@ export class General {
    * @param args.data Object that describes table item
    * @param args.options.ledgerVersion The ledger version to query, if not provided it will get the latest version
    *
-   * @example https://fullnode.devnet.aptoslabs.com/v1/accounts/0x1/resource/0x1::coin::CoinInfo%3C0x1::aptos_coin::AptosCoin%3E
+   * @example https://api.devnet.aptoslabs.com/v1/accounts/0x1/resource/0x1::coin::CoinInfo%3C0x1::aptos_coin::AptosCoin%3E
    * {
    *  data.key_type = "address" // Move type of table key
    *  data.value_type = "u128" // Move type of table value

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -155,7 +155,7 @@ export class Transaction {
   /**
    * Gives an estimate of the gas unit price required to get a
    * transaction on chain in a reasonable amount of time.
-   * For more information {@link https://fullnode.mainnet.aptoslabs.com/v1/spec#/operations/estimate_gas_price}
+   * For more information {@link https://api.mainnet.aptoslabs.com/v1/spec#/operations/estimate_gas_price}
    *
    * @returns Object holding the outputs of the estimate gas API
    * @example

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -213,7 +213,7 @@ export interface Client {
 /**
  * The API request type
  *
- * @param url - the url to make the request to, i.e https://fullnode.aptoslabs.devnet.com/v1
+ * @param url - the url to make the request to, i.e https://fullnode.devnet.aptoslabs.com/v1
  * @param method - the request method "GET" | "POST"
  * @param endpoint (optional) - the endpoint to make the request to, i.e transactions
  * @param body (optional) - the body of the request

--- a/src/utils/apiEndpoints.ts
+++ b/src/utils/apiEndpoints.ts
@@ -10,9 +10,9 @@ export const NetworkToIndexerAPI: Record<string, string> = {
 };
 
 export const NetworkToNodeAPI: Record<string, string> = {
-  mainnet: "https://fullnode.mainnet.aptoslabs.com/v1",
-  testnet: "https://fullnode.testnet.aptoslabs.com/v1",
-  devnet: "https://fullnode.devnet.aptoslabs.com/v1",
+  mainnet: "https://api.mainnet.aptoslabs.com/v1",
+  testnet: "https://api.testnet.aptoslabs.com/v1",
+  devnet: "https://api.devnet.aptoslabs.com/v1",
   randomnet: "https://fullnode.random.aptoslabs.com/v1",
   local: "http://127.0.0.1:8080/v1",
 };


### PR DESCRIPTION
### Description
This is part of the migration to API Gateway. More context here: https://www.notion.so/aptoslabs/Migration-1-Legacy-URL-to-API-Gateway-migration-b007742490684b9bab3debd674504a94.

I found the initial files to change like this:
```
rg -l -e 'fullnode\.[a-z]{3,6}net.aptoslabs.com'
```

I then did a find replace from `fullnode.([a-z]{3,6}net).aptoslabs.com` to `api.$1.aptoslabs.com`.

I did some further digging, e.g. for places where we perhaps build the URL, by just looking at every file that references `aptoslabs.com`. Hopefully this is everything.

I haven't touched indexer API, we'll do that in another PR.

### Test Plan
CI for now.