### PR TITLE
Change the 'waitForTransaction' SDK API to try long poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - Export `LocalNode` module using the module relative path
 
+- Change the `waitForTransaction` SDK API to try long poll
+
 # 1.12.2 (2024-04-10)
 
 - Revert export `LocalNode` module

--- a/src/internal/transaction.ts
+++ b/src/internal/transaction.ts
@@ -149,14 +149,14 @@ export async function waitForTransaction(args: {
 
   // If the transaction is pending, we do a long wait once to avoid polling
   if (isPending) {
-    const startTime = performance.now();
+    const startTime = Date.now();
     try {
       lastTxn = await longWaitForTransaction({ aptosConfig, transactionHash });
       isPending = lastTxn.type === TransactionResponseType.Pending;
     } catch (e) {
       handleAPIError(e);
     }
-    timeElapsed = (performance.now() - startTime) / 1000;
+    timeElapsed = (Date.now() - startTime) / 1000;
   }
 
   // Now we do polling to see if the transaction is still pending

--- a/src/internal/transaction.ts
+++ b/src/internal/transaction.ts
@@ -141,7 +141,6 @@ export async function waitForTransaction(args: {
 
   // check to see if the txn is already on the blockchain
   try {
-    // eslint-disable-next-line no-await-in-loop
     lastTxn = await getTransactionByHash({ aptosConfig, transactionHash });
     isPending = lastTxn.type === TransactionResponseType.Pending;
   } catch (e) {
@@ -150,14 +149,14 @@ export async function waitForTransaction(args: {
 
   // If the transaction is pending, we do a long wait once to avoid polling
   if (isPending) {
+    const startTime = performance.now();
     try {
-      // eslint-disable-next-line no-await-in-loop
       lastTxn = await longWaitForTransaction({ aptosConfig, transactionHash });
       isPending = lastTxn.type === TransactionResponseType.Pending;
     } catch (e) {
       handleAPIError(e);
     }
-    timeElapsed = 1; // Long wait takes about 1 second
+    timeElapsed = (performance.now() - startTime) / 1000;
   }
 
   // Now we do polling to see if the transaction is still pending

--- a/src/internal/transaction.ts
+++ b/src/internal/transaction.ts
@@ -97,7 +97,7 @@ export async function isTransactionPending(args: {
   }
 }
 
-async function longWaitForTransaction(args: {
+export async function longWaitForTransaction(args: {
   aptosConfig: AptosConfig;
   transactionHash: HexInput;
 }): Promise<TransactionResponse> {
@@ -105,7 +105,7 @@ async function longWaitForTransaction(args: {
   const { data } = await getAptosFullNode<{}, TransactionResponse>({
     aptosConfig,
     path: `transactions/wait_by_hash/${transactionHash}`,
-    originMethod: "waitTransactionByHash",
+    originMethod: "longWaitForTransaction",
   });
   return data;
 }

--- a/tests/e2e/api/transaction.test.ts
+++ b/tests/e2e/api/transaction.test.ts
@@ -4,6 +4,7 @@
 import { Account, TransactionResponse, U64 } from "../../../src";
 import { FUND_AMOUNT } from "../../unit/helper";
 import { getAptosClient } from "../helper";
+import { longWaitForTransaction } from "../../../src/internal/transaction";
 
 // use it here since all tests use the same configuration
 const { aptos } = getAptosClient();
@@ -61,6 +62,54 @@ describe("transaction api", () => {
         senderAuthenticator: authenticator,
       });
       txn = await aptos.waitForTransaction({ transactionHash: response.hash });
+    });
+
+    test("it queries for transactions on the chain", async () => {
+      const transactions = await aptos.getTransactions();
+      expect(transactions.length).toBeGreaterThan(0);
+    });
+
+    test("it queries for transactions by version", async () => {
+      if (!("version" in txn)) {
+        throw new Error("Transaction is still pending!");
+      }
+
+      const transaction = await aptos.getTransactionByVersion({
+        ledgerVersion: Number(txn.version),
+      });
+      expect(transaction).toStrictEqual(txn);
+    });
+
+    test("it queries for transactions by hash", async () => {
+      const transaction = await aptos.getTransactionByHash({
+        transactionHash: txn.hash,
+      });
+      expect(transaction).toStrictEqual(txn);
+    });
+  });
+
+  describe("long poll", () => {
+    let txn: TransactionResponse;
+    beforeAll(async () => {
+      const senderAccount = Account.generate();
+      await aptos.fundAccount({ accountAddress: senderAccount.accountAddress, amount: FUND_AMOUNT });
+      const bob = Account.generate();
+      const rawTxn = await aptos.transaction.build.simple({
+        sender: senderAccount.accountAddress,
+        data: {
+          function: "0x1::aptos_account::transfer",
+          functionArguments: [bob.accountAddress, new U64(10)],
+        },
+      });
+      const authenticator = aptos.transaction.sign({
+        signer: senderAccount,
+        transaction: rawTxn,
+      });
+      const response = await aptos.transaction.submit.simple({
+        transaction: rawTxn,
+        senderAuthenticator: authenticator,
+      });
+      txn = await longWaitForTransaction({ aptosConfig: aptos.config, transactionHash: response.hash });
     });
 
     test("it queries for transactions on the chain", async () => {

--- a/tests/e2e/api/transaction.test.ts
+++ b/tests/e2e/api/transaction.test.ts
@@ -98,7 +98,7 @@ describe("transaction api", () => {
         sender: senderAccount.accountAddress,
         data: {
           function: "0x1::aptos_account::transfer",
-          functionArguments: [bob.accountAddress, new U64(10)],
+          functionArguments: [bob.accountAddress, 10],
         },
       });
       const authenticator = aptos.transaction.sign({
@@ -110,22 +110,6 @@ describe("transaction api", () => {
         senderAuthenticator: authenticator,
       });
       txn = await longWaitForTransaction({ aptosConfig: aptos.config, transactionHash: response.hash });
-    });
-
-    test("it queries for transactions on the chain", async () => {
-      const transactions = await aptos.getTransactions();
-      expect(transactions.length).toBeGreaterThan(0);
-    });
-
-    test("it queries for transactions by version", async () => {
-      if (!("version" in txn)) {
-        throw new Error("Transaction is still pending!");
-      }
-
-      const transaction = await aptos.getTransactionByVersion({
-        ledgerVersion: Number(txn.version),
-      });
-      expect(transaction).toStrictEqual(txn);
     });
 
     test("it queries for transactions by hash", async () => {


### PR DESCRIPTION
In aptos-core we now have exposed the API to do a long poll while waiting for a txn (commit https://github.com/aptos-labs/aptos-core/commit/29a9f0c3f38bb3ddab0517b0fa7aa20804b57f37). This waits for about 1s for the txn to complete.

In this change, the 'waitForTransaction' API in the SDK tries to call the long wait with the goal of exposing the subsecond E2E latencies to the end users. In the long wait is not sufficient then we fall back to polling based wait we already have