### PR TITLE
Fix confusing errors in custom clients

### DIFF
--- a/examples/typescript/custom_client.ts
+++ b/examples/typescript/custom_client.ts
@@ -32,7 +32,12 @@ export async function fetchCustomClient<Req, Res>(requestOptions: ClientRequest<
     method,
   };
 
-  const response = await fetch(`${url}?${params}`, request);
+  let path = url;
+  if (params) {
+    path = `${url}?${params}`;
+  }
+
+  const response = await fetch(path, request);
   const data = await response.json();
   return {
     status: response.status,
@@ -60,7 +65,12 @@ export async function superagentCustomClient<Req, Res>(
     method,
   };
 
-  const response = await superagent.get(`${url}?${params}`, request);
+  let path = url;
+  if (params) {
+    path = `${url}?${params}`;
+  }
+
+  const response = await superagent.get(path, request);
   return {
     status: response.status,
     statusText: response.statusText,
@@ -92,6 +102,9 @@ const example = async () => {
 
     const chainInfo = await aptos.getLedgerInfo();
     console.log(`${JSON.stringify(chainInfo)}`);
+
+    const latestVersion = await aptos.getIndexerLastSuccessVersion();
+    console.log(`Latest indexer version: ${latestVersion}`);
   }
 
   // Call the inner functions

--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -95,31 +95,4 @@ export class AptosConfig {
         throw Error(`apiType ${apiType} is not supported`);
     }
   }
-
-  /**
-   * Checks if the URL is a known indexer endpoint
-   *
-   * @internal
-   * */
-  isIndexerRequest(url: string): boolean {
-    return NetworkToIndexerAPI[this.network] === url;
-  }
-
-  /**
-   * Checks if the URL is a known fullnode endpoint
-   *
-   * @internal
-   * */
-  isFullnodeRequest(url: string): boolean {
-    return NetworkToNodeAPI[this.network] === url;
-  }
-
-  /**
-   * Checks if the URL is a known faucet endpoint
-   *
-   * @internal
-   * */
-  isFaucetRequest(url: string): boolean {
-    return NetworkToFaucetAPI[this.network] === url;
-  }
 }

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -4,7 +4,8 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { AptosApiError, AptosResponse } from "./types";
 import { VERSION } from "../version";
-import { AptosRequest, MimeType, ClientRequest, ClientResponse, Client, AnyNumber } from "../types";
+import { AnyNumber, AptosRequest, Client, ClientRequest, ClientResponse, MimeType } from "../types";
+import { AptosApiType } from "../utils";
 
 /**
  * Meaningful errors map
@@ -63,6 +64,7 @@ export async function request<Req, Res>(options: ClientRequest<Req>, client: Cli
 export async function aptosRequest<Req extends {}, Res extends {}>(
   options: AptosRequest,
   aptosConfig: AptosConfig,
+  apiType: AptosApiType,
 ): Promise<AptosResponse<Req, Res>> {
   const { url, path } = options;
   const fullUrl = path ? `${url}/${path}` : url;
@@ -85,7 +87,7 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
 
   // to support both fullnode and indexer responses,
   // check if it is an indexer query, and adjust response.data
-  if (aptosConfig.isIndexerRequest(url)) {
+  if (apiType === AptosApiType.INDEXER) {
     const indexerResponse = result.data as any;
     // Handle Indexer general errors
     if (indexerResponse.errors) {
@@ -115,11 +117,7 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
     errorMessage = `Unhandled Error ${result.status} : ${result.statusText}`;
   }
 
-  // Since we already checked if it is an Indexer request, here we can be sure
-  // it either Fullnode or Faucet request
-  throw new AptosApiError(
-    options,
-    result,
-    `${aptosConfig.isFullnodeRequest(url) ? "Fullnode" : "Faucet"} error: ${errorMessage}`,
-  );
+  // We have to explicitly check for all request types, because if the error is a non-indexer error, but
+  // comes from an indexer request (e.g. 404), we'll need to mention it appropriately
+  throw new AptosApiError(options, result, `${apiType} error: ${errorMessage}`);
 }

--- a/src/client/get.ts
+++ b/src/client/get.ts
@@ -68,6 +68,7 @@ export async function get<Req extends {}, Res extends {}>(
       },
     },
     aptosConfig,
+    options.type,
   );
 }
 

--- a/src/client/post.ts
+++ b/src/client/post.ts
@@ -73,6 +73,7 @@ export async function post<Req extends {}, Res extends {}>(
       overrides,
     },
     aptosConfig,
+    options.type,
   );
 }
 

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -5,9 +5,9 @@
  * Type of API endpoint for request routing
  */
 export enum AptosApiType {
-  FULLNODE,
-  INDEXER,
-  FAUCET,
+  FULLNODE = "Fullnode",
+  INDEXER = "Indexer",
+  FAUCET = "Faucet",
 }
 
 /**

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -1,15 +1,16 @@
 import {
-  aptosRequest,
-  AptosApiError,
-  AptosConfig,
-  Network,
-  NetworkToNodeAPI,
-  Aptos,
   Account,
-  U64,
-  GraphqlQuery,
-  NetworkToIndexerAPI,
+  Aptos,
+  AptosApiError,
+  AptosApiType,
+  AptosConfig,
+  aptosRequest,
   generateSignedTransaction,
+  GraphqlQuery,
+  Network,
+  NetworkToIndexerAPI,
+  NetworkToNodeAPI,
+  U64,
 } from "../../../src";
 import { VERSION } from "../../../src/version";
 import { longTestTimeout } from "../../unit/helper";
@@ -50,6 +51,7 @@ describe("aptos request", () => {
               overrides: { HEADERS: { my: "header" } },
             },
             config,
+            AptosApiType.FULLNODE,
           );
           expect(response.config.headers).toHaveProperty("x-aptos-client", `aptos-typescript-sdk/${VERSION}`);
           expect(response.config.headers).toHaveProperty("my", "header");
@@ -77,6 +79,7 @@ describe("aptos request", () => {
               originMethod: "test when token is set",
             },
             config,
+            AptosApiType.FULLNODE,
           );
           expect(response.config.headers).toHaveProperty("authorization", "Bearer my-api-key");
         } catch (error: any) {
@@ -102,6 +105,7 @@ describe("aptos request", () => {
                 originMethod: "test fullnode 200 status",
               },
               config,
+              AptosApiType.FULLNODE,
             );
             expect(response).toHaveProperty("data", {
               sequence_number: "0",
@@ -129,6 +133,7 @@ describe("aptos request", () => {
                 originMethod: "test 400 status",
               },
               config,
+              AptosApiType.FULLNODE,
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);
@@ -164,6 +169,7 @@ describe("aptos request", () => {
                 originMethod: "test 404 status",
               },
               config,
+              AptosApiType.FULLNODE,
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);
@@ -205,6 +211,7 @@ describe("aptos request", () => {
                 contentType: "application/x.aptos.signed_transaction+bcs",
               },
               config,
+              AptosApiType.FULLNODE,
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);
@@ -252,6 +259,7 @@ describe("aptos request", () => {
                 originMethod: "test indexer 200 status",
               },
               config,
+              AptosApiType.INDEXER,
             );
             expect(response).toHaveProperty("data", {
               ledger_infos: [
@@ -288,6 +296,7 @@ describe("aptos request", () => {
                 originMethod: "test indexer 400 status",
               },
               config,
+              AptosApiType.INDEXER,
             );
           } catch (error: any) {
             expect(error).toBeInstanceOf(AptosApiError);


### PR DESCRIPTION
### Description
If your custom client is setup improperly, it'll throw "faucet error" on indexer errors.  This cleans it up, and fixes the examples to work properly with indexer.

### Test Plan
Tested with the indexer query locally, it failed previously.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->