### PR TITLE
[scripts] auto convert string type tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - TypeTag parsing now support references, uppercase types, and more complete error handling
+- Allow simple string inputs as type arguments in move scripts
 
 # 1.16.0 (2024-05-22)
 

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -10,6 +10,7 @@ import {
   EntryFunctionABI,
   ViewFunctionABI,
   FunctionABI,
+  TypeArgument,
 } from "../types";
 import { Bool, MoveOption, MoveString, MoveVector, U128, U16, U256, U32, U64, U8 } from "../../bcs";
 import { AccountAddress } from "../../core";
@@ -40,9 +41,9 @@ const TEXT_ENCODER = new TextEncoder();
 /**
  * Convert type arguments to only type tags, allowing for string representations of type tags
  */
-export function standardizeTypeTags(typeArguments?: Array<TypeTag | string>): Array<TypeTag> {
+export function standardizeTypeTags(typeArguments?: Array<TypeArgument>): Array<TypeTag> {
   return (
-    typeArguments?.map((typeArg: string | TypeTag): TypeTag => {
+    typeArguments?.map((typeArg: TypeArgument): TypeTag => {
       // Convert to TypeTag if it's a string representation
       if (isString(typeArg)) {
         return parseTypeTag(typeArg);

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -216,7 +216,11 @@ export function generateViewFunctionPayloadWithABI(args: InputViewFunctionDataWi
 
 function generateTransactionPayloadScript(args: InputScriptData) {
   return new TransactionPayloadScript(
-    new Script(Hex.fromHexInput(args.bytecode).toUint8Array(), args.typeArguments ?? [], args.functionArguments),
+    new Script(
+      Hex.fromHexInput(args.bytecode).toUint8Array(),
+      standardizeTypeTags(args.typeArguments),
+      args.functionArguments,
+    ),
   );
 }
 

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -69,6 +69,25 @@ export type ScriptFunctionArgumentTypes =
   | FixedBytes;
 
 /**
+ * TypeArgument inputs for Entry functions, view functions, and scripts
+ *
+ * This can be a string version of the type argument such as:
+ * - u8
+ * - u16
+ * - u32
+ * - u64
+ * - u128
+ * - u256
+ * - bool
+ * - address
+ * - signer
+ * - vector<Type>
+ * - address::module::struct
+ * - address::module::struct<Type1, Type2>
+ */
+export type TypeArgument = TypeTag | string;
+
+/**
  * Type that holds all raw transaction instances Aptos SDK supports
  */
 export type AnyRawTransactionInstance = RawTransaction | MultiAgentRawTransaction | FeePayerRawTransaction;
@@ -109,7 +128,7 @@ export type InputGenerateTransactionPayloadDataWithRemoteABI =
  */
 export type InputEntryFunctionData = {
   function: MoveFunctionId;
-  typeArguments?: Array<TypeTag | string>;
+  typeArguments?: Array<TypeArgument>;
   functionArguments: Array<EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes>;
   abi?: EntryFunctionABI;
 };
@@ -144,7 +163,7 @@ export type InputMultiSigDataWithRemoteABI = {
  */
 export type InputScriptData = {
   bytecode: HexInput;
-  typeArguments?: Array<TypeTag>;
+  typeArguments?: Array<TypeArgument>;
   functionArguments: Array<ScriptFunctionArgumentTypes>;
 };
 
@@ -153,7 +172,7 @@ export type InputScriptData = {
  */
 export type InputViewFunctionData = {
   function: MoveFunctionId;
-  typeArguments?: Array<TypeTag | string>;
+  typeArguments?: Array<TypeArgument>;
   functionArguments?: Array<EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes>;
   abi?: ViewFunctionABI;
 };

--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -214,6 +214,11 @@ export const rawTransactionMultiAgentHelper = async (
 export const PUBLISHER_ACCOUNT_PK = "0xc694948143dea59c195a4918d7fe06c2329624318a073b95f6078ce54940dae9";
 export const PUBLISHER_ACCOUNT_ADDRESS = "2cca48b8b0d7f77ef28bfd608883c599680c5b8db8192c5e3baaae1aee45114c";
 
+// script function byte code form `transfer/sources/script_coin_transfer.move`
+export const TYPED_SCRIPT_TEST =
+  // eslint-disable-next-line max-len
+  "a11ceb0b060000000701000202020603080c04140405181a07321b084d2000000001040100010002030101000003040501000002010203060c0305010b0001090001090002060c0302050b000109000004636f696e04436f696e087769746864726177076465706f736974000000000000000000000000000000000000000000000000000000000000000101000001080b000b0138000c030b020b03380102";
+
 // script function byte code from `arguments/sources/script.move` for the transaction_arguments.test.ts script function tests
 export const MULTI_SIGNER_SCRIPT_ARGUMENT_TEST =
   // eslint-disable-next-line max-len

--- a/tests/e2e/transaction/transactionBuilder.test.ts
+++ b/tests/e2e/transaction/transactionBuilder.test.ts
@@ -28,7 +28,7 @@ import {
 } from "../../../src";
 import { FUND_AMOUNT, longTestTimeout } from "../../unit/helper";
 import { getAptosClient } from "../helper";
-import { fundAccounts, multiSignerScriptBytecode, publishTransferPackage } from "./helper";
+import { fundAccounts, multiSignerScriptBytecode, publishTransferPackage, TYPED_SCRIPT_TEST } from "./helper";
 
 const { aptos, config } = getAptosClient();
 
@@ -145,6 +145,40 @@ describe("transaction builder", () => {
           Account.generate().accountAddress,
           new U64(50),
         ],
+      });
+      const rawTxn = await generateRawTransaction({
+        aptosConfig: config,
+        sender: alice.accountAddress,
+        payload,
+      });
+      expect(rawTxn instanceof RawTransaction).toBeTruthy();
+      expect(rawTxn.payload instanceof TransactionPayloadScript).toBeTruthy();
+    });
+
+    test("it generates a raw transaction with script payload and string type arguments", async () => {
+      const alice = Account.generate();
+      await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: FUND_AMOUNT });
+      const payload = await generateTransactionPayload({
+        bytecode: TYPED_SCRIPT_TEST,
+        typeArguments: ["0x1::aptos_coin::AptosCoin"],
+        functionArguments: [Account.generate().accountAddress, new U64(50)],
+      });
+      const rawTxn = await generateRawTransaction({
+        aptosConfig: config,
+        sender: alice.accountAddress,
+        payload,
+      });
+      expect(rawTxn instanceof RawTransaction).toBeTruthy();
+      expect(rawTxn.payload instanceof TransactionPayloadScript).toBeTruthy();
+    });
+
+    test("it generates a raw transaction with script payload and typed type arguments", async () => {
+      const alice = Account.generate();
+      await aptos.fundAccount({ accountAddress: alice.accountAddress, amount: FUND_AMOUNT });
+      const payload = await generateTransactionPayload({
+        bytecode: TYPED_SCRIPT_TEST,
+        typeArguments: [parseTypeTag("0x1::aptos_coin::AptosCoin")],
+        functionArguments: [Account.generate().accountAddress, new U64(50)],
       });
       const rawTxn = await generateRawTransaction({
         aptosConfig: config,

--- a/tests/move/transfer/sources/script_coin_transfer.move
+++ b/tests/move/transfer/sources/script_coin_transfer.move
@@ -1,0 +1,12 @@
+script {
+    use aptos_framework::coin;
+
+    fun coin_transfer<Coin>(
+        sender: &signer,
+        amount: u64,
+        reciever: address,
+    ) {
+        let coin = coin::withdraw<Coin>(sender, amount);
+        coin::deposit(reciever, coin);
+    }
+}


### PR DESCRIPTION
### Description
Allows strings to be inputted as type arguments for scripts, similar to entry functions

### Test Plan
E2E tests with type tags and with strings

### Related Links
<!-- Please link to any relevant issues or pull requests! -->