### PR TITLE
Fix shared state problem with post.test.ts, use localnet

### DIFF
--- a/tests/e2e/client/post.test.ts
+++ b/tests/e2e/client/post.test.ts
@@ -12,96 +12,88 @@ import { GetChainTopUserTransactionsQuery } from "../../../src/types/generated/o
 import { GetChainTopUserTransactions } from "../../../src/types/generated/queries";
 import { getAptosClient } from "../helper";
 
-const partialConfig = new AptosConfig({
-  clientConfig: {
-    HEADERS: { clientConfig: "clientConfig-header" },
-    API_KEY: "api-key",
-  },
-  fullnodeConfig: { HEADERS: { fullnodeHeader: "fullnode-header" } },
-  indexerConfig: { HEADERS: { indexerHeader: "indexer-header" } },
-  faucetConfig: { HEADERS: { faucetHeader: "faucet-header" }, AUTH_TOKEN: "auth-token" },
-});
-const { config: aptosConfig } = getAptosClient(partialConfig);
+function getAptosConfig(): AptosConfig {
+  const partialConfig = {
+    clientConfig: {
+      HEADERS: { clientConfig: "clientConfig-header" },
+      API_KEY: "api-key",
+    },
+    fullnodeConfig: { HEADERS: { fullnodeHeader: "fullnode-header" } },
+    indexerConfig: { HEADERS: { indexerHeader: "indexer-header" } },
+    faucetConfig: { HEADERS: { faucetHeader: "faucet-header" }, AUTH_TOKEN: "auth-token" },
+  };
+  const { config } = getAptosClient(partialConfig);
+  return config;
+}
 
-// All tests are expected to catch becuase server call will fail
-// due to a fake API_KEY. But that is ok because we just want
-// to test the config we set
 describe("post request", () => {
   describe("indexer", () => {
     test("it sets correct headers", async () => {
-      try {
-        await postAptosIndexer<GraphqlQuery, GetChainTopUserTransactionsQuery>({
-          aptosConfig,
-          originMethod: "testQueryIndexer",
-          path: "",
-          body: {
-            query: GetChainTopUserTransactions,
-            variables: { limit: 5 },
-          },
-          overrides: { WITH_CREDENTIALS: false },
-        });
-      } catch (e: any) {
-        expect(e.request.overrides.API_KEY).toEqual("api-key");
-        expect(e.request.overrides.HEADERS).toHaveProperty("clientConfig");
-        expect(e.request.overrides.HEADERS.clientConfig).toEqual("clientConfig-header");
-        expect(e.request.overrides.HEADERS).toHaveProperty("indexerHeader");
-        expect(e.request.overrides.HEADERS.indexerHeader).toEqual("indexer-header");
-        // Properties should not be included
-        expect(e.request.overrides.HEADERS).not.toHaveProperty("fullnodeHeader");
-        expect(e.request.overrides.HEADERS).not.toHaveProperty("faucetConfig");
-        expect(e.request.overrides.HEADERS).not.toHaveProperty("AUTH_TOKEN");
-      }
+      const response = await postAptosIndexer<GraphqlQuery, GetChainTopUserTransactionsQuery>({
+        aptosConfig: getAptosConfig(),
+        originMethod: "testQueryIndexer",
+        path: "",
+        body: {
+          query: GetChainTopUserTransactions,
+          variables: { limit: 5 },
+        },
+        overrides: { WITH_CREDENTIALS: false },
+      });
+      expect(response.config.headers).toHaveProperty("clientconfig");
+      expect(response.config.headers.clientconfig).toEqual("clientConfig-header");
+      expect(response.config.headers).toHaveProperty("authorization");
+      expect(response.config.headers.authorization).toEqual("Bearer api-key");
+      expect(response.config.headers).toHaveProperty("indexerheader");
+      expect(response.config.headers.indexerheader).toEqual("indexer-header");
+      // Properties that should not be included
+      expect(response.config.headers).not.toHaveProperty("fullnodeheader");
+      expect(response.config.headers).not.toHaveProperty("faucetheader");
     });
   });
   describe("fullnode", () => {
     test("it sets correct headers on post request", async () => {
-      try {
-        await postAptosFullNode<InputViewFunctionData, U8>({
-          aptosConfig,
-          originMethod: "testPostFullnodeQuery",
-          path: "view",
-          body: {
-            function: "0x1::aptos_chain::get",
-          },
-        });
-      } catch (e: any) {
-        expect(e.request.overrides.API_KEY).toEqual("api-key");
-        expect(e.request.overrides.HEADERS).toHaveProperty("clientConfig");
-        expect(e.request.overrides.HEADERS.clientConfig).toEqual("clientConfig-header");
-        expect(e.request.overrides.HEADERS).toHaveProperty("fullnodeHeader");
-        expect(e.request.overrides.HEADERS.fullnodeHeader).toEqual("fullnode-header");
-        // Properties should not be included
-        expect(e.request.overrides.HEADERS).not.toHaveProperty("faucetConfig");
-        expect(e.request.overrides.HEADERS).not.toHaveProperty("AUTH_TOKEN");
-        expect(e.request.overrides.HEADERS).not.toHaveProperty("indexerHeader");
-      }
+      const response = await postAptosFullNode<InputViewFunctionData, U8>({
+        aptosConfig: getAptosConfig(),
+        originMethod: "testPostFullnodeQuery",
+        path: "view",
+        body: {
+          function: "0x1::chain_status::is_operating",
+          type_arguments: [],
+          arguments: [],
+        },
+      });
+      expect(response.config.headers).toHaveProperty("clientconfig");
+      expect(response.config.headers.clientconfig).toEqual("clientConfig-header");
+      expect(response.config.headers).toHaveProperty("authorization");
+      expect(response.config.headers.authorization).toEqual("Bearer api-key");
+      expect(response.config.headers).toHaveProperty("fullnodeheader");
+      expect(response.config.headers.fullnodeheader).toEqual("fullnode-header");
+      // Properties that should not be included
+      expect(response.config.headers).not.toHaveProperty("indexerheader");
+      expect(response.config.headers).not.toHaveProperty("faucetheader");
     });
   });
   describe("faucet", () => {
     test("it sets correct headers", async () => {
       const account = Account.generate();
-      try {
-        await postAptosFaucet<any, { txn_hashes: Array<string> }>({
-          aptosConfig,
-          path: "fund",
-          body: {
-            address: account.accountAddress.toString(),
-            amount: 1000,
-          },
-          originMethod: "testQueryFaucet",
-        });
-      } catch (e: any) {
-        expect(e.request.overrides).toHaveProperty("AUTH_TOKEN");
-        expect(e.request.overrides.AUTH_TOKEN).toEqual("auth-token");
-        expect(e.request.overrides.HEADERS).toHaveProperty("clientConfig");
-        expect(e.request.overrides.HEADERS.clientConfig).toEqual("clientConfig-header");
-        expect(e.request.overrides.HEADERS).toHaveProperty("faucetHeader");
-        expect(e.request.overrides.HEADERS.fullnodeHeader).toEqual("faucet-header");
-        // Properties should not be included
-        expect(e.request.overrides.HEADERS).not.toHaveProperty("fullnodeConfig");
-        expect(e.request.overrides.HEADERS).not.toHaveProperty("indexerHeader");
-        expect(e.request.overrides.API_KEY).not.toHaveProperty("API_KEY");
-      }
+      const response = await postAptosFaucet<any, { txn_hashes: Array<string> }>({
+        aptosConfig: getAptosConfig(),
+        path: "fund",
+        body: {
+          address: account.accountAddress.toString(),
+          amount: 1000,
+        },
+        originMethod: "testQueryFaucet",
+      });
+      expect(response.config.headers).toHaveProperty("clientconfig");
+      expect(response.config.headers.clientconfig).toEqual("clientConfig-header");
+      expect(response.config.headers).toHaveProperty("authorization");
+      expect(response.config.headers.authorization).toEqual("Bearer auth-token");
+      expect(response.config.headers).toHaveProperty("faucetheader");
+      expect(response.config.headers.faucetheader).toEqual("faucet-header");
+      // Properties that should not be included
+      expect(response.config.headers).not.toHaveProperty("fullnodeheader");
+      expect(response.config.headers).not.toHaveProperty("indexerheader");
     });
   });
 });


### PR DESCRIPTION
### Description
Previously this would pass:
```
npx jest tests/e2e/client/post.test.ts
```

This would not:
```
pnpm run e2e-test -t 'faucet it sets correct headers'
```

This is because the faucet test was relying on changes made by the first two tests.

This PR fixes that by using separate clients for each test and fixing the invalid assertions.

I also make the tests run against localnet so there is no need for this try / catch (which was only there bc of some API key rejection stuff that doesn't happen locally) and update all the assertions accordingly.

### Test Plan
See description.

### Related Links
https://aptos-org.slack.com/archives/C05NLAKJM9U/p1712252143249939