### PR TITLE
Run check-version CI only on PRs with `main` as the branch target

### DIFF
--- a/.github/actions/run-check-version/action.yaml
+++ b/.github/actions/run-check-version/action.yaml
@@ -1,6 +1,6 @@
-name: "Lint SDK Code"
+name: "Check SDK versions match"
 description: |
-  Run eslint on the codebase to ensure consistency
+  Run check-version to ensure versions match when the target branch is main
 
 runs:
   using: composite
@@ -14,6 +14,6 @@ runs:
       with:
         version: 8.9.0
 
-    # Run eslint
-    - run: pnpm install --frozen-lockfile && pnpm lint
+    # Run version check
+    - run: pnpm check-version
       shell: bash

--- a/.github/workflows/run-check-version.yaml
+++ b/.github/workflows/run-check-version.yaml
@@ -1,0 +1,20 @@
+env:
+  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+
+name: "Check SDK versions match"
+on:
+  pull_request:
+    branches: [main]
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+  push:
+    branches:
+      - main
+
+jobs:
+  run-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ env.GIT_SHA }}
+      - uses: ./.github/actions/run-check-version


### PR DESCRIPTION
### Description
Used it on this PR https://github.com/aptos-labs/aptos-ts-sdk/pull/318/commits/ab6357729db287e22b6634428229d143788cf8c8

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->