### PR TITLE
[types] Ensure string is checked before other types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- [`Fix`] Ensure that hex input strings are loaded as strings in Javascript
+
 # 1.10.0 (2024-03-11)
 
 - [`Deprecate`] IIFE build support

--- a/examples/javascript/simple_transfer.js
+++ b/examples/javascript/simple_transfer.js
@@ -56,7 +56,7 @@ const example = async () => {
   console.log("\n=== Funding accounts ===\n");
 
   const aliceFundTxn = await sdk.fundAccount({
-    accountAddress: alice.accountAddress,
+    accountAddress: alice.accountAddress.toString(),
     amount: ALICE_INITIAL_BALANCE,
   });
   console.log("Alice's fund transaction: ", aliceFundTxn);

--- a/src/core/accountAddress.ts
+++ b/src/core/accountAddress.ts
@@ -342,13 +342,13 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    * @param input
    */
   static from(input: AccountAddressInput): AccountAddress {
+    if (typeof input === "string") {
+      return AccountAddress.fromString(input);
+    }
     if (input instanceof AccountAddress) {
       return input;
     }
-    if (input instanceof Uint8Array) {
-      return new AccountAddress(input);
-    }
-    return AccountAddress.fromString(input);
+    return new AccountAddress(input);
   }
 
   /**
@@ -358,13 +358,13 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    * @param input
    */
   static fromStrict(input: AccountAddressInput): AccountAddress {
-    if (input instanceof AccountAddress) {
-      return input;
+    if (typeof input === "string") {
+      return AccountAddress.fromStringStrict(input);
     }
     if (input instanceof Uint8Array) {
       return new AccountAddress(input);
     }
-    return AccountAddress.fromStringStrict(input);
+    return input;
   }
 
   // ===

--- a/src/core/hex.ts
+++ b/src/core/hex.ts
@@ -131,8 +131,11 @@ export class Hex {
    * @returns Hex
    */
   static fromHexInput(hexInput: HexInput): Hex {
-    if (hexInput instanceof Uint8Array) return new Hex(hexInput);
-    return Hex.fromString(hexInput);
+    // Note we have to be more defensive here, since Javascript doesn't have the concept of types
+    if (typeof hexInput === "string") {
+      return Hex.fromString(hexInput);
+    }
+    return new Hex(hexInput);
   }
 
   // ===


### PR DESCRIPTION
### Description
In Javascript, the types are erased, so inputs may not have the types associated.  However, string can still be checked, so all inputs should first be checked for if it's a string, then fall back on other options.

This was often manifesting as:
```
"TypeError: Cannot read properties of undefined (reading 'startsWith')",
    "    at n.fromString (file:///var/task/node_modules/@aptos-labs/ts-sdk/dist/esm/chunk-BZMO6Q6L.mjs:1:422)",
    "    at n.fromHexInput (file:///var/task/node_modules/@aptos-labs/ts-sdk/dist/esm/chunk-BZMO6Q6L.mjs:1:879)",
    "    at new r (file:///var/task/node_modules/@aptos-labs/ts-sdk/dist/esm/chunk-NUBFOYQZ.mjs:1:1038)",
    "    at Runtime.handler (file:///var/task/index.mjs:42:57)",
    "    at Runtime.handleOnceNonStreaming (file:///var/runtime/index.mjs:1173:29)"
```

### Test Plan
Tested by replacing one of the AccountAddress shortcuts with a toString()

### Related Links
<!-- Please link to any relevant issues or pull requests! -->