### PR TITLE
Export LocalNode module under the module relative path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Export `LocalNode` module using the module relative path
+
 # 1.12.2 (2024-04-10)
 
 - Revert export `LocalNode` module

--- a/examples/typescript/localNode.ts
+++ b/examples/typescript/localNode.ts
@@ -1,0 +1,15 @@
+/* eslint-disable import/no-commonjs */
+/* eslint-disable import/extensions */
+
+/**
+ * Example to show how one can require the LocalNode module and use it
+ * to run an aptos local node
+ */
+
+const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
+
+async function example() {
+  const localNode = new cli.LocalNode();
+  localNode.run();
+}
+example();

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
         "default": "./dist/esm/index.mjs"
       }
     },
+    "./dist/common/cli/index.js": "./dist/common/cli/index.js",
+    "./dist/esm/cli/index.mjs": "./dist/esm/cli/index.mjs",
     "./package.json": "./package.json"
   },
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -4,7 +4,6 @@ import type { Options, Format } from "tsup";
 // Ensure that these option fields are not undefined
 type MandatoryOptions = Options & {
   outDir: string;
-  platform: string;
   format: Format | Format[];
 };
 
@@ -19,6 +18,7 @@ const DEFAULT_CONFIG: Options = {
   sourcemap: true,
   splitting: true,
   target: "es2020",
+  platform: "node",
   env: {
     APTOS_NETWORK: process.env.APTOS_NETWORK ?? "Devnet",
     ANS_TEST_ACCOUNT_PRIVATE_KEY:
@@ -31,9 +31,9 @@ const DEFAULT_CONFIG: Options = {
 // Common.js config
 const COMMON_CONFIG: MandatoryOptions = {
   ...DEFAULT_CONFIG,
+  entry: ["src/index.ts", "src/cli/index.ts"],
   format: "cjs",
   outDir: "dist/common",
-  platform: "node",
 };
 
 // ESM config
@@ -42,7 +42,6 @@ const ESM_CONFIG: MandatoryOptions = {
   entry: ["src/**/*.ts"],
   format: "esm",
   outDir: "dist/esm",
-  platform: "node",
 };
 
 export default defineConfig([COMMON_CONFIG, ESM_CONFIG]);


### PR DESCRIPTION
### Description
`LocalNode` module can only be used in a Node environment and therefore it is not exported by default from the SDK (to not break web environment).

This change exports the CLI folder under the module relative path - that way it is not exported by default and if anyone wants to use it, they can explicitly require it in their node app.

Note: The `LocalNode` requires `tree-kill` package dependency

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->