### PR TITLE
[typeTag] Add remaining coverage for type tag parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- TypeTag parsing now support references, uppercase types, and more complete error handling
+
 # 1.16.0 (2024-05-22)
 
 - Upgrade `@aptos-labs/aptos-cli` package to version `0.1.8`

--- a/src/transactions/typeTag/parser.ts
+++ b/src/transactions/typeTag/parser.ts
@@ -21,22 +21,64 @@ import {
 import { AccountAddress } from "../../core";
 import { Identifier } from "../instances/identifier";
 
+/**
+ * Tells if the string is a valid Move identifier.  It can only be alphanumeric and `_`
+ * @param str
+ */
 function isValidIdentifier(str: string) {
   return !!str.match(/^[_a-zA-Z0-9]+$/);
 }
 
+/**
+ * Tells if the character is a whitespace character.  Does not work for multiple characters
+ * @param char
+ */
 function isValidWhitespaceCharacter(char: string) {
   return !!char.match(/\s/);
 }
 
+/**
+ * Tells if a type is a generic type from the ABI, this will be of the form T0, T1, ...
+ * @param str
+ */
 function isGeneric(str: string) {
   return !!str.match(/^T[0-9]+$/);
 }
 
+/**
+ * Tells if a type is a reference type (starts with &)
+ * @param str
+ */
 function isRef(str: string) {
   return !!str.match(/^&.+$/);
 }
 
+/**
+ * Tells if a type is a primitive type
+ * @param str
+ */
+function isPrimitive(str: string) {
+  switch (str) {
+    case "signer":
+    case "address":
+    case "bool":
+    case "u8":
+    case "u16":
+    case "u32":
+    case "u64":
+    case "u128":
+    case "u256":
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Consumes all whitespace in a string, similar to trim
+ * @param tagStr
+ * @param pos
+ */
 function consumeWhitespace(tagStr: string, pos: number) {
   let i = pos;
   for (; i < tagStr.length; i += 1) {
@@ -50,6 +92,9 @@ function consumeWhitespace(tagStr: string, pos: number) {
   return i;
 }
 
+/**
+ * State for TypeTag parsing.  This is pushed onto a stack to keep track of what is the current state
+ */
 type TypeTagState = {
   savedExpectedTypes: number;
   savedStr: string;
@@ -225,51 +270,31 @@ export function parseTypeTag(typeStr: string, options?: { allowGenerics?: boolea
  */
 function parseTypeTagInner(str: string, types: Array<TypeTag>, allowGenerics: boolean): TypeTag {
   const trimmedStr = str.trim();
+  const lowerCaseTrimmed = trimmedStr.toLowerCase();
+  if (isPrimitive(lowerCaseTrimmed)) {
+    if (types.length > 0) {
+      throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
+    }
+  }
+
   switch (trimmedStr.toLowerCase()) {
     case "signer":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagSigner();
     case "bool":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagBool();
     case "address":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagAddress();
     case "u8":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagU8();
     case "u16":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagU16();
     case "u32":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagU32();
     case "u64":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagU64();
     case "u128":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagU128();
     case "u256":
-      if (types.length > 0) {
-        throw new TypeTagParserError(str, TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-      }
       return new TypeTagU256();
     case "vector":
       if (types.length !== 1) {

--- a/tests/unit/typeTagParser.test.ts
+++ b/tests/unit/typeTagParser.test.ts
@@ -29,6 +29,8 @@ import {
   APTOS_COIN,
 } from "../../src";
 
+const TAG_STRUCT_NAME = "0x1::tag::Tag";
+
 const MODULE_NAME = new Identifier("tag");
 const STRUCT_NAME = new Identifier("Tag");
 
@@ -38,6 +40,60 @@ const structTagType = (typeTags?: Array<TypeTag>) =>
 const typeTagParserError = (str: string, errorType: TypeTagParserErrorType, subStr?: string) => {
   expect(() => parseTypeTag(str)).toThrow(new TypeTagParserError(subStr ?? str, errorType));
 };
+
+/**
+ * These types are primitives, and we ignore casing on them
+ */
+const primitives = [
+  { str: "signer", type: new TypeTagSigner() },
+  { str: "address", type: new TypeTagAddress() },
+  { str: "bool", type: new TypeTagBool() },
+  { str: "u8", type: new TypeTagU8() },
+  { str: "u16", type: new TypeTagU16() },
+  { str: "u32", type: new TypeTagU32() },
+  { str: "u64", type: new TypeTagU64() },
+  { str: "u128", type: new TypeTagU128() },
+  { str: "u256", type: new TypeTagU256() },
+];
+
+/**
+ * Known struct types without inner arguments
+ */
+const structTypes = [
+  { str: "0x1::string::String", type: new TypeTagStruct(stringStructTag()) },
+  { str: APTOS_COIN, type: new TypeTagStruct(aptosCoinStructTag()) },
+  { str: "0x1::option::Option<u8>", type: new TypeTagStruct(optionStructTag(new TypeTagU8())) },
+  { str: "0x1::object::Object<u8>", type: new TypeTagStruct(objectStructTag(new TypeTagU8())) },
+  { str: TAG_STRUCT_NAME, type: structTagType() },
+  { str: `${TAG_STRUCT_NAME}<u8>`, type: structTagType([new TypeTagU8()]) },
+  { str: `${TAG_STRUCT_NAME}<u8, u8>`, type: structTagType([new TypeTagU8(), new TypeTagU8()]) },
+  { str: `${TAG_STRUCT_NAME}<u64, u8>`, type: structTagType([new TypeTagU64(), new TypeTagU8()]) },
+  {
+    str: `${TAG_STRUCT_NAME}<${TAG_STRUCT_NAME}<u8>, u8>`,
+    type: structTagType([structTagType([new TypeTagU8()]), new TypeTagU8()]),
+  },
+  {
+    str: `${TAG_STRUCT_NAME}<u8, ${TAG_STRUCT_NAME}<u8>>`,
+    type: structTagType([new TypeTagU8(), structTagType([new TypeTagU8()])]),
+  },
+];
+
+/**
+ * Some examples with generics
+ */
+const generics = [
+  { str: "T0", type: new TypeTagGeneric(0) },
+  { str: "T1", type: new TypeTagGeneric(1) },
+  { str: "T1337", type: new TypeTagGeneric(1337) },
+  { str: `${TAG_STRUCT_NAME}<T0>`, type: structTagType([new TypeTagGeneric(0)]) },
+  { str: `${TAG_STRUCT_NAME}<T0, T1>`, type: structTagType([new TypeTagGeneric(0), new TypeTagGeneric(1)]) },
+];
+
+/**
+ * These types have no inner types
+ */
+const combinedTypes = [...primitives, ...structTypes];
+const combinedTypesWithGeneric = [...primitives, ...structTypes, ...generics];
 
 describe("TypeTagParser", () => {
   test("invalid types", () => {
@@ -108,159 +164,81 @@ describe("TypeTagParser", () => {
   });
 
   test("standard types", () => {
-    // TODO: Should we gate signer and &signer similar to how we gate generic?
-    expect(parseTypeTag("signer")).toEqual(new TypeTagSigner());
-    expect(parseTypeTag("u8")).toEqual(new TypeTagU8());
-    expect(parseTypeTag("u16")).toEqual(new TypeTagU16());
-    expect(parseTypeTag("u32")).toEqual(new TypeTagU32());
-    expect(parseTypeTag("u64")).toEqual(new TypeTagU64());
-    expect(parseTypeTag("u128")).toEqual(new TypeTagU128());
-    expect(parseTypeTag("u256")).toEqual(new TypeTagU256());
-    expect(parseTypeTag("bool")).toEqual(new TypeTagBool());
-    expect(parseTypeTag("address")).toEqual(new TypeTagAddress());
+    for (let i = 0; i < combinedTypes.length; i += 1) {
+      const combinedType = combinedTypes[i];
+      expect(parseTypeTag(combinedType.str)).toEqual(combinedType.type);
+      expect(parseTypeTag(` ${combinedType.str}`)).toEqual(combinedType.type);
+      expect(parseTypeTag(`${combinedType.str} `)).toEqual(combinedType.type);
+      expect(parseTypeTag(` ${combinedType.str} `)).toEqual(combinedType.type);
+    }
   });
 
-  test("standard capitalized types", () => {
-    expect(parseTypeTag("Signer")).toEqual(new TypeTagSigner());
-    expect(parseTypeTag("U8")).toEqual(new TypeTagU8());
-    expect(parseTypeTag("U16")).toEqual(new TypeTagU16());
-    expect(parseTypeTag("U32")).toEqual(new TypeTagU32());
-    expect(parseTypeTag("U64")).toEqual(new TypeTagU64());
-    expect(parseTypeTag("U128")).toEqual(new TypeTagU128());
-    expect(parseTypeTag("U256")).toEqual(new TypeTagU256());
-    expect(parseTypeTag("BOOL")).toEqual(new TypeTagBool());
-    expect(parseTypeTag("Address")).toEqual(new TypeTagAddress());
-  });
-
-  test("extra spacing", () => {
-    expect(parseTypeTag("u8 ")).toEqual(new TypeTagU8());
-    expect(parseTypeTag(" u8")).toEqual(new TypeTagU8());
-    expect(parseTypeTag(" u8 ")).toEqual(new TypeTagU8());
-    expect(parseTypeTag("vector< u8 >")).toEqual(new TypeTagVector(new TypeTagU8()));
+  test("capitalized primitive types", () => {
+    for (let i = 0; i < primitives.length; i += 1) {
+      const primitive = primitives[i];
+      expect(parseTypeTag(primitive.str.toUpperCase())).toEqual(primitive.type);
+    }
   });
 
   test("reference types", () => {
-    expect(parseTypeTag("&signer")).toEqual(new TypeTagReference(new TypeTagSigner()));
-    expect(parseTypeTag("&u8")).toEqual(new TypeTagReference(new TypeTagU8()));
-    expect(parseTypeTag("&u16")).toEqual(new TypeTagReference(new TypeTagU16()));
-    expect(parseTypeTag("&u32")).toEqual(new TypeTagReference(new TypeTagU32()));
-    expect(parseTypeTag("&u64")).toEqual(new TypeTagReference(new TypeTagU64()));
-    expect(parseTypeTag("&u128")).toEqual(new TypeTagReference(new TypeTagU128()));
-    expect(parseTypeTag("&u256")).toEqual(new TypeTagReference(new TypeTagU256()));
-    expect(parseTypeTag("&bool")).toEqual(new TypeTagReference(new TypeTagBool()));
-    expect(parseTypeTag("&address")).toEqual(new TypeTagReference(new TypeTagAddress()));
-  });
-  test("generic types with allow generics on", () => {
-    expect(parseTypeTag("T0", { allowGenerics: true })).toEqual(new TypeTagGeneric(0));
-    expect(parseTypeTag("T1", { allowGenerics: true })).toEqual(new TypeTagGeneric(1));
-    expect(parseTypeTag("T1337", { allowGenerics: true })).toEqual(new TypeTagGeneric(1337));
-    expect(parseTypeTag("vector<T0>", { allowGenerics: true })).toEqual(new TypeTagVector(new TypeTagGeneric(0)));
-    expect(parseTypeTag("0x1::tag::Tag<T0, T1>", { allowGenerics: true })).toEqual(
-      structTagType([new TypeTagGeneric(0), new TypeTagGeneric(1)]),
-    );
-    expect(parseTypeTag("&T0", { allowGenerics: true })).toEqual(new TypeTagReference(new TypeTagGeneric(0)));
+    for (let i = 0; i < combinedTypes.length; i += 1) {
+      const combinedType = combinedTypes[i];
+      expect(parseTypeTag(`&${combinedType.str}`)).toEqual(new TypeTagReference(combinedType.type));
+    }
   });
 
-  test("outside spacing", () => {
-    expect(parseTypeTag(" address")).toEqual(new TypeTagAddress());
-    expect(parseTypeTag("address ")).toEqual(new TypeTagAddress());
-    expect(parseTypeTag(" address ")).toEqual(new TypeTagAddress());
+  test("generic types with allow generics on", () => {
+    for (let i = 0; i < combinedTypesWithGeneric.length; i += 1) {
+      const combinedType = combinedTypesWithGeneric[i];
+      expect(parseTypeTag(combinedType.str, { allowGenerics: true })).toEqual(combinedType.type);
+      expect(parseTypeTag(`&${combinedType.str}`, { allowGenerics: true })).toEqual(
+        new TypeTagReference(combinedType.type),
+      );
+      expect(parseTypeTag(`vector<${combinedType.str}>`, { allowGenerics: true })).toEqual(
+        new TypeTagVector(combinedType.type),
+      );
+      expect(parseTypeTag(`0x1::tag::Tag<${combinedType.str}, ${combinedType.str}>`, { allowGenerics: true })).toEqual(
+        structTagType([combinedType.type, combinedType.type]),
+      );
+    }
   });
 
   test("vector", () => {
-    expect(parseTypeTag("vector<u8>")).toEqual(new TypeTagVector(new TypeTagU8()));
-    expect(parseTypeTag("vector<u16>")).toEqual(new TypeTagVector(new TypeTagU16()));
-    expect(parseTypeTag("vector<u32>")).toEqual(new TypeTagVector(new TypeTagU32()));
-    expect(parseTypeTag("vector<u64>")).toEqual(new TypeTagVector(new TypeTagU64()));
-    expect(parseTypeTag("vector<u128>")).toEqual(new TypeTagVector(new TypeTagU128()));
-    expect(parseTypeTag("vector<u256>")).toEqual(new TypeTagVector(new TypeTagU256()));
-    expect(parseTypeTag("vector<bool>")).toEqual(new TypeTagVector(new TypeTagBool()));
-    expect(parseTypeTag("vector<address>")).toEqual(new TypeTagVector(new TypeTagAddress()));
-    expect(parseTypeTag("vector<0x1::string::String>")).toEqual(
-      new TypeTagVector(new TypeTagStruct(stringStructTag())),
-    );
+    for (let i = 0; i < combinedTypes.length; i += 1) {
+      const combinedType = combinedTypes[i];
+      expect(parseTypeTag(`vector<${combinedType.str}>`)).toEqual(new TypeTagVector(combinedType.type));
+      expect(parseTypeTag(`vector< ${combinedType.str}>`)).toEqual(new TypeTagVector(combinedType.type));
+      expect(parseTypeTag(`vector<${combinedType.str} >`)).toEqual(new TypeTagVector(combinedType.type));
+      expect(parseTypeTag(`vector< ${combinedType.str} >`)).toEqual(new TypeTagVector(combinedType.type));
+    }
   });
 
   test("nested vector", () => {
-    expect(parseTypeTag("vector<vector<u8>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU8())));
-    expect(parseTypeTag("vector<vector<u16>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU16())));
-    expect(parseTypeTag("vector<vector<u32>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU32())));
-    expect(parseTypeTag("vector<vector<u64>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU64())));
-    expect(parseTypeTag("vector<vector<u128>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU128())));
-    expect(parseTypeTag("vector<vector<u256>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagU256())));
-    expect(parseTypeTag("vector<vector<bool>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagBool())));
-    expect(parseTypeTag("vector<vector<address>>")).toEqual(new TypeTagVector(new TypeTagVector(new TypeTagAddress())));
-    expect(parseTypeTag("vector<vector<0x1::string::String>>")).toEqual(
-      new TypeTagVector(new TypeTagVector(new TypeTagStruct(stringStructTag()))),
-    );
-  });
-
-  test("aptos coin", () => {
-    const aptosCoin = new TypeTagStruct(aptosCoinStructTag());
-    expect(parseTypeTag("0x1::aptos_coin::AptosCoin")).toEqual(aptosCoin);
-    expect(parseTypeTag(APTOS_COIN)).toEqual(aptosCoin);
-  });
-
-  test("string", () => {
-    expect(parseTypeTag("0x1::string::String")).toEqual(new TypeTagStruct(stringStructTag()));
+    for (let i = 0; i < combinedTypes.length; i += 1) {
+      const combinedType = combinedTypes[i];
+      expect(parseTypeTag(`vector<vector<${combinedType.str}>>`)).toEqual(
+        new TypeTagVector(new TypeTagVector(combinedType.type)),
+      );
+    }
   });
 
   test("object", () => {
-    expect(parseTypeTag("0x1::object::Object<0x1::tag::Tag>")).toEqual(
-      new TypeTagStruct(objectStructTag(structTagType())),
-    );
-    expect(parseTypeTag("0x1::object::Object<0x1::tag::Tag<u8>>")).toEqual(
-      new TypeTagStruct(objectStructTag(structTagType([new TypeTagU8()]))),
-    );
+    // TODO: Do we block primitives from object type?  Technically it isn't possible
+    for (let i = 0; i < structTypes.length; i += 1) {
+      const structType = structTypes[i];
+      expect(parseTypeTag(`0x1::object::Object<${structType.str}>`)).toEqual(
+        new TypeTagStruct(objectStructTag(structType.type)),
+      );
+    }
   });
 
   test("option", () => {
-    expect(parseTypeTag("0x1::option::Option<0x1::tag::Tag>")).toEqual(
-      new TypeTagStruct(optionStructTag(structTagType())),
-    );
-    expect(parseTypeTag("0x1::option::Option<0x1::tag::Tag<u8>>")).toEqual(
-      new TypeTagStruct(optionStructTag(structTagType([new TypeTagU8()]))),
-    );
-  });
-
-  test("0x1::tag::Tag", () => {
-    expect(parseTypeTag("0x1::tag::Tag")).toEqual(structTagType());
-  });
-
-  test("0x1::tag::Tag<u8>", () => {
-    expect(parseTypeTag("0x1::tag::Tag<u8>")).toEqual(structTagType([new TypeTagU8()]));
-  });
-
-  test("0x1::tag::Tag<u8,u64>", () => {
-    expect(parseTypeTag("0x1::tag::Tag<u8,u64>")).toEqual(structTagType([new TypeTagU8(), new TypeTagU64()]));
-  });
-
-  test("0x1::tag::Tag<u8,  u8>", () => {
-    expect(parseTypeTag("0x1::tag::Tag<u8,  u8>")).toEqual(structTagType([new TypeTagU8(), new TypeTagU8()]));
-  });
-
-  test("0x1::tag::Tag<  u8,u8>", () => {
-    expect(parseTypeTag("0x1::tag::Tag<  u8,u8>")).toEqual(structTagType([new TypeTagU8(), new TypeTagU8()]));
-  });
-
-  test("0x1::tag::Tag<u8,u8  >", () => {
-    expect(parseTypeTag("0x1::tag::Tag<u8,u8  >")).toEqual(structTagType([new TypeTagU8(), new TypeTagU8()]));
-  });
-
-  test("0x1::tag::Tag<0x1::tag::Tag<u8>>", () => {
-    expect(parseTypeTag("0x1::tag::Tag<0x1::tag::Tag<u8>>")).toEqual(structTagType([structTagType([new TypeTagU8()])]));
-  });
-
-  test("0x1::tag::Tag<0x1::tag::Tag<u8, u8>>", () => {
-    expect(parseTypeTag("0x1::tag::Tag<0x1::tag::Tag<u8, u8>>")).toEqual(
-      structTagType([structTagType([new TypeTagU8(), new TypeTagU8()])]),
-    );
-  });
-
-  test("0x1::tag::Tag<u8, 0x1::tag::Tag<u8>>", () => {
-    expect(parseTypeTag("0x1::tag::Tag<u8, 0x1::tag::Tag<u8>>")).toEqual(
-      structTagType([new TypeTagU8(), structTagType([new TypeTagU8()])]),
-    );
+    for (let i = 0; i < combinedTypes.length; i += 1) {
+      const combinedType = combinedTypes[i];
+      expect(parseTypeTag(`0x1::option::Option<${combinedType.str}>`)).toEqual(
+        new TypeTagStruct(optionStructTag(combinedType.type)),
+      );
+    }
   });
 
   test("0x1::tag::Tag<0x1::tag::Tag<u8>, u8>", () => {
@@ -276,15 +254,12 @@ describe("TypeTagParser", () => {
   });
 
   test("Invalid type args", () => {
-    expect(() => parseTypeTag("signer<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-    expect(() => parseTypeTag("bool<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-    expect(() => parseTypeTag("address<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-    expect(() => parseTypeTag("u8<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-    expect(() => parseTypeTag("u16<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-    expect(() => parseTypeTag("u32<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-    expect(() => parseTypeTag("u64<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-    expect(() => parseTypeTag("u128<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
-    expect(() => parseTypeTag("u256<u8>")).toThrow(TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments);
+    for (let i = 0; i < primitives.length; i += 1) {
+      const primitiveType = primitives[i];
+      expect(() => parseTypeTag(`${primitiveType.str}<u8>`)).toThrow(
+        TypeTagParserErrorType.UnexpectedPrimitiveTypeArguments,
+      );
+    }
     // TODO: This could be a better message
     expect(() => parseTypeTag("vector<>")).toThrow(TypeTagParserErrorType.TypeArgumentCountMismatch);
     expect(() => parseTypeTag("vector<u8, u8>")).toThrow(TypeTagParserErrorType.UnexpectedVectorTypeArgumentCount);
@@ -294,16 +269,5 @@ describe("TypeTagParser", () => {
   test("edge case invalid types", () => {
     expect(() => parseTypeTag("0x1::tag::Tag< , u8>")).toThrow();
     expect(() => parseTypeTag("0x1::tag::Tag<,u8>")).toThrow();
-  });
-
-  /* These need to be supported for ABI parsing */
-  test("struct with generic", () => {
-    expect(parseTypeTag("0x1::tag::Tag<T0>", { allowGenerics: true })).toEqual(structTagType([new TypeTagGeneric(0)]));
-    expect(parseTypeTag("0x1::tag::Tag<T0, T1>", { allowGenerics: true })).toEqual(
-      structTagType([new TypeTagGeneric(0), new TypeTagGeneric(1)]),
-    );
-    expect(parseTypeTag("0x1::tag::Tag<0x1::tag::Tag<T0, T1>, T2>", { allowGenerics: true })).toEqual(
-      structTagType([structTagType([new TypeTagGeneric(0), new TypeTagGeneric(1)]), new TypeTagGeneric(2)]),
-    );
   });
 });


### PR DESCRIPTION
### Description
1. This now trims excess spaces out from around tags
2. This now allows uppercase primitive types (not struct names)
3. This now allows nested references on all types
4. Properly handles commas and spaces in generics
5. Tests generics with primitive types

### Test Plan
The test coverage for this area is near 100% now

### Related Links
<!-- Please link to any relevant issues or pull requests! -->