### PR TITLE
Fix flakiness in E2E tests

### DIFF
--- a/src/cli/localNode.ts
+++ b/src/cli/localNode.ts
@@ -3,7 +3,7 @@ import kill from "tree-kill";
 import { sleep } from "../utils/helpers";
 
 export class LocalNode {
-  readonly MAXIMUM_WAIT_TIME_SEC = 30;
+  readonly MAXIMUM_WAIT_TIME_SEC = 75;
 
   readonly READINESS_ENDPOINT = "http://127.0.0.1:8070/";
 

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -174,13 +174,13 @@ describe("general api", () => {
       expect(symbol).toEqual("APT");
 
       const payload2: InputViewFunctionData = {
-        function: "0x1::coin::is_account_registered",
+        function: "0x1::coin::decimals",
         typeArguments: ["0x1::aptos_coin::AptosCoin"],
-        functionArguments: ["0x1"],
+        functionArguments: [],
       };
 
-      const isRegistered = (await aptos.view<[boolean]>({ payload: payload2 }))[0];
-      expect(isRegistered).toEqual(false);
+      const decimals = (await aptos.view<[number]>({ payload: payload2 }))[0];
+      expect(decimals).toEqual(8);
 
       const payload3: InputViewFunctionData = {
         function: "0x1::coin::supply",

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -60,6 +60,8 @@ describe("aptos request", () => {
           expect(response.config.headers).toHaveProperty("content-type", "application/x.aptos.signed_transaction+bcs");
         } catch (error: any) {
           // should not get here
+          // eslint-disable-next-line no-console
+          console.log("Error in 'headers'", error);
           expect(true).toBe(false);
         }
       },
@@ -76,7 +78,7 @@ describe("aptos request", () => {
             {
               url: fullnodeUrl,
               method: "GET",
-              path: "accounts/0x1",
+              path: "",
               overrides: { API_KEY: dummyKey },
               originMethod: "test when token is set",
             },
@@ -86,6 +88,8 @@ describe("aptos request", () => {
           expect(response.config.headers).toHaveProperty("authorization", `Bearer ${dummyKey}`);
         } catch (error: any) {
           // should not get here
+          // eslint-disable-next-line no-console
+          console.log("Error in 'api_token for full node requests'", error);
           expect(true).toBe(false);
         }
       },
@@ -115,6 +119,8 @@ describe("aptos request", () => {
             });
           } catch (error: any) {
             // should not get here
+            // eslint-disable-next-line no-console
+            console.log("Error in 'fullnode server returns 200 status code'", error);
             expect(true).toBe(false);
           }
         },


### PR DESCRIPTION
## Summary
A few changes in one PR. I'll rebase rather than squash:
- **Increase wait time for local testnet startup**
- **Hit / in api_token for full node requests test, log on error**
  - Log to help debug why it failed.
- **Use decimals function rather than is_registered in function generics test**

## Test Plan
See that CI passes, hopefully with fewer retries than normally required.