### PR TITLE
Introduce `table` function API. Add `getTableItemsData` and `getTableItemsMetadata` queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Separates the signing message functionality out of the transactionSubmission.ts file
 - Adds an Account implementation for MultiKey accounts
 - Upgrade `@aptos-labs/aptos-cli` package to version `0.1.7`
+- Introduce `table` function APIs
+- Add `getTableItemsData` and `getTableItemsMetadata` API queries
+- Add `decimal` prop back to `current_token_ownerships_v2.current_token_data` response
 
 # 1.14.0 (2024-05-09)
 

--- a/src/api/aptos.ts
+++ b/src/api/aptos.ts
@@ -12,6 +12,7 @@ import { General } from "./general";
 import { ANS } from "./ans";
 import { Staking } from "./staking";
 import { Transaction } from "./transaction";
+import { Table } from "./table";
 
 /**
  * This class is the main entry point into Aptos's
@@ -47,6 +48,8 @@ export class Aptos {
 
   readonly transaction: Transaction;
 
+  readonly table: Table;
+
   constructor(settings?: AptosConfig) {
     this.config = new AptosConfig(settings);
     this.account = new Account(this.config);
@@ -59,6 +62,7 @@ export class Aptos {
     this.general = new General(this.config);
     this.staking = new Staking(this.config);
     this.transaction = new Transaction(this.config);
+    this.table = new Table(this.config);
   }
 }
 
@@ -74,6 +78,7 @@ export interface Aptos
     FungibleAsset,
     General,
     Staking,
+    Table,
     Omit<Transaction, "build" | "simulate" | "submit" | "batch"> {}
 
 /**
@@ -107,3 +112,4 @@ applyMixin(Aptos, FungibleAsset, "fungibleAsset");
 applyMixin(Aptos, General, "general");
 applyMixin(Aptos, Staking, "staking");
 applyMixin(Aptos, Transaction, "transaction");
+applyMixin(Aptos, Table, "table");

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -9,7 +9,6 @@ import {
   getIndexerLastSuccessVersion,
   getLedgerInfo,
   getProcessorStatus,
-  getTableItem,
   queryIndexer,
 } from "../internal/general";
 import { view } from "../internal/view";
@@ -22,7 +21,6 @@ import {
   LedgerInfo,
   LedgerVersionArg,
   MoveValue,
-  TableItemRequest,
 } from "../types";
 import { ProcessorType } from "../utils/const";
 import { InputViewFunctionData } from "../transactions";
@@ -110,30 +108,6 @@ export class General {
    */
   async getBlockByHeight(args: { blockHeight: AnyNumber; options?: { withTransactions?: boolean } }): Promise<Block> {
     return getBlockByHeight({ aptosConfig: this.config, ...args });
-  }
-
-  /**
-   * Queries for a table item for a table identified by the handle and the key for the item.
-   * Key and value types need to be passed in to help with key serialization and value deserialization.
-   *
-   * @example https://api.devnet.aptoslabs.com/v1/accounts/0x1/resource/0x1::coin::CoinInfo%3C0x1::aptos_coin::AptosCoin%3E
-   * const tableItem = await aptos.getTableItem({
-   *  handle: "0x123",
-   *  data: {
-   *   key_type: "address", // Move type of table key
-   *   value_type: "u128", // Move type of table value
-   *   key: "0x619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935" // Value of table key
-   *  },
-   * })
-   *
-   * @param args.handle A pointer to where that table is stored
-   * @param args.data Object that describes table item
-   * @param args.options.ledgerVersion The ledger version to query, if not provided it will get the latest version
-   *
-   * @returns Table item value rendered in JSON
-   */
-  async getTableItem<T>(args: { handle: string; data: TableItemRequest; options?: LedgerVersionArg }): Promise<T> {
-    return getTableItem<T>({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/api/table.ts
+++ b/src/api/table.ts
@@ -1,0 +1,108 @@
+import { getTableItem, getTableItemsData, getTableItemsMetadata } from "../internal/table";
+import {
+  TableItemRequest,
+  LedgerVersionArg,
+  AnyNumber,
+  PaginationArgs,
+  WhereArg,
+  OrderByArg,
+  GetTableItemsDataResponse,
+  GetTableItemsMetadataResponse,
+} from "../types";
+import { TableItemsBoolExp, TableMetadatasBoolExp } from "../types/generated/types";
+import { ProcessorType } from "../utils";
+import { AptosConfig } from "./aptosConfig";
+import { waitForIndexerOnVersion } from "./utils";
+
+/**
+ * A class to query all `Table` Aptos related queries
+ */
+export class Table {
+  readonly config: AptosConfig;
+
+  constructor(config: AptosConfig) {
+    this.config = config;
+  }
+
+  /**
+   * Queries for a table item for a table identified by the handle and the key for the item.
+   * Key and value types need to be passed in to help with key serialization and value deserialization.
+   *
+   * Note, this query calls the fullnode server
+   *
+   * @example https://api.devnet.aptoslabs.com/v1/accounts/0x1/resource/0x1::coin::CoinInfo%3C0x1::aptos_coin::AptosCoin%3E
+   * const tableItem = await aptos.getTableItem({
+   *  handle: "0x1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca",
+   *  data: {
+   *   key_type: "address", // Move type of table key
+   *   value_type: "u128", // Move type of table value
+   *   key: "0x619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935" // Value of table key
+   *  },
+   * })
+   *
+   * @param args.handle A pointer to where that table is stored
+   * @param args.data Object that describes table item
+   * @param args.options.ledgerVersion The ledger version to query, if not provided it will get the latest version
+   *
+   * @returns Table item value rendered in JSON
+   */
+  async getTableItem<T>(args: { handle: string; data: TableItemRequest; options?: LedgerVersionArg }): Promise<T> {
+    return getTableItem<T>({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Queries for a table items data.
+   *
+   * Optional `options.where` param can be passed to filter the response.
+   *
+   * Note, this query calls the indexer server
+   *
+   * @example
+   * const data = await aptos.getTableItemsData({
+   *  options: { where: {
+   *      table_handle: { _eq: "0x1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca" },
+   *      transaction_version: { _eq: "0" }
+   *    }
+   *  },
+   * });
+   *
+   * @returns GetTableItemsDataResponse
+   */
+  async getTableItemsData(args: {
+    minimumLedgerVersion?: AnyNumber;
+    options?: PaginationArgs & WhereArg<TableItemsBoolExp> & OrderByArg<GetTableItemsDataResponse[0]>;
+  }): Promise<GetTableItemsDataResponse> {
+    await waitForIndexerOnVersion({
+      config: this.config,
+      minimumLedgerVersion: args.minimumLedgerVersion,
+      processorType: ProcessorType.DEFAULT,
+    });
+    return getTableItemsData({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Queries for a table items metadata.
+   *
+   * Optional `options.where` param can be passed to filter the response.
+   *
+   * Note, this query calls the indexer server
+   *
+   * @example
+   * const data = await aptos.getTableItemsMetadata({
+   *  options: { where: { handle: { _eq: "0x1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca" } } },
+   * });
+   *
+   * @returns GetTableItemsMetadataResponse
+   */
+  async getTableItemsMetadata(args: {
+    minimumLedgerVersion?: AnyNumber;
+    options?: PaginationArgs & WhereArg<TableMetadatasBoolExp> & OrderByArg<GetTableItemsMetadataResponse[0]>;
+  }): Promise<GetTableItemsMetadataResponse> {
+    await waitForIndexerOnVersion({
+      config: this.config,
+      minimumLedgerVersion: args.minimumLedgerVersion,
+      processorType: ProcessorType.DEFAULT,
+    });
+    return getTableItemsMetadata({ aptosConfig: this.config, ...args });
+  }
+}

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -13,7 +13,7 @@ import { AptosApiError, getAptosFullNode, paginateWithCursor } from "../client";
 import { AccountAddress, AccountAddressInput } from "../core/accountAddress";
 import { Account } from "../account";
 import { AnyPublicKey, Ed25519PublicKey, PrivateKey } from "../core/crypto";
-import { getTableItem, queryIndexer } from "./general";
+import { queryIndexer } from "./general";
 import {
   AccountData,
   GetAccountCoinsDataResponse,
@@ -54,6 +54,7 @@ import {
 import { memoizeAsync } from "../utils/memoize";
 import { Secp256k1PrivateKey, AuthenticationKey, Ed25519PrivateKey } from "../core";
 import { CurrentFungibleAssetBalancesBoolExp } from "../types/generated/types";
+import { getTableItem } from "./table";
 
 export async function getInfo(args: {
   aptosConfig: AptosConfig;

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -9,7 +9,7 @@
  */
 
 import { AptosConfig } from "../api/aptosConfig";
-import { getAptosFullNode, postAptosFullNode, postAptosIndexer } from "../client";
+import { getAptosFullNode, postAptosIndexer } from "../client";
 import {
   AnyNumber,
   Block,
@@ -17,8 +17,6 @@ import {
   GetProcessorStatusResponse,
   GraphqlQuery,
   LedgerInfo,
-  LedgerVersionArg,
-  TableItemRequest,
 } from "../types";
 import { GetChainTopUserTransactionsQuery, GetProcessorStatusQuery } from "../types/generated/operations";
 import { GetChainTopUserTransactions, GetProcessorStatus } from "../types/generated/queries";
@@ -62,23 +60,6 @@ export async function getBlockByHeight(args: {
     params: { with_transactions: options?.withTransactions },
   });
   return data;
-}
-
-export async function getTableItem<T>(args: {
-  aptosConfig: AptosConfig;
-  handle: string;
-  data: TableItemRequest;
-  options?: LedgerVersionArg;
-}): Promise<T> {
-  const { aptosConfig, handle, data, options } = args;
-  const response = await postAptosFullNode<TableItemRequest, any>({
-    aptosConfig,
-    originMethod: "getTableItem",
-    path: `tables/${handle}/item`,
-    params: { ledger_version: options?.ledgerVersion },
-    body: data,
-  });
-  return response.data as T;
 }
 
 export async function getChainTopUserTransactions(args: {

--- a/src/internal/queries/currentTokenOwnershipFieldsFragment.graphql
+++ b/src/internal/queries/currentTokenOwnershipFieldsFragment.graphql
@@ -25,6 +25,7 @@ fragment CurrentTokenOwnershipFields on current_token_ownerships_v2 {
     token_properties
     token_standard
     token_uri
+    decimals
     current_collection {
       collection_id
       collection_name

--- a/src/internal/queries/getTableItemsData.graphql
+++ b/src/internal/queries/getTableItemsData.graphql
@@ -1,0 +1,15 @@
+query getTableItemsData(
+  $where_condition: table_items_bool_exp!
+  $offset: Int
+  $limit: Int
+  $order_by: [table_items_order_by!]
+) {
+  table_items(where: $where_condition, offset: $offset, limit: $limit, order_by: $order_by){
+    decoded_key
+    decoded_value
+    key
+    table_handle
+    transaction_version
+    write_set_change_index
+  }
+}

--- a/src/internal/queries/getTableItemsMetadata.graphql
+++ b/src/internal/queries/getTableItemsMetadata.graphql
@@ -1,0 +1,12 @@
+query getTableItemsMetadata(
+  $where_condition: table_metadatas_bool_exp!
+  $offset: Int
+  $limit: Int
+  $order_by: [table_metadatas_order_by!]
+) {
+  table_metadatas(where: $where_condition, offset: $offset, limit: $limit, order_by: $order_by){
+     handle
+    key_type
+    value_type
+  }
+}

--- a/src/internal/table.ts
+++ b/src/internal/table.ts
@@ -1,0 +1,82 @@
+import { AptosConfig } from "../api/aptosConfig";
+import { postAptosFullNode } from "../client";
+import {
+  TableItemRequest,
+  LedgerVersionArg,
+  PaginationArgs,
+  WhereArg,
+  OrderByArg,
+  GetTableItemsDataResponse,
+  GetTableItemsMetadataResponse,
+} from "../types";
+import { GetTableItemsDataQuery, GetTableItemsMetadataQuery } from "../types/generated/operations";
+import { GetTableItemsData, GetTableItemsMetadata } from "../types/generated/queries";
+import { TableItemsBoolExp, TableMetadatasBoolExp } from "../types/generated/types";
+import { queryIndexer } from "./general";
+
+export async function getTableItem<T>(args: {
+  aptosConfig: AptosConfig;
+  handle: string;
+  data: TableItemRequest;
+  options?: LedgerVersionArg;
+}): Promise<T> {
+  const { aptosConfig, handle, data, options } = args;
+  const response = await postAptosFullNode<TableItemRequest, any>({
+    aptosConfig,
+    originMethod: "getTableItem",
+    path: `tables/${handle}/item`,
+    params: { ledger_version: options?.ledgerVersion },
+    body: data,
+  });
+  return response.data as T;
+}
+
+export async function getTableItemsData(args: {
+  aptosConfig: AptosConfig;
+  options?: PaginationArgs & WhereArg<TableItemsBoolExp> & OrderByArg<GetTableItemsDataResponse[0]>;
+}) {
+  const { aptosConfig, options } = args;
+
+  const graphqlQuery = {
+    query: GetTableItemsData,
+    variables: {
+      where_condition: options?.where,
+      offset: options?.offset,
+      limit: options?.limit,
+      order_by: options?.orderBy,
+    },
+  };
+
+  const data = await queryIndexer<GetTableItemsDataQuery>({
+    aptosConfig,
+    query: graphqlQuery,
+    originMethod: "getTableItemsData",
+  });
+
+  return data.table_items;
+}
+
+export async function getTableItemsMetadata(args: {
+  aptosConfig: AptosConfig;
+  options?: PaginationArgs & WhereArg<TableMetadatasBoolExp> & OrderByArg<GetTableItemsMetadataResponse[0]>;
+}): Promise<GetTableItemsMetadataResponse> {
+  const { aptosConfig, options } = args;
+
+  const graphqlQuery = {
+    query: GetTableItemsMetadata,
+    variables: {
+      where_condition: options?.where,
+      offset: options?.offset,
+      limit: options?.limit,
+      order_by: options?.orderBy,
+    },
+  };
+
+  const data = await queryIndexer<GetTableItemsMetadataQuery>({
+    aptosConfig,
+    query: graphqlQuery,
+    originMethod: "getTableItemsMetadata",
+  });
+
+  return data.table_metadatas;
+}

--- a/src/types/generated/operations.ts
+++ b/src/types/generated/operations.ts
@@ -535,6 +535,35 @@ export type GetProcessorStatusQuery = {
   processor_status: Array<{ last_success_version: any; processor: string; last_updated: any }>;
 };
 
+export type GetTableItemsDataQueryVariables = Types.Exact<{
+  where_condition: Types.TableItemsBoolExp;
+  offset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  limit?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  order_by?: Types.InputMaybe<Array<Types.TableItemsOrderBy> | Types.TableItemsOrderBy>;
+}>;
+
+export type GetTableItemsDataQuery = {
+  table_items: Array<{
+    decoded_key: any;
+    decoded_value?: any | null;
+    key: string;
+    table_handle: string;
+    transaction_version: any;
+    write_set_change_index: any;
+  }>;
+};
+
+export type GetTableItemsMetadataQueryVariables = Types.Exact<{
+  where_condition: Types.TableMetadatasBoolExp;
+  offset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  limit?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  order_by?: Types.InputMaybe<Array<Types.TableMetadatasOrderBy> | Types.TableMetadatasOrderBy>;
+}>;
+
+export type GetTableItemsMetadataQuery = {
+  table_metadatas: Array<{ handle: string; key_type: string; value_type: string }>;
+};
+
 export type GetTokenActivityQueryVariables = Types.Exact<{
   where_condition: Types.TokenActivitiesV2BoolExp;
   offset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;

--- a/src/types/generated/queries.ts
+++ b/src/types/generated/queries.ts
@@ -389,6 +389,37 @@ export const GetProcessorStatus = `
   }
 }
     `;
+export const GetTableItemsData = `
+    query getTableItemsData($where_condition: table_items_bool_exp!, $offset: Int, $limit: Int, $order_by: [table_items_order_by!]) {
+  table_items(
+    where: $where_condition
+    offset: $offset
+    limit: $limit
+    order_by: $order_by
+  ) {
+    decoded_key
+    decoded_value
+    key
+    table_handle
+    transaction_version
+    write_set_change_index
+  }
+}
+    `;
+export const GetTableItemsMetadata = `
+    query getTableItemsMetadata($where_condition: table_metadatas_bool_exp!, $offset: Int, $limit: Int, $order_by: [table_metadatas_order_by!]) {
+  table_metadatas(
+    where: $where_condition
+    offset: $offset
+    limit: $limit
+    order_by: $order_by
+  ) {
+    handle
+    key_type
+    value_type
+  }
+}
+    `;
 export const GetTokenActivity = `
     query getTokenActivity($where_condition: token_activities_v2_bool_exp!, $offset: Int, $limit: Int, $order_by: [token_activities_v2_order_by!]) {
   token_activities_v2(
@@ -724,6 +755,34 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         "getProcessorStatus",
+        "query",
+      );
+    },
+    getTableItemsData(
+      variables: Types.GetTableItemsDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<Types.GetTableItemsDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<Types.GetTableItemsDataQuery>(GetTableItemsData, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        "getTableItemsData",
+        "query",
+      );
+    },
+    getTableItemsMetadata(
+      variables: Types.GetTableItemsMetadataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<Types.GetTableItemsMetadataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<Types.GetTableItemsMetadataQuery>(GetTableItemsMetadata, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        "getTableItemsMetadata",
         "query",
       );
     },

--- a/src/types/generated/types.ts
+++ b/src/types/generated/types.ts
@@ -98,6 +98,8 @@ export type AccountTransactions = {
   /** An aggregate relationship */
   token_activities_v2_aggregate: TokenActivitiesV2Aggregate;
   transaction_version: Scalars["bigint"]["output"];
+  /** An object relationship */
+  user_transaction?: Maybe<UserTransactions>;
 };
 
 /** columns and relationships of "account_transactions" */
@@ -219,6 +221,7 @@ export type AccountTransactionsBoolExp = {
   token_activities_v2?: InputMaybe<TokenActivitiesV2BoolExp>;
   token_activities_v2_aggregate?: InputMaybe<TokenActivitiesV2AggregateBoolExp>;
   transaction_version?: InputMaybe<BigintComparisonExp>;
+  user_transaction?: InputMaybe<UserTransactionsBoolExp>;
 };
 
 /** aggregate max on columns */
@@ -242,6 +245,7 @@ export type AccountTransactionsOrderBy = {
   token_activities_aggregate?: InputMaybe<TokenActivitiesAggregateOrderBy>;
   token_activities_v2_aggregate?: InputMaybe<TokenActivitiesV2AggregateOrderBy>;
   transaction_version?: InputMaybe<OrderBy>;
+  user_transaction?: InputMaybe<UserTransactionsOrderBy>;
 };
 
 /** select columns of table "account_transactions" */
@@ -1875,6 +1879,7 @@ export type CurrentAnsLookupV2StreamCursorValueInput = {
 /** columns and relationships of "current_aptos_names" */
 export type CurrentAptosNames = {
   domain?: Maybe<Scalars["String"]["output"]>;
+  domain_expiration_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
   domain_with_suffix?: Maybe<Scalars["String"]["output"]>;
   expiration_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
   is_active?: Maybe<Scalars["Boolean"]["output"]>;
@@ -1885,6 +1890,7 @@ export type CurrentAptosNames = {
   owner_address?: Maybe<Scalars["String"]["output"]>;
   registered_address?: Maybe<Scalars["String"]["output"]>;
   subdomain?: Maybe<Scalars["String"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["bigint"]["output"]>;
   token_name?: Maybe<Scalars["String"]["output"]>;
   token_standard?: Maybe<Scalars["String"]["output"]>;
 };
@@ -1961,11 +1967,13 @@ export type CurrentAptosNamesAggregateOrderBy = {
 /** aggregate avg on columns */
 export type CurrentAptosNamesAvgFields = {
   last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** order by avg() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesAvgOrderBy = {
   last_transaction_version?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
 };
 
 /** Boolean expression to filter rows from the table "current_aptos_names". All fields are combined with a logical 'AND'. */
@@ -1974,6 +1982,7 @@ export type CurrentAptosNamesBoolExp = {
   _not?: InputMaybe<CurrentAptosNamesBoolExp>;
   _or?: InputMaybe<Array<CurrentAptosNamesBoolExp>>;
   domain?: InputMaybe<StringComparisonExp>;
+  domain_expiration_timestamp?: InputMaybe<TimestampComparisonExp>;
   domain_with_suffix?: InputMaybe<StringComparisonExp>;
   expiration_timestamp?: InputMaybe<TimestampComparisonExp>;
   is_active?: InputMaybe<BooleanComparisonExp>;
@@ -1983,6 +1992,7 @@ export type CurrentAptosNamesBoolExp = {
   owner_address?: InputMaybe<StringComparisonExp>;
   registered_address?: InputMaybe<StringComparisonExp>;
   subdomain?: InputMaybe<StringComparisonExp>;
+  subdomain_expiration_policy?: InputMaybe<BigintComparisonExp>;
   token_name?: InputMaybe<StringComparisonExp>;
   token_standard?: InputMaybe<StringComparisonExp>;
 };
@@ -1990,12 +2000,14 @@ export type CurrentAptosNamesBoolExp = {
 /** aggregate max on columns */
 export type CurrentAptosNamesMaxFields = {
   domain?: Maybe<Scalars["String"]["output"]>;
+  domain_expiration_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
   domain_with_suffix?: Maybe<Scalars["String"]["output"]>;
   expiration_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
   last_transaction_version?: Maybe<Scalars["bigint"]["output"]>;
   owner_address?: Maybe<Scalars["String"]["output"]>;
   registered_address?: Maybe<Scalars["String"]["output"]>;
   subdomain?: Maybe<Scalars["String"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["bigint"]["output"]>;
   token_name?: Maybe<Scalars["String"]["output"]>;
   token_standard?: Maybe<Scalars["String"]["output"]>;
 };
@@ -2003,12 +2015,14 @@ export type CurrentAptosNamesMaxFields = {
 /** order by max() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesMaxOrderBy = {
   domain?: InputMaybe<OrderBy>;
+  domain_expiration_timestamp?: InputMaybe<OrderBy>;
   domain_with_suffix?: InputMaybe<OrderBy>;
   expiration_timestamp?: InputMaybe<OrderBy>;
   last_transaction_version?: InputMaybe<OrderBy>;
   owner_address?: InputMaybe<OrderBy>;
   registered_address?: InputMaybe<OrderBy>;
   subdomain?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
   token_name?: InputMaybe<OrderBy>;
   token_standard?: InputMaybe<OrderBy>;
 };
@@ -2016,12 +2030,14 @@ export type CurrentAptosNamesMaxOrderBy = {
 /** aggregate min on columns */
 export type CurrentAptosNamesMinFields = {
   domain?: Maybe<Scalars["String"]["output"]>;
+  domain_expiration_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
   domain_with_suffix?: Maybe<Scalars["String"]["output"]>;
   expiration_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
   last_transaction_version?: Maybe<Scalars["bigint"]["output"]>;
   owner_address?: Maybe<Scalars["String"]["output"]>;
   registered_address?: Maybe<Scalars["String"]["output"]>;
   subdomain?: Maybe<Scalars["String"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["bigint"]["output"]>;
   token_name?: Maybe<Scalars["String"]["output"]>;
   token_standard?: Maybe<Scalars["String"]["output"]>;
 };
@@ -2029,12 +2045,14 @@ export type CurrentAptosNamesMinFields = {
 /** order by min() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesMinOrderBy = {
   domain?: InputMaybe<OrderBy>;
+  domain_expiration_timestamp?: InputMaybe<OrderBy>;
   domain_with_suffix?: InputMaybe<OrderBy>;
   expiration_timestamp?: InputMaybe<OrderBy>;
   last_transaction_version?: InputMaybe<OrderBy>;
   owner_address?: InputMaybe<OrderBy>;
   registered_address?: InputMaybe<OrderBy>;
   subdomain?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
   token_name?: InputMaybe<OrderBy>;
   token_standard?: InputMaybe<OrderBy>;
 };
@@ -2042,6 +2060,7 @@ export type CurrentAptosNamesMinOrderBy = {
 /** Ordering options when selecting data from "current_aptos_names". */
 export type CurrentAptosNamesOrderBy = {
   domain?: InputMaybe<OrderBy>;
+  domain_expiration_timestamp?: InputMaybe<OrderBy>;
   domain_with_suffix?: InputMaybe<OrderBy>;
   expiration_timestamp?: InputMaybe<OrderBy>;
   is_active?: InputMaybe<OrderBy>;
@@ -2051,6 +2070,7 @@ export type CurrentAptosNamesOrderBy = {
   owner_address?: InputMaybe<OrderBy>;
   registered_address?: InputMaybe<OrderBy>;
   subdomain?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
   token_name?: InputMaybe<OrderBy>;
   token_standard?: InputMaybe<OrderBy>;
 };
@@ -2059,6 +2079,8 @@ export type CurrentAptosNamesOrderBy = {
 export enum CurrentAptosNamesSelectColumn {
   /** column name */
   Domain = "domain",
+  /** column name */
+  DomainExpirationTimestamp = "domain_expiration_timestamp",
   /** column name */
   DomainWithSuffix = "domain_with_suffix",
   /** column name */
@@ -2075,6 +2097,8 @@ export enum CurrentAptosNamesSelectColumn {
   RegisteredAddress = "registered_address",
   /** column name */
   Subdomain = "subdomain",
+  /** column name */
+  SubdomainExpirationPolicy = "subdomain_expiration_policy",
   /** column name */
   TokenName = "token_name",
   /** column name */
@@ -2100,31 +2124,37 @@ export enum CurrentAptosNamesSelectColumnCurrentAptosNamesAggregateBoolExpBoolOr
 /** aggregate stddev on columns */
 export type CurrentAptosNamesStddevFields = {
   last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** order by stddev() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesStddevOrderBy = {
   last_transaction_version?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
 };
 
 /** aggregate stddev_pop on columns */
 export type CurrentAptosNamesStddevPopFields = {
   last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** order by stddev_pop() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesStddevPopOrderBy = {
   last_transaction_version?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
 };
 
 /** aggregate stddev_samp on columns */
 export type CurrentAptosNamesStddevSampFields = {
   last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** order by stddev_samp() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesStddevSampOrderBy = {
   last_transaction_version?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
 };
 
 /** Streaming cursor of the table "current_aptos_names" */
@@ -2138,6 +2168,7 @@ export type CurrentAptosNamesStreamCursorInput = {
 /** Initial value of the column from where the streaming should start */
 export type CurrentAptosNamesStreamCursorValueInput = {
   domain?: InputMaybe<Scalars["String"]["input"]>;
+  domain_expiration_timestamp?: InputMaybe<Scalars["timestamp"]["input"]>;
   domain_with_suffix?: InputMaybe<Scalars["String"]["input"]>;
   expiration_timestamp?: InputMaybe<Scalars["timestamp"]["input"]>;
   is_active?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -2146,6 +2177,7 @@ export type CurrentAptosNamesStreamCursorValueInput = {
   owner_address?: InputMaybe<Scalars["String"]["input"]>;
   registered_address?: InputMaybe<Scalars["String"]["input"]>;
   subdomain?: InputMaybe<Scalars["String"]["input"]>;
+  subdomain_expiration_policy?: InputMaybe<Scalars["bigint"]["input"]>;
   token_name?: InputMaybe<Scalars["String"]["input"]>;
   token_standard?: InputMaybe<Scalars["String"]["input"]>;
 };
@@ -2153,41 +2185,49 @@ export type CurrentAptosNamesStreamCursorValueInput = {
 /** aggregate sum on columns */
 export type CurrentAptosNamesSumFields = {
   last_transaction_version?: Maybe<Scalars["bigint"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["bigint"]["output"]>;
 };
 
 /** order by sum() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesSumOrderBy = {
   last_transaction_version?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
 };
 
 /** aggregate var_pop on columns */
 export type CurrentAptosNamesVarPopFields = {
   last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** order by var_pop() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesVarPopOrderBy = {
   last_transaction_version?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
 };
 
 /** aggregate var_samp on columns */
 export type CurrentAptosNamesVarSampFields = {
   last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** order by var_samp() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesVarSampOrderBy = {
   last_transaction_version?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
 };
 
 /** aggregate variance on columns */
 export type CurrentAptosNamesVarianceFields = {
   last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+  subdomain_expiration_policy?: Maybe<Scalars["Float"]["output"]>;
 };
 
 /** order by variance() on columns of table "current_aptos_names" */
 export type CurrentAptosNamesVarianceOrderBy = {
   last_transaction_version?: InputMaybe<OrderBy>;
+  subdomain_expiration_policy?: InputMaybe<OrderBy>;
 };
 
 /** columns and relationships of "current_coin_balances" */
@@ -3495,8 +3535,10 @@ export type CurrentTokenDatasV2 = {
   collection_id: Scalars["String"]["output"];
   /** An object relationship */
   current_collection?: Maybe<CurrentCollectionsV2>;
-  /** An object relationship */
-  current_token_ownership?: Maybe<CurrentTokenOwnershipsV2>;
+  /** An array relationship */
+  current_token_ownerships: Array<CurrentTokenOwnershipsV2>;
+  /** An aggregate relationship */
+  current_token_ownerships_aggregate: CurrentTokenOwnershipsV2Aggregate;
   decimals: Scalars["bigint"]["output"];
   description: Scalars["String"]["output"];
   is_fungible_v2?: Maybe<Scalars["Boolean"]["output"]>;
@@ -3513,6 +3555,24 @@ export type CurrentTokenDatasV2 = {
 };
 
 /** columns and relationships of "current_token_datas_v2" */
+export type CurrentTokenDatasV2CurrentTokenOwnershipsArgs = {
+  distinct_on?: InputMaybe<Array<CurrentTokenOwnershipsV2SelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<CurrentTokenOwnershipsV2OrderBy>>;
+  where?: InputMaybe<CurrentTokenOwnershipsV2BoolExp>;
+};
+
+/** columns and relationships of "current_token_datas_v2" */
+export type CurrentTokenDatasV2CurrentTokenOwnershipsAggregateArgs = {
+  distinct_on?: InputMaybe<Array<CurrentTokenOwnershipsV2SelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<CurrentTokenOwnershipsV2OrderBy>>;
+  where?: InputMaybe<CurrentTokenOwnershipsV2BoolExp>;
+};
+
+/** columns and relationships of "current_token_datas_v2" */
 export type CurrentTokenDatasV2TokenPropertiesArgs = {
   path?: InputMaybe<Scalars["String"]["input"]>;
 };
@@ -3526,7 +3586,8 @@ export type CurrentTokenDatasV2BoolExp = {
   cdn_asset_uris?: InputMaybe<NftMetadataCrawlerParsedAssetUrisBoolExp>;
   collection_id?: InputMaybe<StringComparisonExp>;
   current_collection?: InputMaybe<CurrentCollectionsV2BoolExp>;
-  current_token_ownership?: InputMaybe<CurrentTokenOwnershipsV2BoolExp>;
+  current_token_ownerships?: InputMaybe<CurrentTokenOwnershipsV2BoolExp>;
+  current_token_ownerships_aggregate?: InputMaybe<CurrentTokenOwnershipsV2AggregateBoolExp>;
   decimals?: InputMaybe<BigintComparisonExp>;
   description?: InputMaybe<StringComparisonExp>;
   is_fungible_v2?: InputMaybe<BooleanComparisonExp>;
@@ -3548,7 +3609,7 @@ export type CurrentTokenDatasV2OrderBy = {
   cdn_asset_uris?: InputMaybe<NftMetadataCrawlerParsedAssetUrisOrderBy>;
   collection_id?: InputMaybe<OrderBy>;
   current_collection?: InputMaybe<CurrentCollectionsV2OrderBy>;
-  current_token_ownership?: InputMaybe<CurrentTokenOwnershipsV2OrderBy>;
+  current_token_ownerships_aggregate?: InputMaybe<CurrentTokenOwnershipsV2AggregateOrderBy>;
   decimals?: InputMaybe<OrderBy>;
   description?: InputMaybe<OrderBy>;
   is_fungible_v2?: InputMaybe<OrderBy>;
@@ -3938,6 +3999,7 @@ export type CurrentTokenOwnershipsV2 = {
   is_soulbound_v2?: Maybe<Scalars["Boolean"]["output"]>;
   last_transaction_timestamp: Scalars["timestamp"]["output"];
   last_transaction_version: Scalars["bigint"]["output"];
+  non_transferrable_by_owner?: Maybe<Scalars["Boolean"]["output"]>;
   owner_address: Scalars["String"]["output"];
   property_version_v1: Scalars["numeric"]["output"];
   storage_id: Scalars["String"]["output"];
@@ -4066,6 +4128,7 @@ export type CurrentTokenOwnershipsV2BoolExp = {
   is_soulbound_v2?: InputMaybe<BooleanComparisonExp>;
   last_transaction_timestamp?: InputMaybe<TimestampComparisonExp>;
   last_transaction_version?: InputMaybe<BigintComparisonExp>;
+  non_transferrable_by_owner?: InputMaybe<BooleanComparisonExp>;
   owner_address?: InputMaybe<StringComparisonExp>;
   property_version_v1?: InputMaybe<NumericComparisonExp>;
   storage_id?: InputMaybe<StringComparisonExp>;
@@ -4136,6 +4199,7 @@ export type CurrentTokenOwnershipsV2OrderBy = {
   is_soulbound_v2?: InputMaybe<OrderBy>;
   last_transaction_timestamp?: InputMaybe<OrderBy>;
   last_transaction_version?: InputMaybe<OrderBy>;
+  non_transferrable_by_owner?: InputMaybe<OrderBy>;
   owner_address?: InputMaybe<OrderBy>;
   property_version_v1?: InputMaybe<OrderBy>;
   storage_id?: InputMaybe<OrderBy>;
@@ -4158,6 +4222,8 @@ export enum CurrentTokenOwnershipsV2SelectColumn {
   /** column name */
   LastTransactionVersion = "last_transaction_version",
   /** column name */
+  NonTransferrableByOwner = "non_transferrable_by_owner",
+  /** column name */
   OwnerAddress = "owner_address",
   /** column name */
   PropertyVersionV1 = "property_version_v1",
@@ -4179,6 +4245,8 @@ export enum CurrentTokenOwnershipsV2SelectColumnCurrentTokenOwnershipsV2Aggregat
   IsFungibleV2 = "is_fungible_v2",
   /** column name */
   IsSoulboundV2 = "is_soulbound_v2",
+  /** column name */
+  NonTransferrableByOwner = "non_transferrable_by_owner",
 }
 
 /** select "current_token_ownerships_v2_aggregate_bool_exp_bool_or_arguments_columns" columns of table "current_token_ownerships_v2" */
@@ -4187,6 +4255,8 @@ export enum CurrentTokenOwnershipsV2SelectColumnCurrentTokenOwnershipsV2Aggregat
   IsFungibleV2 = "is_fungible_v2",
   /** column name */
   IsSoulboundV2 = "is_soulbound_v2",
+  /** column name */
+  NonTransferrableByOwner = "non_transferrable_by_owner",
 }
 
 /** aggregate stddev on columns */
@@ -4246,6 +4316,7 @@ export type CurrentTokenOwnershipsV2StreamCursorValueInput = {
   is_soulbound_v2?: InputMaybe<Scalars["Boolean"]["input"]>;
   last_transaction_timestamp?: InputMaybe<Scalars["timestamp"]["input"]>;
   last_transaction_version?: InputMaybe<Scalars["bigint"]["input"]>;
+  non_transferrable_by_owner?: InputMaybe<Scalars["Boolean"]["input"]>;
   owner_address?: InputMaybe<Scalars["String"]["input"]>;
   property_version_v1?: InputMaybe<Scalars["numeric"]["input"]>;
   storage_id?: InputMaybe<Scalars["String"]["input"]>;
@@ -7072,6 +7143,10 @@ export type QueryRoot = {
   proposal_votes_aggregate: ProposalVotesAggregate;
   /** fetch data from the table: "proposal_votes" using primary key columns */
   proposal_votes_by_pk?: Maybe<ProposalVotes>;
+  /** fetch data from the table: "signatures" */
+  signatures: Array<Signatures>;
+  /** fetch data from the table: "signatures" using primary key columns */
+  signatures_by_pk?: Maybe<Signatures>;
   /** fetch data from the table: "table_items" */
   table_items: Array<TableItems>;
   /** fetch data from the table: "table_items" using primary key columns */
@@ -7802,6 +7877,21 @@ export type QueryRootProposalVotesByPkArgs = {
   voter_address: Scalars["String"]["input"];
 };
 
+export type QueryRootSignaturesArgs = {
+  distinct_on?: InputMaybe<Array<SignaturesSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<SignaturesOrderBy>>;
+  where?: InputMaybe<SignaturesBoolExp>;
+};
+
+export type QueryRootSignaturesByPkArgs = {
+  is_sender_primary: Scalars["Boolean"]["input"];
+  multi_agent_index: Scalars["bigint"]["input"];
+  multi_sig_index: Scalars["bigint"]["input"];
+  transaction_version: Scalars["bigint"]["input"];
+};
+
 export type QueryRootTableItemsArgs = {
   distinct_on?: InputMaybe<Array<TableItemsSelectColumn>>;
   limit?: InputMaybe<Scalars["Int"]["input"]>;
@@ -7923,6 +8013,108 @@ export type QueryRootUserTransactionsArgs = {
 
 export type QueryRootUserTransactionsByPkArgs = {
   version: Scalars["bigint"]["input"];
+};
+
+/** columns and relationships of "signatures" */
+export type Signatures = {
+  is_sender_primary: Scalars["Boolean"]["output"];
+  multi_agent_index: Scalars["bigint"]["output"];
+  multi_sig_index: Scalars["bigint"]["output"];
+  public_key: Scalars["String"]["output"];
+  public_key_indices: Scalars["jsonb"]["output"];
+  signature: Scalars["String"]["output"];
+  signer: Scalars["String"]["output"];
+  threshold: Scalars["bigint"]["output"];
+  transaction_block_height: Scalars["bigint"]["output"];
+  transaction_version: Scalars["bigint"]["output"];
+  type: Scalars["String"]["output"];
+};
+
+/** columns and relationships of "signatures" */
+export type SignaturesPublicKeyIndicesArgs = {
+  path?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+/** Boolean expression to filter rows from the table "signatures". All fields are combined with a logical 'AND'. */
+export type SignaturesBoolExp = {
+  _and?: InputMaybe<Array<SignaturesBoolExp>>;
+  _not?: InputMaybe<SignaturesBoolExp>;
+  _or?: InputMaybe<Array<SignaturesBoolExp>>;
+  is_sender_primary?: InputMaybe<BooleanComparisonExp>;
+  multi_agent_index?: InputMaybe<BigintComparisonExp>;
+  multi_sig_index?: InputMaybe<BigintComparisonExp>;
+  public_key?: InputMaybe<StringComparisonExp>;
+  public_key_indices?: InputMaybe<JsonbComparisonExp>;
+  signature?: InputMaybe<StringComparisonExp>;
+  signer?: InputMaybe<StringComparisonExp>;
+  threshold?: InputMaybe<BigintComparisonExp>;
+  transaction_block_height?: InputMaybe<BigintComparisonExp>;
+  transaction_version?: InputMaybe<BigintComparisonExp>;
+  type?: InputMaybe<StringComparisonExp>;
+};
+
+/** Ordering options when selecting data from "signatures". */
+export type SignaturesOrderBy = {
+  is_sender_primary?: InputMaybe<OrderBy>;
+  multi_agent_index?: InputMaybe<OrderBy>;
+  multi_sig_index?: InputMaybe<OrderBy>;
+  public_key?: InputMaybe<OrderBy>;
+  public_key_indices?: InputMaybe<OrderBy>;
+  signature?: InputMaybe<OrderBy>;
+  signer?: InputMaybe<OrderBy>;
+  threshold?: InputMaybe<OrderBy>;
+  transaction_block_height?: InputMaybe<OrderBy>;
+  transaction_version?: InputMaybe<OrderBy>;
+  type?: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "signatures" */
+export enum SignaturesSelectColumn {
+  /** column name */
+  IsSenderPrimary = "is_sender_primary",
+  /** column name */
+  MultiAgentIndex = "multi_agent_index",
+  /** column name */
+  MultiSigIndex = "multi_sig_index",
+  /** column name */
+  PublicKey = "public_key",
+  /** column name */
+  PublicKeyIndices = "public_key_indices",
+  /** column name */
+  Signature = "signature",
+  /** column name */
+  Signer = "signer",
+  /** column name */
+  Threshold = "threshold",
+  /** column name */
+  TransactionBlockHeight = "transaction_block_height",
+  /** column name */
+  TransactionVersion = "transaction_version",
+  /** column name */
+  Type = "type",
+}
+
+/** Streaming cursor of the table "signatures" */
+export type SignaturesStreamCursorInput = {
+  /** Stream column input with initial value */
+  initial_value: SignaturesStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type SignaturesStreamCursorValueInput = {
+  is_sender_primary?: InputMaybe<Scalars["Boolean"]["input"]>;
+  multi_agent_index?: InputMaybe<Scalars["bigint"]["input"]>;
+  multi_sig_index?: InputMaybe<Scalars["bigint"]["input"]>;
+  public_key?: InputMaybe<Scalars["String"]["input"]>;
+  public_key_indices?: InputMaybe<Scalars["jsonb"]["input"]>;
+  signature?: InputMaybe<Scalars["String"]["input"]>;
+  signer?: InputMaybe<Scalars["String"]["input"]>;
+  threshold?: InputMaybe<Scalars["bigint"]["input"]>;
+  transaction_block_height?: InputMaybe<Scalars["bigint"]["input"]>;
+  transaction_version?: InputMaybe<Scalars["bigint"]["input"]>;
+  type?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type SubscriptionRoot = {
@@ -8226,6 +8418,12 @@ export type SubscriptionRoot = {
   proposal_votes_by_pk?: Maybe<ProposalVotes>;
   /** fetch data from the table in a streaming manner: "proposal_votes" */
   proposal_votes_stream: Array<ProposalVotes>;
+  /** fetch data from the table: "signatures" */
+  signatures: Array<Signatures>;
+  /** fetch data from the table: "signatures" using primary key columns */
+  signatures_by_pk?: Maybe<Signatures>;
+  /** fetch data from the table in a streaming manner: "signatures" */
+  signatures_stream: Array<Signatures>;
   /** fetch data from the table: "table_items" */
   table_items: Array<TableItems>;
   /** fetch data from the table: "table_items" using primary key columns */
@@ -9258,6 +9456,27 @@ export type SubscriptionRootProposalVotesStreamArgs = {
   batch_size: Scalars["Int"]["input"];
   cursor: Array<InputMaybe<ProposalVotesStreamCursorInput>>;
   where?: InputMaybe<ProposalVotesBoolExp>;
+};
+
+export type SubscriptionRootSignaturesArgs = {
+  distinct_on?: InputMaybe<Array<SignaturesSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<SignaturesOrderBy>>;
+  where?: InputMaybe<SignaturesBoolExp>;
+};
+
+export type SubscriptionRootSignaturesByPkArgs = {
+  is_sender_primary: Scalars["Boolean"]["input"];
+  multi_agent_index: Scalars["bigint"]["input"];
+  multi_sig_index: Scalars["bigint"]["input"];
+  transaction_version: Scalars["bigint"]["input"];
+};
+
+export type SubscriptionRootSignaturesStreamArgs = {
+  batch_size: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<SignaturesStreamCursorInput>>;
+  where?: InputMaybe<SignaturesBoolExp>;
 };
 
 export type SubscriptionRootTableItemsArgs = {

--- a/src/types/indexer.ts
+++ b/src/types/indexer.ts
@@ -30,6 +30,8 @@ import {
   GetTokenActivityQuery,
   GetCurrentTokenOwnershipQuery,
   GetNamesQuery,
+  GetTableItemsDataQuery,
+  GetTableItemsMetadataQuery,
 } from "./generated/operations";
 
 /**
@@ -66,6 +68,8 @@ export type GetCurrentFungibleAssetBalancesResponse =
 export type GetTokenActivityResponse = GetTokenActivityQuery["token_activities_v2"];
 export type GetCurrentTokenOwnershipResponse = GetCurrentTokenOwnershipQuery["current_token_ownerships_v2"][0];
 export type GetOwnedTokensResponse = GetCurrentTokenOwnershipQuery["current_token_ownerships_v2"];
+export type GetTableItemsDataResponse = GetTableItemsDataQuery["table_items"];
+export type GetTableItemsMetadataResponse = GetTableItemsMetadataQuery["table_metadatas"];
 
 export type GetANSNameResponse = GetNamesQuery["current_aptos_names"];
 

--- a/tests/e2e/api/table.test.ts
+++ b/tests/e2e/api/table.test.ts
@@ -1,0 +1,63 @@
+import { getAptosClient } from "../helper";
+
+const { aptos } = getAptosClient();
+let resource: Supply;
+
+type Supply = {
+  supply: {
+    vec: [
+      {
+        aggregator: {
+          vec: [{ handle: string; key: string }];
+        };
+      },
+    ];
+  };
+};
+
+describe("table", () => {
+  beforeAll(async () => {
+    resource = await aptos.getAccountResource<Supply>({
+      accountAddress: "0x1",
+      resourceType: "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>",
+    });
+  });
+
+  test("it fetches table item", async () => {
+    const { handle, key } = resource.supply.vec[0].aggregator.vec[0];
+
+    const supply = await aptos.getTableItem<string>({
+      handle,
+      data: {
+        key_type: "address",
+        value_type: "u128",
+        key,
+      },
+    });
+
+    expect(parseInt(supply, 10)).toBeGreaterThan(0);
+  });
+
+  test("it fetches table items data", async () => {
+    const { handle } = resource.supply.vec[0].aggregator.vec[0];
+
+    const data = await aptos.getTableItemsData({
+      options: { where: { table_handle: { _eq: handle }, transaction_version: { _eq: 0 } } },
+    });
+
+    expect(data[0].decoded_key).toEqual("0x619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935");
+    expect(data[0].decoded_value).toEqual("18446744073709551625");
+    expect(data[0].key).toEqual("0x0619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935");
+  });
+
+  test("it fetches table items metadata data", async () => {
+    const { handle } = resource.supply.vec[0].aggregator.vec[0];
+
+    const data = await aptos.getTableItemsMetadata({
+      options: { where: { handle: { _eq: handle } } },
+    });
+
+    expect(data[0].value_type).toEqual("u128");
+    expect(data[0].key_type).toEqual("address");
+  });
+});


### PR DESCRIPTION
### Description

This PR
1. Adds `decimal` prop back to `current_token_ownerships_v2.current_token_data` response
2. Solves https://github.com/aptos-labs/aptos-ts-sdk/issues/376 , by adding 2 new `table` related queries - `getTableItemsData` and `getTableItemsMetadata`.

Currently, PFN doesnt return the table item data or metadata (i.e `data` field is always `null`, see https://fullnode.mainnet.aptoslabs.com/v1/transactions/by_version/563060087 ) and Indexer doesnt have a join query that can return all the data in one response.

This PR adds the 2 different Indexer queries where one can fetch the decoded table item data.

For example, consider https://explorer.aptoslabs.com/txn/563060087/changes?network=mainnet (index 5) [Indexer](https://cloud.hasura.io/public/graphiql?endpoint=https%3A%2F%2Findexer.mainnet.aptoslabs.com%2Fv1%2Fgraphql&query=query+MyQuery+%7B%0A++table_items%28%0A++++where%3A+%7Btable_handle%3A+%7B_eq%3A+%220x7a36d3935ebd2045f49fab033acad5212782ff81c4b79bd55cc1af3ce7c8418b%22%7D%2C+transaction_version%3A+%7B_eq%3A+%22563060087%22%7D%7D%0A++%29+%7B%0A++++decoded_key%0A++++decoded_value%0A++++key%0A++++table_handle%0A++++transaction_version%0A++++write_set_change_index%0A++%7D%0A++table_metadatas%28%0A++++where%3A+%7Bhandle%3A+%7B_eq%3A+%220x7a36d3935ebd2045f49fab033acad5212782ff81c4b79bd55cc1af3ce7c8418b%22%7D%7D%0A++%29+%7B%0A++++handle%0A++++key_type%0A++++value_type%0A++%7D%0A%7D%0A) is able to get us the decoded values. 

With this change, the SDK uses indexer to fetch the decoded values

```
const data = await aptos.getTableItemsData({
      options: { where: { table_handle: { _eq:"0x7a36d3935ebd2045f49fab033acad5212782ff81c4b79bd55cc1af3ce7c8418b" }, transaction_version: { _eq: "563060087" } } },
}); 

const metadata = await aptos.getTableItemsMetadata({
      options: { where: { handle: { _eq:"0x7a36d3935ebd2045f49fab033acad5212782ff81c4b79bd55cc1af3ce7c8418b" } } },
});
```

Can compare with [aptoscan.com](https://aptoscan.com/transaction/563060087#changes)

### Test Plan
- new tests have been added for the 2 new functions
- new test has been added to make sure `decimal` prop doesnt break queries (as happened in https://aptos-org.slack.com/archives/C05NLAKJM9U/p1709164127936519 )
- tests are passing

### Related Links
<!-- Please link to any relevant issues or pull requests! -->