### PR TITLE
Fix transaction submission from different bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- [`Fix`] Fix `generateSignedTransaction` so that it works with object instances from different bundles
+- [`Fix`] Preventing undefined options from overriding fallbacks in `generateRawTransaction`
+
 # 1.13.1 (2024-04-23)
 
 - [`Fix`] Fixes Local ABI to use it locally rather than make an external network call

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -296,9 +296,8 @@ export async function generateRawTransaction(args: {
 
   const { maxGasAmount, gasUnitPrice, expireTimestamp } = {
     maxGasAmount: options?.maxGasAmount ? BigInt(options.maxGasAmount) : BigInt(DEFAULT_MAX_GAS_AMOUNT),
-    gasUnitPrice: BigInt(gasEstimate),
-    expireTimestamp: BigInt(Math.floor(Date.now() / 1000) + DEFAULT_TXN_EXP_SEC_FROM_NOW),
-    ...options,
+    gasUnitPrice: options?.gasUnitPrice ?? BigInt(gasEstimate),
+    expireTimestamp: options?.expireTimestamp ?? BigInt(Math.floor(Date.now() / 1000) + DEFAULT_TXN_EXP_SEC_FROM_NOW),
   };
 
   return new RawTransaction(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,3 @@
 export * from "./apiEndpoints";
 export * from "./const";
+export * from "./normalizeBundle";

--- a/src/utils/normalizeBundle.ts
+++ b/src/utils/normalizeBundle.ts
@@ -1,0 +1,21 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { Deserializer, Serializable } from "../bcs";
+
+export type DeserializableClass<T extends Serializable> = {
+  deserialize(deserializer: Deserializer): T;
+};
+
+/**
+ * Utility function that serializes and deserialize an object back into the same bundle as the sdk.
+ * This is a workaround to have the `instanceof` operator work when input objects come from a different
+ * bundle.
+ * @param cls The class of the object to normalize
+ * @param value the instance to normalize
+ */
+export function normalizeBundle<T extends Serializable>(cls: DeserializableClass<T>, value: T) {
+  const serializedBytes = value.bcsToBytes();
+  const deserializer = new Deserializer(serializedBytes);
+  return cls.deserialize(deserializer);
+}


### PR DESCRIPTION
### Description
When using a wallet extension, objects returned from the wallet belong to the wallet's bundle.
If we pass those objects directly to the ts-sdk, the `instanceof` operator doesn't work.

The change implemented in this PR is a temporary fix, to make sure that the submission flow from a walle extension works as expected.

Ideally, we should try to avoid `instanceof` as much as possible, unless we can guarantee the object was instantiated from the same bundle.

### Test Plan
CI

https://github.com/aptos-labs/aptos-ts-sdk/assets/7707719/51e8b0a8-5f69-44f2-9e20-249cec4f2ce4


