### PR TITLE
[abi] Fix local ABI to use local version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - [`Fix`] Fixes Local ABI to use it locally rather than make an external network call
+- Peformance improvements to transaction build times
 
 # 1.13.0 (2024-04-19)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- [`Fix`] Fixes Local ABI to use it locally rather than make an external network call
+
 # 1.13.0 (2024-04-19)
 
 - [`Breaking`] Change ed25519 library to be `@noble/curves/ed25519`

--- a/examples/typescript-esm/transaction_with_predefined_abi.ts
+++ b/examples/typescript-esm/transaction_with_predefined_abi.ts
@@ -54,13 +54,13 @@ async function timeSubmission(
   signer: Account,
   buildTxn: () => Promise<SimpleTransaction>,
 ): Promise<void> {
-  const start = Date.now();
+  const start = performance.now();
   const rawTxn = await buildTxn();
-  const buildTime = Date.now();
+  const buildTime = performance.now();
   const submittedTxn = await aptos.signAndSubmitTransaction({ signer, transaction: rawTxn });
-  const submitTime = Date.now();
+  const submitTime = performance.now();
   await aptos.waitForTransaction({ transactionHash: submittedTxn.hash });
-  const endTime = Date.now();
+  const endTime = performance.now();
   const builtLatency = buildTime - start;
   const submitLatency = submitTime - start;
   const e2eLatency = endTime - start;

--- a/examples/typescript-esm/transaction_with_predefined_abi.ts
+++ b/examples/typescript-esm/transaction_with_predefined_abi.ts
@@ -57,15 +57,20 @@ async function timeSubmission(
   const start = performance.now();
   const rawTxn = await buildTxn();
   const buildTime = performance.now();
-  const submittedTxn = await aptos.signAndSubmitTransaction({ signer, transaction: rawTxn });
+  const senderAuthenticator = await aptos.sign({ signer, transaction: rawTxn });
+  const signTime = performance.now();
+  const submittedTxn = await aptos.transaction.submit.simple({ transaction: rawTxn, senderAuthenticator });
   const submitTime = performance.now();
   await aptos.waitForTransaction({ transactionHash: submittedTxn.hash });
   const endTime = performance.now();
   const builtLatency = buildTime - start;
-  const submitLatency = submitTime - start;
+  const signLatency = signTime - buildTime;
+  const submitLatency = submitTime - signTime;
   const e2eLatency = endTime - start;
 
-  console.log(`Time for building: ${builtLatency}ms | submission: ${submitLatency}ms | total E2E: ${e2eLatency}ms`);
+  console.log(
+    `Time for building: ${builtLatency}ms | signing ${signLatency}ms submission: ${submitLatency}ms | total E2E: ${e2eLatency}ms`,
+  );
 }
 
 const example = async () => {

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -102,10 +102,10 @@ export async function buildTransactionPayload(
   args: { aptosConfig: AptosConfig } & InputGenerateTransactionData,
 ): Promise<AnyTransactionPayloadInstance> {
   const { aptosConfig, data } = args;
-
   // Merge in aptosConfig for remote ABI on non-script payloads
   let generateTransactionPayloadData: InputGenerateTransactionPayloadDataWithRemoteABI;
   let payload: AnyTransactionPayloadInstance;
+
   if ("bytecode" in data) {
     // TODO: Add ABI checking later
     payload = await generateTransactionPayload(data);
@@ -116,6 +116,7 @@ export async function buildTransactionPayload(
       function: data.function,
       functionArguments: data.functionArguments,
       typeArguments: data.typeArguments,
+      abi: data.abi,
     };
     payload = await generateTransactionPayload(generateTransactionPayloadData);
   } else {
@@ -124,6 +125,7 @@ export async function buildTransactionPayload(
       function: data.function,
       functionArguments: data.functionArguments,
       typeArguments: data.typeArguments,
+      abi: data.abi,
     };
     payload = await generateTransactionPayload(generateTransactionPayloadData);
   }

--- a/src/utils/apiEndpoints.ts
+++ b/src/utils/apiEndpoints.ts
@@ -38,6 +38,7 @@ export const NetworkToChainId: Record<string, number> = {
   mainnet: 1,
   testnet: 2,
   randomnet: 70,
+  local: 4,
 };
 
 export const NetworkToNetworkName: Record<string, Network> = {


### PR DESCRIPTION
### Description
This provides general performance upgrades to the SDK on submission of transactions.

### Test Plan
Performance before upgrades (caching turned off)
```
=== Remote ABI, normal inputs ===

Time for building: 245.67583300000024ms | signing 3.397457999999915ms submission: 74.88608400000021ms | total E2E: 617.3080000000004ms

=== Remote ABI, BCS inputs ===

Time for building: 252.75995799999964ms | signing 3.7125000000005457ms submission: 76.13624999999956ms | total E2E: 711.8725830000003ms

=== Local ABI, normal inputs ===

Time for building: 281.67945899999995ms | signing 3.238916000000245ms submission: 80.9857920000004ms | total E2E: 738.3943750000008ms

=== Local ABI, BCS inputs ===

Time for building: 233.43504099999973ms | signing 2.6963340000002063ms submission: 71.50787500000024ms | total E2E: 633.0672910000003ms

=== Local ABI, BCS inputs, sequence number already cached ===

Time for building: 299.7606249999999ms | signing 3.8891249999996944ms submission: 72.4272920000003ms | total E2E: 661.8672919999999ms

=== Local ABI, BCS inputs, sequence number and gas already cached ===

Time for building: 136.6538330000003ms | signing 1.1031249999996362ms submission: 75.19066699999985ms | total E2E: 501.5662919999995ms

```


Performance after upgrades (caching turned off)
```
=== Remote ABI, normal inputs ===

Time for building: 177.95516700000007ms | signing 4.468124999999873ms submission: 77.40929200000028ms | total E2E: 586.8097090000001ms

=== Remote ABI, BCS inputs ===

Time for building: 161.694708ms | signing 1.5960829999999078ms submission: 97.5043340000002ms | total E2E: 525.1057910000004ms

=== Local ABI, normal inputs ===

Time for building: 83.030667ms | signing 3.8221669999993537ms submission: 74.75112499999977ms | total E2E: 507.9666669999997ms

=== Local ABI, BCS inputs ===

Time for building: 82.1668750000008ms | signing 3.340665999999146ms submission: 73.23645900000065ms | total E2E: 475.6780830000007ms

=== Local ABI, BCS inputs, sequence number already cached ===

Time for building: 75.06945799999994ms | signing 2.9076670000004015ms submission: 75.67066700000032ms | total E2E: 615.121083ms

=== Local ABI, BCS inputs, sequence number and gas already cached ===

Time for building: 0.38758299999972223ms | signing 3.1974580000005517ms submission: 72.22120899999936ms | total E2E: 340.22000000000025ms

```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->