### PR TITLE
Make reference docs very prominent in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 [![NPM Package Downloads][npm-image-downloads]][npm-url]
 
 ### Reference Docs
-[Read the latest reference documentation here.](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-latest)
+ 1. For SDK documentation, check out the [TypeScript SDK documentation](https://aptos.dev/sdks/new-ts-sdk/)
+ 2. For detailed reference documentation you can search, check out the [API reference documentation](https://aptos-labs.github.io/aptos-ts-sdk/) for the associated version.
+ 3. For in-depth examples, check out the [examples](./examples) folder with ready-made `package.json` files to get you going quickly!
 
 ### Latest Version
 
@@ -171,12 +173,6 @@ const transaction = await aptos.transferCoinTransaction({
 
 const pendingTransaction = await aptos.signAndSubmitTransaction({ signer: alice, transaction });
 ```
-
-## Documentation and examples
-
-- For full SDK documentation, check out the [TypeScript SDK documentation](https://aptos.dev/sdks/new-ts-sdk/)
-- For reference documenation, check out the [API reference documentation](https://aptos-labs.github.io/aptos-ts-sdk/) for the associated version.
-- For in-depth examples, check out the [examples](./examples) folder with ready-made `package.json` files to get you going quickly!
 
 ### Testing
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 [![Discord][discord-image]][discord-url]
 [![NPM Package Downloads][npm-image-downloads]][npm-url]
 
+### Reference Docs
+[Read the latest reference documentation here.](https://aptos-labs.github.io/aptos-ts-sdk/@aptos-labs/ts-sdk-latest)
+
 ### Latest Version
 
 [![NPM Package Version][npm-image-version]][npm-url]


### PR DESCRIPTION
### Description
When someone is using the TypeScript SDK, they will need the reference docs. As of now, the only way to find them is to notice the link in the top-right corner in the "About" section, which is quite hard to find. 

The reference docs show everything in the README anyway, so we want users to click that link right away. They'll get all the same information and more.

### Test Plan
Inspection. It looked understandable in preview mode.

### Related Links
N/A