### PR TITLE
fix your first fungible asset example

### DIFF
--- a/src/internal/fungibleAsset.ts
+++ b/src/internal/fungibleAsset.ts
@@ -117,7 +117,7 @@ export async function getCurrentFungibleAssetBalances(args: {
 }
 
 const faTransferAbi: EntryFunctionABI = {
-  typeParameters: [],
+  typeParameters: [{ constraints: [] }],
   parameters: [parseTypeTag("0x1::object::Object"), new TypeTagAddress(), new TypeTagU64()],
 };
 


### PR DESCRIPTION
### Description
got the error of 
```
Error: Type argument count mismatch, expected 0, received 1
    at Tn (/Users/angiehuang/aptos-ts-sdk/dist/common/index.js:426:40395)
    at Ti (/Users/angiehuang/aptos-ts-sdk/dist/common/index.js:426:46212)
    at A (/Users/angiehuang/aptos-ts-sdk/dist/common/index.js:426:45888)
    at fs (/Users/angiehuang/aptos-ts-sdk/dist/common/index.js:426:66253)
    at zt.transferFungibleAsset (/Users/angiehuang/aptos-ts-sdk/dist/common/index.js:426:67560)
    at X.o.value (/Users/angiehuang/aptos-ts-sdk/dist/common/index.js:426:88905)
    at main (/Users/angiehuang/aptos-ts-sdk/examples/typescript/your_fungible_asset.ts:209:59)
```
when running `pnpm run your_fungible_asset`

### Test Plan
run `pnpm run your_fungible_asset` again and make sure it works 


