### PR TITLE
Increase digital asset e2e test suite timeout

### DIFF
--- a/tests/e2e/api/digitalAsset.test.ts
+++ b/tests/e2e/api/digitalAsset.test.ts
@@ -57,6 +57,8 @@ async function setupToken(): Promise<string> {
   )[0].current_token_data?.token_data_id!;
 }
 
+jest.setTimeout(20000);
+
 describe("DigitalAsset", () => {
   let tokenAddress: string;
 


### PR DESCRIPTION
### Description
When testing locally with a release mode local testnet these tests would sometimes time out. The job of these tests is not to catch regressions in timing or anything, it is to test correctness. Let's give them more time.

### Test Plan
CI

### Related Links
N/A