### PR TITLE
Include `aptos-typescript-sdk-origin-method` header on server request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Include `x-aptos-typescript-sdk-origin-method` header on server request
+
 # 1.12.2 (2024-04-10)
 
 - Revert export `LocalNode` module

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -26,11 +26,12 @@ const errors: Record<number, string> = {
  * returns the response.
  */
 export async function request<Req, Res>(options: ClientRequest<Req>, client: Client): Promise<ClientResponse<Res>> {
-  const { url, method, body, contentType, params, overrides } = options;
+  const { url, method, body, contentType, params, overrides, originMethod } = options;
   const headers: Record<string, string | AnyNumber | boolean | undefined> = {
     ...overrides?.HEADERS,
     "x-aptos-client": `aptos-typescript-sdk/${VERSION}`,
     "content-type": contentType ?? MimeType.JSON,
+    "x-aptos-typescript-sdk-origin-method": originMethod,
   };
 
   if (overrides?.AUTH_TOKEN) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -224,6 +224,7 @@ export type ClientHeadersType = {
 export interface ClientRequest<Req> {
   url: string;
   method: "GET" | "POST";
+  originMethod?: string;
   body?: Req;
   contentType?: string;
   params?: any;

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -58,6 +58,10 @@ describe("aptos request", () => {
           expect(response.config.headers).toHaveProperty("x-aptos-client", `aptos-typescript-sdk/${VERSION}`);
           expect(response.config.headers).toHaveProperty("my", "header");
           expect(response.config.headers).toHaveProperty("content-type", "application/x.aptos.signed_transaction+bcs");
+          expect(response.config.headers).toHaveProperty(
+            "x-aptos-typescript-sdk-origin-method",
+            "test request includes all headers",
+          );
         } catch (error: any) {
           // should not get here
           // eslint-disable-next-line no-console


### PR DESCRIPTION
### Description
Include the method used in the sdk when making a server call in the request header to analyze user usage

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->