### PR TITLE
Updates queries for ANS to ignore expired names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Add function to create token object address locally
 - Add signers to entry function ABI for future signature count checking
 - [`Breaking`] Add type-safe view functions with ABI support
+- [`Fix`] ANS `getName` and `getDomainSubdomains` now appropriately ignores invalid and expired names
 
 # 1.10.0 (2024-03-11)
 

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -340,6 +340,7 @@ export async function getName(args: {
   const where: CurrentAptosNamesBoolExp = {
     domain: { _eq: domainName },
     subdomain: { _eq: subdomainName },
+    is_active: { _eq: true },
   };
 
   const data = await queryIndexer<GetNamesQuery>({
@@ -487,6 +488,7 @@ export async function getDomainSubdomains(
           ...(args.options?.where ?? {}),
           domain: { _eq: domain },
           subdomain: { _neq: "" },
+          is_active: { _eq: true },
         },
       },
     },


### PR DESCRIPTION
### Description
**Update:**
This will be a two step refactor. This PR just fixes the imidiate issues. A future PR will address the points listed bellow. 

**Original context**
This PR addresses ANS queries that return values for expired or inactive names when they should not. 

Questions to answer: 
- The following functions directly hit the `router` and not the indexer. As a result, they will return values even if the name is expired. Do we want to shift these to using the indexer and return `null` for expired names? 
  - `getOwnerAddress` 
  - `getExpiration` 
  - `getTargetAddress`
  - `getPrimaryName` (Need to investigate this one.)
- The following APIs use the indexer and ensure that expiration date is valid, should be fine, but good to double check.
  - `getAccountNames`
  - `getAccountDomains`
  - `getAccountSubdomains`
  - `getDomainSubdomains`


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->