### PR TITLE
Remove decimals field from CurrentTokenOwnershipFields fragement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- [`Fix`] Remove decimals field from `CurrentTokenOwnershipFields` gql fragement
+
 # 1.9.0 (2024-02-27)
 
 - Add `getCollectionByCollectionId` API

--- a/src/internal/queries/currentTokenOwnershipFieldsFragment.graphql
+++ b/src/internal/queries/currentTokenOwnershipFieldsFragment.graphql
@@ -25,7 +25,6 @@ fragment CurrentTokenOwnershipFields on current_token_ownerships_v2 {
     token_properties
     token_standard
     token_uri
-    decimals
     current_collection {
       collection_id
       collection_name


### PR DESCRIPTION
### Description
Was added as part of https://github.com/aptos-labs/aptos-ts-sdk/pull/291/files#diff-229f58a820e940aade5b67f09fa23edbb936998678b506411112c2b6add2fefe and broke some queries
https://aptos-org.slack.com/archives/C05NLAKJM9U/p1709164127936519

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->