### PR TITLE
custom PaginationArgs

### DIFF
--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -39,7 +39,7 @@ export async function getModuleEventsByEventType(args: {
 
   const customOptions = {
     where: whereCondition,
-    pagination: options,
+    limit: options?.limit,
     orderBy: options?.orderBy,
   };
 
@@ -62,7 +62,7 @@ export async function getAccountEventsByCreationNumber(args: {
 
   const customOptions = {
     where: whereCondition,
-    pagination: options,
+    limit: options?.limit,
     orderBy: options?.orderBy,
   };
 
@@ -85,7 +85,7 @@ export async function getAccountEventsByEventType(args: {
 
   const customOptions = {
     where: whereCondition,
-    pagination: options,
+    limit: options?.limit,
     orderBy: options?.orderBy,
   };
 


### PR DESCRIPTION
PaginationArgs have tow params 

orderBy and limit .

we must extract limit field out from options field like orderBy.

### Description

When we getEvents , we need pass PaginationArgs params to get paged data. 
While we need pass limit and orderBy field.

So we must extract limit field from options very like orderBy.

