### PR TITLE
Filter `getCurrentDigitalAssetOwnership` where amount > 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - [`Deprecate`] IIFE build support
 - Use node API via API Gateway
+- [`Fix`] Filter `getCurrentDigitalAssetOwnership` where amount > 0
 
 # 1.9.1 (2024-02-28)
 

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -114,6 +114,7 @@ export async function getCurrentDigitalAssetOwnership(args: {
 
   const whereCondition: CurrentTokenOwnershipsV2BoolExp = {
     token_data_id: { _eq: AccountAddress.from(digitalAssetAddress).toStringLong() },
+    amount: { _gt: 0 },
   };
 
   const graphqlQuery = {


### PR DESCRIPTION
### Description
Filter `amount > 0` when fetching current digital asset ownership since Indexer marks token `amount` as `0` if it’s been transferred out or burnt.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->