### PR TITLE
Deprecate IIFE build support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- [`Deprecate`] IIFE build support
+
 # 1.9.1 (2024-02-28)
 
 - [`Fix`] Remove decimals field from `CurrentTokenOwnershipFields` gql fragement

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Install with your favorite package manager such as npm, yarn, or pnpm:
 pnpm install @aptos-labs/ts-sdk
 ```
 
-##### For use in a browser
+##### For use in a browser (<= 1.9.1 version only)
 
 You can add the SDK to your web application using a script tag:
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -28,16 +28,6 @@ const DEFAULT_CONFIG: Options = {
   },
 };
 
-// Browser config, uses iife
-const IIFE_CONFIG: MandatoryOptions = {
-  ...DEFAULT_CONFIG,
-  format: "iife",
-  globalName: "aptosSDK",
-  outDir: "dist/browser",
-  platform: "browser",
-  splitting: false,
-};
-
 // Common.js config
 const COMMON_CONFIG: MandatoryOptions = {
   ...DEFAULT_CONFIG,
@@ -55,4 +45,4 @@ const ESM_CONFIG: MandatoryOptions = {
   platform: "node",
 };
 
-export default defineConfig([IIFE_CONFIG, COMMON_CONFIG, ESM_CONFIG]);
+export default defineConfig([COMMON_CONFIG, ESM_CONFIG]);


### PR DESCRIPTION
### Description
Following discussions, we decided to remove IIFE build support
1. It increases the overall package size in more than 2MB
2. Creates issues when integrating packages without IIFE support
3. If we do want to support those packages we need to inject polyfills which highly increased maintenance work and package size
4. We dont feel there is a valid reason for devs to use IIFE format these days

https://aptos-org.slack.com/archives/C03N83P7QUC/p1709228938688099

https://aptos-org.slack.com/archives/C066E8D05P0/p1709162304228609


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->