### PR TITLE
Introduce Serializable transaction modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - [`Breaking`] Change `getOwnerAddress` and `getTargetAddress` return type to `AccountAddress`
 - Add `message` input type verification on `sign` and `verifySignature` functions and convert it into a correct type if needed
 - [`Breaking`] Change `fromString` to `fromHexString` on `Hex` class
+- Introduce Serializable `SimpleTransaction` and `MultiAgentTransaction` modules
+- [`Breaking] Change any generate transaction function to return `SimpleTransaction` or `MultiAgentTransaction` instance
 
 # 1.11.0 (2024-03-26)
 

--- a/examples/typescript-esm/multisig_v2.ts
+++ b/examples/typescript-esm/multisig_v2.ts
@@ -30,6 +30,7 @@ import {
   MultiSig,
   AccountAddress,
   InputViewFunctionData,
+  SimpleTransaction,
 } from "@aptos-labs/ts-sdk";
 
 // Default to devnet, but allow for overriding
@@ -168,10 +169,12 @@ const executeMultiSigTransferTransaction = async () => {
     payload: transactionPayload,
   });
 
-  const owner2Authenticator = aptos.transaction.sign({ signer: owner2, transaction: { rawTransaction } });
+  const transaction = new SimpleTransaction(rawTransaction);
+
+  const owner2Authenticator = aptos.transaction.sign({ signer: owner2, transaction });
   const transferTransactionReponse = await aptos.transaction.submit.simple({
     senderAuthenticator: owner2Authenticator,
-    transaction: { rawTransaction },
+    transaction,
   });
   await aptos.waitForTransaction({ transactionHash: transferTransactionReponse.hash });
 };
@@ -225,13 +228,15 @@ const executeMultiSigTransferTransactionWithPayloadHash = async () => {
     payload: transactionPayload,
   });
 
+  const transaction = new SimpleTransaction(createTransactionWithHashRawTransaction);
+
   const owner2Authenticator2 = aptos.transaction.sign({
     signer: owner2,
-    transaction: { rawTransaction: createTransactionWithHashRawTransaction },
+    transaction,
   });
   const multisigTxExecution2Reponse = await aptos.transaction.submit.simple({
     senderAuthenticator: owner2Authenticator2,
-    transaction: { rawTransaction: createTransactionWithHashRawTransaction },
+    transaction,
   });
   await aptos.waitForTransaction({ transactionHash: multisigTxExecution2Reponse.hash });
 };
@@ -280,13 +285,15 @@ const executeAddingAnOwnerToMultiSigAccountTransaction = async () => {
     payload: new TransactionPayloadMultiSig(new MultiSig(AccountAddress.fromString(multisigAddress))),
   });
 
+  const transaction = new SimpleTransaction(multisigTxExecution3);
+
   const owner2Authenticator3 = aptos.transaction.sign({
     signer: owner2,
-    transaction: { rawTransaction: multisigTxExecution3 },
+    transaction,
   });
   const multisigTxExecution3Reponse = await aptos.transaction.submit.simple({
     senderAuthenticator: owner2Authenticator3,
-    transaction: { rawTransaction: multisigTxExecution3 },
+    transaction,
   });
   await aptos.waitForTransaction({ transactionHash: multisigTxExecution3Reponse.hash });
 };
@@ -334,13 +341,16 @@ const executeRemovingAnOwnerToMultiSigAccount = async () => {
     sender: owner2.accountAddress,
     payload: new TransactionPayloadMultiSig(new MultiSig(AccountAddress.fromString(multisigAddress))),
   });
+
+  const transaction = new SimpleTransaction(multisigTxExecution4);
+
   const owner2Authenticator4 = aptos.transaction.sign({
     signer: owner2,
-    transaction: { rawTransaction: multisigTxExecution4 },
+    transaction,
   });
   const multisigTxExecution4Reponse = await aptos.transaction.submit.simple({
     senderAuthenticator: owner2Authenticator4,
-    transaction: { rawTransaction: multisigTxExecution4 },
+    transaction,
   });
   await aptos.waitForTransaction({ transactionHash: multisigTxExecution4Reponse.hash });
 };
@@ -389,13 +399,15 @@ const executeChangeSignatureThresholdTransaction = async () => {
     payload: new TransactionPayloadMultiSig(new MultiSig(AccountAddress.fromString(multisigAddress))),
   });
 
+  const transaction = new SimpleTransaction(multisigTxExecution5);
+
   const owner2Authenticator5 = aptos.transaction.sign({
     signer: owner2,
-    transaction: { rawTransaction: multisigTxExecution5 },
+    transaction,
   });
   const multisigTxExecution5Reponse = await aptos.transaction.submit.simple({
     senderAuthenticator: owner2Authenticator5,
-    transaction: { rawTransaction: multisigTxExecution5 },
+    transaction,
   });
   await aptos.waitForTransaction({ transactionHash: multisigTxExecution5Reponse.hash });
 };

--- a/examples/typescript-esm/sponsored_transactions/server_as_sponsor.ts
+++ b/examples/typescript-esm/sponsored_transactions/server_as_sponsor.ts
@@ -17,7 +17,6 @@ import {
   Deserializer,
   Network,
   NetworkToNetworkName,
-  RawTransaction,
   SimpleTransaction,
 } from "@aptos-labs/ts-sdk";
 
@@ -48,7 +47,7 @@ const sendToTheSponsorServer = async (transactionBytes: Uint8Array) => {
 
   const sponsorAuthBytes = sponsorAuth.bcsToBytes();
 
-  return sponsorAuthBytes;
+  return { sponsorAuthBytes, signedTransaction: transaction };
 };
 
 const example = async () => {
@@ -83,14 +82,14 @@ const example = async () => {
   const senderAuth = aptos.transaction.sign({ signer: alice, transaction });
 
   // Send the serialized transaction to the sponsor server to sign
-  const sponsorAuthBytes = await sendToTheSponsorServer(transaction.bcsToBytes());
+  const { sponsorAuthBytes, signedTransaction } = await sendToTheSponsorServer(transaction.bcsToBytes());
 
   // deserialize fee payer authenticator
-  const deserializer3 = new Deserializer(sponsorAuthBytes);
-  const feePayerAuthenticator = AccountAuthenticator.deserialize(deserializer3);
+  const deserializer = new Deserializer(sponsorAuthBytes);
+  const feePayerAuthenticator = AccountAuthenticator.deserialize(deserializer);
 
   const response = await aptos.transaction.submit.simple({
-    transaction,
+    transaction: signedTransaction,
     senderAuthenticator: senderAuth,
     feePayerAuthenticator,
   });

--- a/examples/typescript/external_signing.ts
+++ b/examples/typescript/external_signing.ts
@@ -16,8 +16,6 @@ import {
   Ed25519Signature,
   Network,
   NetworkToNetworkName,
-  RawTransaction,
-  Serializer,
   Ed25519Account,
   SimpleTransaction,
 } from "@aptos-labs/ts-sdk";

--- a/src/api/ans.ts
+++ b/src/api/ans.ts
@@ -23,8 +23,9 @@ import {
   GetDomainSubdomainsArgs,
 } from "../internal/ans";
 import { GetANSNameResponse } from "../types";
-import { InputGenerateTransactionOptions, SimpleTransaction } from "../transactions/types";
+import { InputGenerateTransactionOptions } from "../transactions/types";
 import { AptosConfig } from "./aptosConfig";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 
 /**
  * A class to handle all `ANS` operations

--- a/src/api/coin.ts
+++ b/src/api/coin.ts
@@ -3,7 +3,8 @@
 
 import { AccountAddressInput } from "../core";
 import { transferCoinTransaction } from "../internal/coin";
-import { SimpleTransaction, InputGenerateTransactionOptions } from "../transactions/types";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
+import { InputGenerateTransactionOptions } from "../transactions/types";
 import { AnyNumber, MoveStructId } from "../types";
 import { AptosConfig } from "./aptosConfig";
 

--- a/src/api/digitalAsset.ts
+++ b/src/api/digitalAsset.ts
@@ -14,7 +14,7 @@ import {
   TokenStandardArg,
 } from "../types";
 import { Account, AccountAddress, AccountAddressInput } from "../core";
-import { InputGenerateTransactionOptions, SimpleTransaction } from "../transactions/types";
+import { InputGenerateTransactionOptions } from "../transactions/types";
 import {
   addDigitalAssetPropertyTransaction,
   addDigitalAssetTypedPropertyTransaction,
@@ -45,6 +45,7 @@ import {
 import { ProcessorType } from "../utils/const";
 import { AptosConfig } from "./aptosConfig";
 import { waitForIndexerOnVersion } from "./utils";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 
 /**
  * A class to query all `DigitalAsset` related queries on Aptos.

--- a/src/api/fungibleAsset.ts
+++ b/src/api/fungibleAsset.ts
@@ -24,7 +24,8 @@ import { ProcessorType } from "../utils/const";
 import { AptosConfig } from "./aptosConfig";
 import { waitForIndexerOnVersion } from "./utils";
 import { Account, AccountAddress } from "../core";
-import { InputGenerateTransactionOptions, SimpleTransaction } from "../transactions";
+import { InputGenerateTransactionOptions } from "../transactions";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 
 /**
  * A class to query all `FungibleAsset` related queries on Aptos.

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -32,13 +32,13 @@ import {
   AnyRawTransaction,
   InputGenerateTransactionOptions,
   InputGenerateTransactionPayloadData,
-  SimpleTransaction,
 } from "../transactions";
 import { AccountAddressInput, Account, PrivateKey } from "../core";
 import { Build } from "./transactionSubmission/build";
 import { Simulate } from "./transactionSubmission/simulate";
 import { Submit } from "./transactionSubmission/submit";
 import { TransactionManagement } from "./transactionSubmission/management";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 
 export class Transaction {
   readonly config: AptosConfig;

--- a/src/api/transactionSubmission/build.ts
+++ b/src/api/transactionSubmission/build.ts
@@ -3,12 +3,9 @@
 
 import { AccountAddressInput } from "../../core";
 import { generateTransaction } from "../../internal/transactionSubmission";
-import {
-  InputGenerateTransactionPayloadData,
-  InputGenerateTransactionOptions,
-  SimpleTransaction,
-  MultiAgentTransaction,
-} from "../../transactions";
+import { InputGenerateTransactionPayloadData, InputGenerateTransactionOptions } from "../../transactions";
+import { MultiAgentTransaction } from "../../transactions/instances/multiAgentTransaction";
+import { SimpleTransaction } from "../../transactions/instances/simpleTransaction";
 import { AptosConfig } from "../aptosConfig";
 
 /**

--- a/src/internal/ans.ts
+++ b/src/internal/ans.ts
@@ -10,7 +10,7 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import { Account, AccountAddress, AccountAddressInput } from "../core";
-import { InputGenerateTransactionOptions, SimpleTransaction } from "../transactions/types";
+import { InputGenerateTransactionOptions } from "../transactions/types";
 import { GetANSNameResponse, MoveAddressType, OrderByArg, PaginationArgs, WhereArg } from "../types";
 import { GetNamesQuery } from "../types/generated/operations";
 import { GetNames } from "../types/generated/queries";
@@ -19,6 +19,7 @@ import { Network } from "../utils/apiEndpoints";
 import { queryIndexer } from "./general";
 import { view } from "./view";
 import { generateTransaction } from "./transactionSubmission";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 
 export const VALIDATION_RULES_DESCRIPTION = [
   "A name must be between 3 and 63 characters long,",

--- a/src/internal/coin.ts
+++ b/src/internal/coin.ts
@@ -1,10 +1,11 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { AccountAddressInput } from "../core";
-import { EntryFunctionABI, InputGenerateTransactionOptions, SimpleTransaction } from "../transactions/types";
+import { EntryFunctionABI, InputGenerateTransactionOptions } from "../transactions/types";
 import { AnyNumber, MoveStructId } from "../types";
 import { APTOS_COIN } from "../utils/const";
 import { generateTransaction } from "./transactionSubmission";
 import { TypeTagAddress, TypeTagU64 } from "../transactions";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 
 const coinTransferAbi: EntryFunctionABI = {
   typeParameters: [{ constraints: [] }],

--- a/src/internal/digitalAsset.ts
+++ b/src/internal/digitalAsset.ts
@@ -11,7 +11,7 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { Bool, MoveString, MoveVector, U64 } from "../bcs";
 import { Account, AccountAddress, AccountAddressInput } from "../core";
-import { EntryFunctionABI, InputGenerateTransactionOptions, SimpleTransaction } from "../transactions/types";
+import { EntryFunctionABI, InputGenerateTransactionOptions } from "../transactions/types";
 import {
   AnyNumber,
   GetCollectionDataResponse,
@@ -53,6 +53,7 @@ import {
   TypeTagU64,
   TypeTagVector,
 } from "../transactions";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 
 // A property type map for the user input and what Move expects
 const PropertyTypeMap = {

--- a/src/internal/fungibleAsset.ts
+++ b/src/internal/fungibleAsset.ts
@@ -38,11 +38,11 @@ import {
   EntryFunctionABI,
   InputGenerateTransactionOptions,
   parseTypeTag,
-  SimpleTransaction,
   TypeTagAddress,
   TypeTagU64,
 } from "../transactions";
 import { generateTransaction } from "./transactionSubmission";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 
 export async function getFungibleAssetMetadata(args: {
   aptosConfig: AptosConfig;

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -26,18 +26,18 @@ import {
   AnyRawTransaction,
   InputSimulateTransactionData,
   InputGenerateTransactionOptions,
-  SimpleTransaction,
   InputGenerateTransactionPayloadDataWithRemoteABI,
   InputSubmitTransactionData,
   InputGenerateMultiAgentRawTransactionData,
   InputGenerateSingleSignerRawTransactionData,
-  MultiAgentTransaction,
   AnyTransactionPayloadInstance,
   EntryFunctionABI,
 } from "../transactions/types";
 import { getInfo } from "./account";
 import { UserTransactionResponse, PendingTransactionResponse, MimeType, HexInput, TransactionResponse } from "../types";
 import { TypeTagU8, TypeTagVector } from "../transactions";
+import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
+import { MultiAgentTransaction } from "../transactions/instances/multiAgentTransaction";
 
 /**
  * We are defining function signatures, each with its specific input and output.

--- a/src/transactions/instances/index.ts
+++ b/src/transactions/instances/index.ts
@@ -9,3 +9,4 @@ export * from "./rotationProofChallenge";
 export * from "./signedTransaction";
 export * from "./transactionArgument";
 export * from "./transactionPayload";
+export * from "./simpleTransaction";

--- a/src/transactions/instances/multiAgentTransaction.ts
+++ b/src/transactions/instances/multiAgentTransaction.ts
@@ -1,0 +1,68 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { Deserializer } from "../../bcs/deserializer";
+import { Serializable, Serializer } from "../../bcs/serializer";
+import { AccountAddress } from "../../core";
+import { RawTransaction } from "./rawTransaction";
+
+/**
+ * Representation of a Raw Transaction that can serialized and deserialized
+ */
+export class MultiAgentTransaction extends Serializable {
+  public rawTransaction: RawTransaction;
+
+  public feePayerAddress?: AccountAddress | undefined;
+
+  public secondarySignerAddresses: AccountAddress[];
+
+  /**
+   * SimpleTransaction represents a simple transaction type of a single signer that
+   * can be submitted to Aptos chain for execution.
+   *
+   * SimpleTransaction metadata contains the Raw Transaction and an optional
+   * sponsor Account Address to pay the gas fees.
+   *
+   * @param rawTransaction The Raw Tranasaction
+   * @param feePayerAddress The sponsor Account Address
+   */
+  constructor(
+    rawTransaction: RawTransaction,
+    secondarySignerAddresses: AccountAddress[],
+    feePayerAddress?: AccountAddress,
+  ) {
+    super();
+    this.rawTransaction = rawTransaction;
+    this.feePayerAddress = feePayerAddress;
+    this.secondarySignerAddresses = secondarySignerAddresses;
+  }
+
+  serialize(serializer: Serializer): void {
+    this.rawTransaction.serialize(serializer);
+
+    serializer.serializeVector<AccountAddress>(this.secondarySignerAddresses);
+
+    if (this.feePayerAddress === undefined) {
+      serializer.serializeBool(false);
+    } else {
+      serializer.serializeBool(true);
+      this.feePayerAddress.serialize(serializer);
+    }
+  }
+
+  static deserialize(deserializer: Deserializer): MultiAgentTransaction {
+    const rawTransaction = RawTransaction.deserialize(deserializer);
+
+    const secondarySignerAddresses = deserializer.deserializeVector(AccountAddress);
+
+    const feepayerPresent = deserializer.deserializeBool();
+    let feePayerAddress;
+    if (feepayerPresent) {
+      feePayerAddress = AccountAddress.deserialize(deserializer);
+    }
+
+    return new MultiAgentTransaction(rawTransaction, secondarySignerAddresses, feePayerAddress);
+  }
+}

--- a/src/transactions/instances/simpleTransaction.ts
+++ b/src/transactions/instances/simpleTransaction.ts
@@ -1,0 +1,60 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @typescript-eslint/naming-convention */
+
+import { Deserializer } from "../../bcs/deserializer";
+import { Serializable, Serializer } from "../../bcs/serializer";
+import { AccountAddress } from "../../core";
+import { RawTransaction } from "./rawTransaction";
+
+/**
+ * Representation of a SimpleTransaction that can serialized and deserialized
+ */
+export class SimpleTransaction extends Serializable {
+  public rawTransaction: RawTransaction;
+
+  public feePayerAddress?: AccountAddress | undefined;
+
+  // We dont really need it, we add it for type checkings we do
+  // throughout the SDK
+  public readonly secondarySignerAddresses: undefined;
+
+  /**
+   * SimpleTransaction represents a simple transaction type of a single signer that
+   * can be submitted to Aptos chain for execution.
+   *
+   * SimpleTransaction metadata contains the Raw Transaction and an optional
+   * sponsor Account Address to pay the gas fees.
+   *
+   * @param rawTransaction The Raw Tranasaction
+   * @param feePayerAddress The sponsor Account Address
+   */
+  constructor(rawTransaction: RawTransaction, feePayerAddress?: AccountAddress) {
+    super();
+    this.rawTransaction = rawTransaction;
+    this.feePayerAddress = feePayerAddress;
+  }
+
+  serialize(serializer: Serializer): void {
+    this.rawTransaction.serialize(serializer);
+
+    if (this.feePayerAddress === undefined) {
+      serializer.serializeBool(false);
+    } else {
+      serializer.serializeBool(true);
+      this.feePayerAddress.serialize(serializer);
+    }
+  }
+
+  static deserialize(deserializer: Deserializer): SimpleTransaction {
+    const rawTransaction = RawTransaction.deserialize(deserializer);
+    const feepayerPresent = deserializer.deserializeBool();
+    let feePayerAddress;
+    if (feepayerPresent) {
+      feePayerAddress = AccountAddress.deserialize(deserializer);
+    }
+
+    return new SimpleTransaction(rawTransaction, feePayerAddress);
+  }
+}

--- a/src/transactions/management/transactionWorker.ts
+++ b/src/transactions/management/transactionWorker.ts
@@ -6,9 +6,10 @@ import { Account } from "../../core";
 import { waitForTransaction } from "../../internal/transaction";
 import { generateTransaction, signAndSubmitTransaction } from "../../internal/transactionSubmission";
 import { PendingTransactionResponse, TransactionResponse } from "../../types";
-import { InputGenerateTransactionOptions, InputGenerateTransactionPayloadData, SimpleTransaction } from "../types";
+import { InputGenerateTransactionOptions, InputGenerateTransactionPayloadData } from "../types";
 import { AccountSequenceNumber } from "./accountSequenceNumber";
 import { AsyncQueue, AsyncQueueCancelledError } from "./asyncQueue";
+import { SimpleTransaction } from "../instances/simpleTransaction";
 
 export const promiseFulfilledStatus = "fulfilled";
 

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -57,9 +57,7 @@ import {
   InputGenerateMultiAgentRawTransactionArgs,
   InputGenerateRawTransactionArgs,
   InputGenerateSingleSignerRawTransactionArgs,
-  SimpleTransaction,
   InputGenerateTransactionOptions,
-  MultiAgentTransaction,
   InputScriptData,
   InputSimulateTransactionData,
   InputMultiSigDataWithRemoteABI,
@@ -77,6 +75,8 @@ import { convertArgument, fetchEntryFunctionAbi, fetchViewFunctionAbi, standardi
 import { memoizeAsync } from "../../utils/memoize";
 import { AnyNumber } from "../../types";
 import { getFunctionParts, isScriptDataInput } from "./helpers";
+import { SimpleTransaction } from "../instances/simpleTransaction";
+import { MultiAgentTransaction } from "../instances/multiAgentTransaction";
 
 /**
  * We are defining function signatures, each with its specific input and output.
@@ -347,17 +347,14 @@ export async function buildTransaction(args: InputGenerateRawTransactionArgs): P
     const signers: Array<AccountAddress> =
       args.secondarySignerAddresses?.map((signer) => AccountAddress.from(signer)) ?? [];
 
-    return {
-      rawTransaction: rawTxn,
-      secondarySignerAddresses: signers,
-      feePayerAddress: args.feePayerAddress ? AccountAddress.from(args.feePayerAddress) : undefined,
-    };
+    return new MultiAgentTransaction(
+      rawTxn,
+      signers,
+      args.feePayerAddress ? AccountAddress.from(args.feePayerAddress) : undefined,
+    );
   }
   // return the raw transaction
-  return {
-    rawTransaction: rawTxn,
-    feePayerAddress: args.feePayerAddress ? AccountAddress.from(args.feePayerAddress) : undefined,
-  };
+  return new SimpleTransaction(rawTxn, args.feePayerAddress ? AccountAddress.from(args.feePayerAddress) : undefined);
 }
 
 /**

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -18,6 +18,8 @@ import {
 import { AnyNumber, HexInput, MoveFunctionGenericTypeParam, MoveFunctionId } from "../types";
 import { TypeTag } from "./typeTag";
 import { AccountAuthenticator } from "./authenticator/account";
+import { SimpleTransaction } from "./instances/simpleTransaction";
+import { MultiAgentTransaction } from "./instances/multiAgentTransaction";
 
 /**
  * Entry function arguments to be used when building a raw transaction using remote ABI
@@ -223,29 +225,6 @@ export interface InputGenerateMultiAgentRawTransactionArgs {
 export type InputGenerateRawTransactionArgs =
   | InputGenerateSingleSignerRawTransactionArgs
   | InputGenerateMultiAgentRawTransactionArgs;
-
-/**
- * Interface that holds the return data when generating a single signer transaction
- *
- * @param rawTransaction a bcs serialized raw transaction
- */
-export interface SimpleTransaction {
-  rawTransaction: RawTransaction;
-  feePayerAddress?: AccountAddress;
-  secondarySignerAddresses?: undefined;
-}
-
-/**
- * Interface that holds the return data when generating a multi-agent transaction.
- *
- * @param rawTransaction a bcs serialized raw transaction
- * @param secondarySignerAddresses secondary signer addresses for multi-agent transaction
- */
-export interface MultiAgentTransaction {
-  rawTransaction: RawTransaction;
-  secondarySignerAddresses: AccountAddress[];
-  feePayerAddress?: AccountAddress;
-}
 
 /**
  * Unified type that holds all the return interfaces when generating different transaction types


### PR DESCRIPTION
### Description
solves https://github.com/aptos-labs/aptos-ts-sdk/issues/259 

Following requests to simplify the communication between servers when sending transactions, this PR introduces new modules for generated transactions - `SimpleTransaction` and `MultiAgentTransaction`.
With these changes, a server can easily serialize a transaction and send to another server for easy deserialization.

**Before:**
The generated `transaction` is of a simple type and can't be bcs serialized. Therefore we need to serialize the `rawTransaction` and send it to the server along with other needed transaction details.
```
const rawTransactionBytes = transaction.rawTransaction.bcsToBytes();
const feePayerAddressByes = sponsor.accountAddress.bcsToBytes();
const serializedSenderAuthenticatorBytes = senderAuth.bcsToBytes();
const serializedFeePayerAuthenticatorBytes = sponsorAuth.bcsToBytes();

const serializedData = {
  rawTransactionBytes,
  feePayerAddressByes,
  serializedSenderAuthenticatorBytes,
  serializedFeePayerAuthenticatorBytes,
};

await sendToOtherServer(serializedData);
```

**After:**
The generated transaction is of type Serializable and can be bcs serialized.
```
await sendToOtherServer(transaction.bcsToBytes(), senderAuth.bcsToBytes(), sponsorAuth.bcsToBytes());
```

### Test Plan
- tests are passing
- examples have been updated 

### Related Links
<!-- Please link to any relevant issues or pull requests! -->