### PR TITLE
[crypto] Add malleability check on EDD2519 verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 - [`Breaking`] Change ed25519 library to be `@noble/curves/ed25519`
-- Fix ed25519 signatures to ensure for canonical signatures to prevent malleability
+- Fix ed25519 signature verification to ensure for canonical signatures to prevent malleability
 
 # 1.12.2 (2024-04-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 - [`Breaking`] Change ed25519 library to be `@noble/curves/ed25519`
+- Fix ed25519 signatures to ensure for canonical signatures to prevent malleability
 
 # 1.12.2 (2024-04-10)
 

--- a/src/core/crypto/ed25519.ts
+++ b/src/core/crypto/ed25519.ts
@@ -74,7 +74,7 @@ export class Ed25519PublicKey extends AccountPublicKey {
     const signatureBytes = signature.toUint8Array();
     const publicKeyBytes = this.key.toUint8Array();
     // Also verify malleability
-    if (!signature.checkSMalleability()) {
+    if (!signature.isCanonicalSignature()) {
       return false;
     }
 
@@ -327,8 +327,11 @@ export class Ed25519Signature extends Signature {
 
   /**
    * Checks if an ED25519 signature is non-canonical.
+   *
+   * Comes from Aptos Core
+   * https://github.com/aptos-labs/aptos-core/blob/main/crates/aptos-crypto/src/ed25519/ed25519_sigs.rs#L47-L85
    */
-  checkSMalleability(): boolean {
+  isCanonicalSignature(): boolean {
     const s = this.toUint8Array().slice(32);
 
     for (let i = s.length - 1; i >= 0; i -= 1) {

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -41,7 +41,11 @@ export class Secp256k1PublicKey extends PublicKey {
   }
 
   // region PublicKey
-
+  /**
+   * Verifies a Secp256k1 signature against the public key
+   *
+   * Note signatures are validated to be canonical as a malleability check
+   */
   verifySignature(args: VerifySignatureArgs): boolean {
     const { message, signature } = args;
     if (!(signature instanceof Secp256k1Signature)) {
@@ -51,7 +55,7 @@ export class Secp256k1PublicKey extends PublicKey {
     const messageBytes = Hex.fromHexInput(messageToVerify).toUint8Array();
     const messageSha3Bytes = sha3_256(messageBytes);
     const signatureBytes = signature.toUint8Array();
-    return secp256k1.verify(signatureBytes, messageSha3Bytes, this.key.toUint8Array());
+    return secp256k1.verify(signatureBytes, messageSha3Bytes, this.key.toUint8Array(), { lowS: true });
   }
 
   toUint8Array(): Uint8Array {
@@ -166,6 +170,8 @@ export class Secp256k1PrivateKey extends Serializable implements PrivateKey {
   /**
    * Sign the given message with the private key.
    *
+   * Note: signatures are canonical, and non-malleable
+   *
    * @param message a message as a string or Uint8Array
    * @returns Signature
    */
@@ -173,7 +179,7 @@ export class Secp256k1PrivateKey extends Serializable implements PrivateKey {
     const messageToSign = convertSigningMessage(message);
     const messageBytes = Hex.fromHexInput(messageToSign);
     const messageHashBytes = sha3_256(messageBytes.toUint8Array());
-    const signature = secp256k1.sign(messageHashBytes, this.key.toUint8Array());
+    const signature = secp256k1.sign(messageHashBytes, this.key.toUint8Array(), { lowS: true });
     return new Secp256k1Signature(signature.toCompactRawBytes());
   }
 

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -50,13 +50,19 @@ describe("Ed25519PublicKey", () => {
   });
 
   it("should fail malleable signatures", () => {
+    // Here we make a signature exactly with the L
     const signature = new Ed25519Signature(
       // eslint-disable-next-line max-len
-      "ad0828843228048fee9ead35cf0decc8155342e967993851f70bfc0bb9e97719a094c6f956e5cd65872fa769e7dce26f6e637eb4ff70c3f6aafc5f06fbc300ad",
+      "0x0000000000000000000000000000000000000000000000000000000000000000edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
     );
+    expect(signature.isCanonicalSignature()).toBe(false);
 
-    // Verify with malleable message
-    expect(signature.checkSMalleability()).toBe(false);
+    // We now check with L + 1
+    const signature2 = new Ed25519Signature(
+      // eslint-disable-next-line max-len
+      "0x0000000000000000000000000000000000000000000000000000000000000000edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000011",
+    );
+    expect(signature2.isCanonicalSignature()).toBe(false);
   });
 
   it("should serialize correctly", () => {

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -49,6 +49,16 @@ describe("Ed25519PublicKey", () => {
     ).toBe(false);
   });
 
+  it("should fail malleable signatures", () => {
+    const signature = new Ed25519Signature(
+      // eslint-disable-next-line max-len
+      "ad0828843228048fee9ead35cf0decc8155342e967993851f70bfc0bb9e97719a094c6f956e5cd65872fa769e7dce26f6e637eb4ff70c3f6aafc5f06fbc300ad",
+    );
+
+    // Verify with malleable message
+    expect(signature.checkSMalleability()).toBe(false);
+  });
+
   it("should serialize correctly", () => {
     const publicKey = new Ed25519PublicKey(ed25519.publicKey);
     const serializer = new Serializer();


### PR DESCRIPTION
### Description
Adds malleability verification to SDK, copied from Rust code

### Test Plan
See unit tests