### PR TITLE
Remove `instanceOf` usage when generating signing message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Run all examples in CI
 - Introcude cli `Move` class that holds `move` related commands
 - Add common cli commands - `move.init()`, `move.compile()`, `move.test()`, `move.publish()`
+- [`Fix`] Fix `generateSigningMessage` to check type explicitly instead of using `intanceOf`
 
 # 1.13.3 (2024-04-30)
 

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -587,21 +587,19 @@ export function deriveTransactionType(transaction: AnyRawTransaction): AnyRawTra
 }
 
 export function generateSigningMessage(transaction: AnyRawTransaction): Uint8Array {
-  const rawTxn = deriveTransactionType(transaction);
   const hash = sha3Hash.create();
 
-  if (rawTxn instanceof RawTransaction) {
-    hash.update(RAW_TRANSACTION_SALT);
-  } else if (rawTxn instanceof MultiAgentRawTransaction) {
+  if (transaction.feePayerAddress) {
     hash.update(RAW_TRANSACTION_WITH_DATA_SALT);
-  } else if (rawTxn instanceof FeePayerRawTransaction) {
+  } else if (transaction.secondarySignerAddresses) {
     hash.update(RAW_TRANSACTION_WITH_DATA_SALT);
   } else {
-    throw new Error(`Unknown transaction type to sign on: ${rawTxn}`);
+    hash.update(RAW_TRANSACTION_SALT);
   }
 
   const prefix = hash.digest();
 
+  const rawTxn = deriveTransactionType(transaction);
   const body = rawTxn.bcsToBytes();
 
   const mergedArray = new Uint8Array(prefix.length + body.length);


### PR DESCRIPTION
### Description
Partner is facing this issue when they are trying to integrate their wallet code with the new wallet standard. We had past issues with using `instanceOf` (see https://github.com/aptos-labs/aptos-ts-sdk/pull/380 )


### Test Plan
tests are passing

### Related Links
<!-- Please link to any relevant issues or pull requests! -->