### PR TITLE
[crypto] Add AIP-80 input types for private keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Add support for AIP-80 compatible private keys, for input and output
 
 - Support `Serialized Type` to Script txn.  Now can use vector<String> for example.
 - Add optional address parameter to MultiKeyAccount constructor.

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -203,6 +203,25 @@ describe("PrivateKey", () => {
     expect(key).toBeInstanceOf(Ed25519PrivateKey);
     expect(privateKey).toEqual(key.toString());
   });
+
+  it("should take either hex or aip-80", () => {
+    const privateKey = new Ed25519PrivateKey(ed25519.privateKey);
+    const privateKey2 = new Ed25519PrivateKey(ed25519.privateKeyAip80);
+
+    expect(privateKey).toEqual(privateKey2);
+    expect(privateKey.toString()).toEqual(ed25519.privateKeyAip80);
+    expect(privateKey2.toString()).toEqual(ed25519.privateKeyAip80);
+  });
+
+  it("strict should only take aip-80", () => {
+    // eslint-disable-next-line no-new
+    expect(() => {
+      new Ed25519PrivateKey(ed25519.privateKey, true);
+    }).toThrow();
+    const privateKey = new Ed25519PrivateKey(ed25519.privateKeyAip80, true);
+
+    expect(privateKey.toString()).toEqual(ed25519.privateKeyAip80);
+  });
 });
 
 describe("Signature", () => {

--- a/tests/unit/helper.ts
+++ b/tests/unit/helper.ts
@@ -42,6 +42,7 @@ export const zeroWallet = {
 
 export const ed25519 = {
   privateKey: "0xc5338cd251c22daa8c9c9cc94f498cc8a5c7e1d2e75287a5dda91096fe64efa5",
+  privateKeyAip80: "ed25519-priv-0xc5338cd251c22daa8c9c9cc94f498cc8a5c7e1d2e75287a5dda91096fe64efa5",
   publicKey: "0xde19e5d1880cac87d57484ce9ed2e84cf0f9599f12e7cc3a52e4e7657a763f2c",
   authKey: "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa",
   address: "0x978c213990c4833df71548df7ce49d54c759d6b6d932de22b24d56060b7af2aa",
@@ -74,6 +75,7 @@ export const multiEd25519SigTestObject = {
 
 export const secp256k1TestObject = {
   privateKey: "0xd107155adf816a0a94c6db3c9489c13ad8a1eda7ada2e558ba3bfa47c020347e",
+  privateKeyAip80: "secp256k1-priv-0xd107155adf816a0a94c6db3c9489c13ad8a1eda7ada2e558ba3bfa47c020347e",
   publicKey:
     "0x04acdd16651b839c24665b7e2033b55225f384554949fef46c397b5275f37f6ee95554d70fb5d9f93c5831ebf695c7206e7477ce708f03ae9bb2862dc6c9e033ea",
   address: "0x5792c985bc96f436270bd2a3c692210b09c7febb8889345ceefdbae4bacfe498",

--- a/tests/unit/secp256k1.test.ts
+++ b/tests/unit/secp256k1.test.ts
@@ -2,8 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { secp256k1 } from "@noble/curves/secp256k1";
-import { secp256k1TestObject, secp256k1WalletTestObject } from "./helper";
-import { Deserializer, Hex, Secp256k1PrivateKey, Secp256k1PublicKey, Secp256k1Signature, Serializer } from "../../src";
+import { ed25519, secp256k1TestObject, secp256k1WalletTestObject } from "./helper";
+import {
+  Deserializer,
+  Ed25519PrivateKey,
+  Hex,
+  Secp256k1PrivateKey,
+  Secp256k1PublicKey,
+  Secp256k1Signature,
+  Serializer,
+} from "../../src";
 
 /* eslint-disable max-len */
 describe("Secp256k1PublicKey", () => {
@@ -139,6 +147,25 @@ describe("Secp256k1PrivateKey", () => {
     const key = Secp256k1PrivateKey.fromDerivationPath(path, mnemonic);
     expect(key).toBeInstanceOf(Secp256k1PrivateKey);
     expect(key.toString()).toEqual(privateKey);
+  });
+
+  it("should take either hex or aip-80", () => {
+    const privateKey = new Secp256k1PrivateKey(secp256k1TestObject.privateKey);
+    const privateKey2 = new Secp256k1PrivateKey(secp256k1TestObject.privateKeyAip80);
+
+    expect(privateKey).toEqual(privateKey2);
+    expect(privateKey.toString()).toEqual(secp256k1TestObject.privateKeyAip80);
+    expect(privateKey2.toString()).toEqual(secp256k1TestObject.privateKeyAip80);
+  });
+
+  it("strict should only take aip-80", () => {
+    // eslint-disable-next-line no-new
+    expect(() => {
+      new Secp256k1PrivateKey(secp256k1TestObject.privateKey, true);
+    }).toThrow();
+    const privateKey = new Secp256k1PrivateKey(secp256k1TestObject.privateKeyAip80, true);
+
+    expect(privateKey.toString()).toEqual(secp256k1TestObject.privateKeyAip80);
   });
 });
 


### PR DESCRIPTION
### Description
Adds support for AIP-80 private keys

### Test Plan
See unit tests

### Related Links
Discussion https://github.com/aptos-foundation/AIPs/issues/405