### PR TITLE
[transaction] Add ability to get transaction hash

### DIFF
--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -528,6 +528,36 @@ export function generateSignedTransaction(args: InputSubmitTransactionData): Uin
 }
 
 /**
+ * Hashes the set of values with a SHA-3 256 hash
+ * @param input array of UTF-8 strings or Uint8array byte arrays
+ */
+export function hashValues(input: (Uint8Array | string)[]): Uint8Array {
+  const hash = sha3Hash.create();
+  for (const item of input) {
+    hash.update(item);
+  }
+  return hash.digest();
+}
+
+/**
+ * The domain separated prefix for hashing transacitons
+ */
+const TRANSACTION_PREFIX = hashValues(["APTOS::Transaction"]);
+
+/**
+ * Generates a transaction hash for the given transaction payload.  It must already have an authenticator
+ * @param args
+ */
+export function generateTransactionHash(args: InputSubmitTransactionData): string {
+  const signedTransaction = generateSignedTransaction(args);
+
+  // Transaction signature is defined as, the domain separated prefix based on struct (Transaction)
+  // Then followed by the type of the transaction for the enum, UserTransaction is 0
+  // Then followed by BCS encoded bytes of the signed transaction
+  return new Hex(hashValues([TRANSACTION_PREFIX, new Uint8Array([0]), signedTransaction])).toString();
+}
+
+/**
  * Derive the raw transaction type - FeePayerRawTransaction or MultiAgentRawTransaction or RawTransaction
  *
  * @param transaction A aptos transaction type

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -28,6 +28,7 @@ import {
   generateTransactionPayloadWithABI,
   sign,
   SignedTransaction,
+  generateTransactionHash,
 } from "../../../src";
 import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
 import { fundAccounts, multiSignerScriptBytecode, publishTransferPackage } from "./helper";
@@ -552,6 +553,102 @@ describe("transaction builder", () => {
       const deserializer = new Deserializer(bcsTransaction);
       const signedTransaction = SignedTransaction.deserialize(deserializer);
       expect(signedTransaction instanceof SignedTransaction).toBeTruthy();
+    });
+  });
+
+  describe("generateTransactionHash", () => {
+    test("it generates a single signer signed transaction hash", async () => {
+      const alice = Account.generate();
+      await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: FUND_AMOUNT });
+      const transaction = await aptos.coin.transferCoinTransaction({
+        sender: alice.accountAddress,
+        recipient: "0x1",
+        amount: 1,
+      });
+
+      const senderAuthenticator = sign({ signer: alice, transaction });
+
+      // Generate hash
+      const signedTxnInput = {
+        transaction,
+        senderAuthenticator,
+      };
+      const transactionHash = generateTransactionHash(signedTxnInput);
+
+      // Submit transaction
+      const submitted = await aptos.transaction.submit.simple(signedTxnInput);
+
+      expect(submitted.hash).toBe(transactionHash);
+    });
+
+    test("it generates a multi agent signed transaction", async () => {
+      const alice = Account.generate();
+      await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: FUND_AMOUNT });
+      const bob = await Account.generate();
+      await aptos.fundAccount({ accountAddress: bob.accountAddress, amount: 1 });
+      const payload = await generateTransactionPayload({
+        aptosConfig: config,
+        function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+        functionArguments: [1, bob.accountAddress],
+      });
+      const transaction = await buildTransaction({
+        aptosConfig: config,
+        sender: alice.accountAddress,
+        payload,
+        secondarySignerAddresses: [bob.accountAddress],
+      });
+      const senderAuthenticator = sign({ signer: alice, transaction });
+      const secondaryAuthenticator = sign({
+        signer: bob,
+        transaction,
+      });
+      // Generate hash
+      const signedTxnInput = {
+        transaction,
+        senderAuthenticator,
+        additionalSignersAuthenticators: [secondaryAuthenticator],
+      };
+      const transactionHash = generateTransactionHash(signedTxnInput);
+
+      // Submit transaction
+      const submitted = await aptos.transaction.submit.multiAgent(signedTxnInput);
+      expect(submitted.hash).toBe(transactionHash);
+    });
+
+    test("it generates a fee payer signed transaction", async () => {
+      const alice = Account.generate();
+      const bob = Account.generate();
+      await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: FUND_AMOUNT });
+      const transaction = await aptos.transaction.build.simple({
+        sender: bob.accountAddress,
+        data: {
+          function: "0x1::aptos_account::transfer",
+          functionArguments: ["0x1", 1],
+        },
+        withFeePayer: true,
+      });
+
+      // Bob signs without knowing the fee payer
+      const senderAuthenticator = sign({
+        signer: bob,
+        transaction,
+      });
+      // Alice signs after putting themselves in as fee payer
+      transaction.feePayerAddress = alice.accountAddress;
+      const feePayerAuthenticator = sign({ signer: alice, transaction });
+
+      // Generate hash
+      const signedTxnInput = {
+        transaction,
+        senderAuthenticator,
+        feePayerAuthenticator,
+      };
+      const transactionHash = generateTransactionHash(signedTxnInput);
+
+      // Submit transaction
+      const submitted = await aptos.transaction.submit.simple(signedTxnInput);
+
+      expect(submitted.hash).toBe(transactionHash);
     });
   });
   describe("deriveTransactionType", () => {


### PR DESCRIPTION
### Description
This adds the ability to get the transaction hash locally.

How it works is that all Rust structs are signed as follows:
1. SHA3_256 Hash `APTOS::` + `StructName` = `prefix`
2. SHA3_256 Hash the above `prefix` + BCS encoded bytes of the struct

Note that, enums are encoded by a u8, followed by the actual bytes associated.  So, in the case of the transaction hash, it must be a `UserTransaction` = 0 for the enum type before the rest of the bytes.

Resolves https://github.com/aptos-labs/aptos-ts-sdk/issues/321

Note this code, only hashes user transactions

### Test Plan
E2E test ensures it's the same as the API

### Related Links
<!-- Please link to any relevant issues or pull requests! -->