### PR TITLE
Use indexer API via API Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Use indexer API via API Gateway
 
 # 1.10.0 (2024-03-11)
 

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -159,7 +159,7 @@ export class General {
   /**
    * A generic function for retrieving data from Aptos Indexer.
    * For more detailed queries specification see
-   * {@link https://cloud.hasura.io/public/graphiql?endpoint=https://indexer.mainnet.aptoslabs.com/v1/graphql}
+   * {@link https://cloud.hasura.io/public/graphiql?endpoint=https://api.mainnet.aptoslabs.com/v1/graphql}
    *
    * @param args.query.query A GraphQL query
    * @param args.query.variables The variables for the query

--- a/src/types/codegen.yaml
+++ b/src/types/codegen.yaml
@@ -1,6 +1,6 @@
 overwrite: true
 documents: src/internal/queries/**/*.graphql
-schema: https://indexer.mainnet.aptoslabs.com/v1/graphql
+schema: https://api.mainnet.aptoslabs.com/v1/graphql
 generates:
   src/types/generated/types.ts:
     plugins:

--- a/src/utils/apiEndpoints.ts
+++ b/src/utils/apiEndpoints.ts
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 export const NetworkToIndexerAPI: Record<string, string> = {
-  mainnet: "https://indexer.mainnet.aptoslabs.com/v1/graphql",
-  testnet: "https://indexer-testnet.staging.gcp.aptosdev.com/v1/graphql",
-  devnet: "https://indexer-devnet.staging.gcp.aptosdev.com/v1/graphql",
+  mainnet: "https://api.mainnet.aptoslabs.com/v1/graphql",
+  testnet: "https://api.testnet.aptoslabs.com/v1/graphql",
+  devnet: "https://api.devnet.aptoslabs.com/v1/graphql",
   randomnet: "https://indexer-randomnet.hasura.app/v1/graphql",
   local: "http://127.0.0.1:8090/v1/graphql",
 };

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -50,7 +50,7 @@ export const RAW_TRANSACTION_WITH_DATA_SALT = "APTOS::RawTransactionWithData";
  * The list of supported Processor types for our indexer api.
  *
  * These can be found from the processor_status table in the indexer database.
- * {@link https://cloud.hasura.io/public/graphiql?endpoint=https://indexer.mainnet.aptoslabs.com/v1/graphql}
+ * {@link https://cloud.hasura.io/public/graphiql?endpoint=https://api.mainnet.aptoslabs.com/v1/graphql}
  */
 export enum ProcessorType {
   ACCOUNT_TRANSACTION_PROCESSOR = "account_transactions_processor",


### PR DESCRIPTION
### Description
This is part of the migration to API Gateway. More context here: https://www.notion.so/aptoslabs/Migration-1-Legacy-URL-to-API-Gateway-migration-b007742490684b9bab3debd674504a94.

I found the initial files to change like this:
```
rg -l 'aptoslabs.com'
```

### Test Plan
CI for now.