### PR TITLE
[bugfix] Fix TSC when compiling using SDK

### DIFF
--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -4,7 +4,7 @@
 import aptosClient from "@aptos-labs/aptos-client";
 import { AptosSettings, ClientConfig, Client } from "../types";
 import { NetworkToNodeAPI, NetworkToFaucetAPI, NetworkToIndexerAPI, Network } from "../utils/apiEndpoints";
-import { AptosApiType, DEFAULT_NETWORK } from "../utils/const";
+import { AptosApiType } from "../utils/const";
 
 /**
  * This class holds the config information for the SDK client instance.
@@ -36,7 +36,7 @@ export class AptosConfig {
   readonly clientConfig?: ClientConfig;
 
   constructor(settings?: AptosSettings) {
-    this.network = settings?.network ?? DEFAULT_NETWORK;
+    this.network = settings?.network ?? Network.DEVNET;
     this.fullnode = settings?.fullnode;
     this.faucet = settings?.faucet;
     this.indexer = settings?.indexer;

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -1,8 +1,6 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Network } from "./apiEndpoints";
-
 /**
  * Type of API endpoint for request routing
  */
@@ -11,8 +9,6 @@ export enum AptosApiType {
   INDEXER,
   FAUCET,
 }
-
-export const DEFAULT_NETWORK = Network.DEVNET;
 
 /**
  * The default max gas amount when none is given.


### PR DESCRIPTION
### Description
For some reason, TSC does not like this Network.DEVNET constant, even though the message specifically says, enum literals are okay.

This allows `tsc -b` to work properly on its own, and I've tested with the examples and other locations.

This has no actual behavior change (probably should be released with a patch version).  The DEFAULT_NETWORK constant is probably not very useful, given that most users would change it to the network they expect.

I discovered this trying to build a CLI with a prebuilt example, but tsc -b would always fail with:
```
node_modules/.pnpm/@aptos-labs+ts-sdk@1.8.0/node_modules/@aptos-labs/ts-sdk/dist/esm/utils/const.d.mts:9:33 - error TS2304: Cannot find name 'Network'.

9 declare const DEFAULT_NETWORK = Network.DEVNET;
                                  ~~~~~~~

node_modules/.pnpm/@aptos-labs+ts-sdk@1.8.0/node_modules/@aptos-labs/ts-sdk/dist/esm/utils/const.d.mts:9:33 - error TS1254: A 'const' initializer in an ambient context must be a string or numeric literal or literal enum reference.

9 declare const DEFAULT_NETWORK = Network.DEVNET;

```

### Test Plan
I tested this locally against the examples folder and ran `tsc -b`.
