### PR TITLE
Typescript strict

### DIFF
--- a/.github/actions/run-examples/action.yaml
+++ b/.github/actions/run-examples/action.yaml
@@ -50,7 +50,7 @@ runs:
       with:
         max_attempts: 3
         timeout_minutes: 25
-        command: cd examples/typescript && pnpm install && pnpm test
+        command: cd examples/typescript && pnpm install && pnpm build && pnpm test
 
     - name: Print local testnet logs on failure
       shell: bash

--- a/examples/typescript/batch_funds.ts
+++ b/examples/typescript/batch_funds.ts
@@ -30,7 +30,7 @@ import {
   UserTransactionResponse,
 } from "@aptos-labs/ts-sdk";
 
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.LOCAL;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 const config = new AptosConfig({ network: APTOS_NETWORK });
 const aptos = new Aptos(config);

--- a/examples/typescript/batch_mint.ts
+++ b/examples/typescript/batch_mint.ts
@@ -29,7 +29,7 @@ import {
   TransactionWorkerEventsEnum,
 } from "@aptos-labs/ts-sdk";
 
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 const config = new AptosConfig({ network: APTOS_NETWORK });
 const aptos = new Aptos(config);

--- a/examples/typescript/custom_client.ts
+++ b/examples/typescript/custom_client.ts
@@ -10,13 +10,12 @@
  * `<Req, Res>(requestOptions: ClientRequest<Req>): Promise<ClientResponse<Res>>;`
  *
  */
-import "dotenv";
 import { Aptos, AptosConfig, ClientResponse, ClientRequest, Network, NetworkToNetworkName } from "@aptos-labs/ts-sdk";
 // eslint-disable-next-line import/no-commonjs
 const superagent = require("superagent");
 
 // Default to devnet, but allow for overriding
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 export async function fetchCustomClient<Req, Res>(requestOptions: ClientRequest<Req>): Promise<ClientResponse<Res>> {
   const { params, method, url, headers, body } = requestOptions;

--- a/examples/typescript/external_signing.ts
+++ b/examples/typescript/external_signing.ts
@@ -26,7 +26,7 @@ const HOT_INITIAL_BALANCE = 100;
 const TRANSFER_AMOUNT = 100;
 
 // Default to devnet, but allow for overriding
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 const balance = async (aptos: Aptos, account: Account, name: string): Promise<number> => {
   type Coin = { coin: { value: string } };

--- a/examples/typescript/multi_agent_transfer.ts
+++ b/examples/typescript/multi_agent_transfer.ts
@@ -23,7 +23,7 @@ const ALICE_INITIAL_BALANCE = 100_000_000;
 const BOB_INITIAL_BALANCE = 100_000_000;
 const TRANSFER_AMOUNT = 10;
 // Default to devnet, but allow for overriding
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 /**
  * Prints the balance of an account

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "simple_transfer.ts",
   "scripts": {
+    "build": "tsc",
     "multi_agent_transfer": "ts-node multi_agent_transfer.ts",
     "simple_transfer": "ts-node simple_transfer.ts",
     "simple_sponsored_transaction": "ts-node simple_sponsored_transaction.ts",

--- a/examples/typescript/publish_package_from_filepath.ts
+++ b/examples/typescript/publish_package_from_filepath.ts
@@ -14,7 +14,7 @@ import assert from "assert";
 import { Account, Aptos, AptosConfig, Hex, Network, NetworkToNetworkName } from "@aptos-labs/ts-sdk";
 import { compilePackage, getPackageBytesToPublish } from "./utils";
 
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 /** run our demo! */
 async function main() {

--- a/examples/typescript/rotate_key.ts
+++ b/examples/typescript/rotate_key.ts
@@ -13,7 +13,7 @@ import {
 const WIDTH = 16;
 
 // Setup the client
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 const config = new AptosConfig({ network: APTOS_NETWORK });
 const aptos = new Aptos(config);
 

--- a/examples/typescript/sign_struct.ts
+++ b/examples/typescript/sign_struct.ts
@@ -21,7 +21,7 @@ const BOB_INITIAL_BALANCE = 100_000_000;
 const TRANSFER_AMOUNT = 10000;
 
 // Default to devnet, but allow for overriding
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 /**
  * Prints the balance of an account

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -13,7 +13,7 @@ const SPONSOR_INITIAL_BALANCE = 100_000_000;
 const BOB_INITIAL_BALANCE = 0;
 const TRANSFER_AMOUNT = 10;
 // Default to devnet, but allow for overriding
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 const example = async () => {
   console.log(

--- a/examples/typescript/simple_transfer.ts
+++ b/examples/typescript/simple_transfer.ts
@@ -14,7 +14,7 @@ const BOB_INITIAL_BALANCE = 100;
 const TRANSFER_AMOUNT = 100;
 
 // Default to devnet, but allow for overriding
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 /**
  * Prints the balance of an account

--- a/examples/typescript/swap.ts
+++ b/examples/typescript/swap.ts
@@ -25,7 +25,7 @@ import {
 } from "@aptos-labs/ts-sdk";
 import { createInterface } from "readline";
 // Default to devnet, but allow for overriding
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 
 const readline = createInterface({
   input: process.stdin,

--- a/examples/typescript/transfer_coin.ts
+++ b/examples/typescript/transfer_coin.ts
@@ -12,7 +12,7 @@ const BOB_INITIAL_BALANCE = 0;
 const TRANSFER_AMOUNT = 1_000_000;
 
 // Setup the client
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 const config = new AptosConfig({ network: APTOS_NETWORK });
 const aptos = new Aptos(config);
 

--- a/examples/typescript/tsconfig.json
+++ b/examples/typescript/tsconfig.json
@@ -11,8 +11,12 @@
     "outDir": "./dist",
     "sourceMap": true,
     "target": "es2020",
-    "pretty": true
+    "pretty": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "noEmit": true,
   },
+  "include": ["./*.ts"],
   "paths": {
     "@aptos/*": "../.."
   }

--- a/examples/typescript/your_coin.ts
+++ b/examples/typescript/your_coin.ts
@@ -18,7 +18,7 @@ const MOON_COINS_TO_MINT = 100;
 const MOON_COINS_TO_TRANSFER = 100;
 
 // Setup the client
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 const config = new AptosConfig({ network: APTOS_NETWORK });
 const aptos = new Aptos(config);
 

--- a/examples/typescript/your_fungible_asset.ts
+++ b/examples/typescript/your_fungible_asset.ts
@@ -23,7 +23,7 @@ import { compilePackage, getPackageBytesToPublish } from "./utils";
  */
 
 // Setup the client
-const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK] || Network.DEVNET;
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
 const config = new AptosConfig({ network: APTOS_NETWORK });
 const aptos = new Aptos(config);
 


### PR DESCRIPTION
### Description
- [x] Added [`strict`](https://www.typescriptlang.org/tsconfig/#strict) typing for better correctness

Example:
Using `undefined` as an index will not compile when using typescript strictly
```ts
// Error: if process.env.APTOS_NETWORK is undefined, this will fail when strict because 
// it does not allow you to use an undefined type to index values
NetworkToNetworkName[process.env.APTOS_NETWORK];
```
In javascript however, `undefined` will convert to a string `undefined`

```js
// Passes: if process.env.APTOS_NETWORK is undefined, it will pass in "undefined" as an index to NetworkToNetworkName
NetworkToNetworkName[process.env.APTOS_NETWORK];
```
Thus, if you have a key in `NetworkToNetworkName` called `"undefined"`, it will unintentionally use that key / value pair

- [x] Added a `tsc` step (build) to package.json and CI to ensure all ts files are built correctly in the `examples/typescript` directory

### Test Plan
Build passes