### PR TITLE
Support generating transactions with loose types for SDK V1 backward …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - Upgrade `@aptos-labs/aptos-cli` package to version `0.1.8`
 - [`Fix`] CLI scripts to be OS compatible with Mac, Linux and Windows
+- [`Fix`] Support generating transactions with loose types for SDK V1 backward compatibility
 
 # 1.15.0 (2024-05-21)
 

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -217,6 +217,10 @@ function parseArg(
     if (isBool(arg)) {
       return new Bool(arg);
     }
+    if (isString(arg)) {
+      if (arg === "true") return new Bool(true);
+      if (arg === "false") return new Bool(false);
+    }
     throwTypeMismatch("boolean", position);
   }
   // TODO: support uint8array?
@@ -230,17 +234,26 @@ function parseArg(
     if (isNumber(arg)) {
       return new U8(arg);
     }
+    if (isString(arg)) {
+      return new U8(Number.parseInt(arg, 10));
+    }
     throwTypeMismatch("number", position);
   }
   if (param.isU16()) {
     if (isNumber(arg)) {
       return new U16(arg);
     }
+    if (isString(arg)) {
+      return new U16(Number.parseInt(arg, 10));
+    }
     throwTypeMismatch("number", position);
   }
   if (param.isU32()) {
     if (isNumber(arg)) {
       return new U32(arg);
+    }
+    if (isString(arg)) {
+      return new U32(Number.parseInt(arg, 10));
     }
     throwTypeMismatch("number", position);
   }

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -807,4 +807,25 @@ describe("transaction submission", () => {
       expect(uncreatedAccountInfo.sequence_number).toEqual("1");
     });
   });
+
+  describe("transactions with loose types for SDK v1 compatibility", () => {
+    it("submits transactions with loose types successfully", async () => {
+      const transaction = await aptos.transaction.build.simple({
+        sender: singleSignerED25519SenderAccount.accountAddress,
+        data: {
+          function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+          functionArguments: ["1", receiverAccounts[0].accountAddress],
+        },
+      });
+      const response = await aptos.signAndSubmitTransaction({
+        signer: singleSignerED25519SenderAccount,
+        transaction,
+      });
+      const submittedTransaction = await aptos.waitForTransaction({
+        transactionHash: response.hash,
+      });
+
+      expect(submittedTransaction.success).toBe(true);
+    });
+  });
 });

--- a/tests/unit/remoteAbi.test.ts
+++ b/tests/unit/remoteAbi.test.ts
@@ -52,6 +52,21 @@ describe("Remote ABI", () => {
       expect(checkOrConvertArgument(MAX_U256.toString(), parseTypeTag("u256"), 0, [])).toEqual(new U256(MAX_U256));
     });
 
+    // This test is for backward compatibility with the SDK V1 to generate transactions with loose types
+    it("should parse primitive types for sdk v1 compatibility", () => {
+      // boolean as a string
+      expect(checkOrConvertArgument("true", parseTypeTag("bool"), 0, [])).toEqual(new Bool(true));
+      expect(checkOrConvertArgument("false", parseTypeTag("bool"), 0, [])).toEqual(new Bool(false));
+
+      // integers as strings
+      expect(checkOrConvertArgument("255", parseTypeTag("u8"), 0, [])).toEqual(new U8(MAX_U8));
+      expect(checkOrConvertArgument("65535", parseTypeTag("u16"), 0, [])).toEqual(new U16(MAX_U16));
+      expect(checkOrConvertArgument("255", parseTypeTag("u32"), 0, [])).toEqual(new U32(MAX_U8));
+      expect(checkOrConvertArgument("255", parseTypeTag("u64"), 0, [])).toEqual(new U64(MAX_U8));
+      expect(checkOrConvertArgument("255", parseTypeTag("u128"), 0, [])).toEqual(new U128(MAX_U8));
+      expect(checkOrConvertArgument("255", parseTypeTag("u256"), 0, [])).toEqual(new U256(MAX_U8));
+    });
+
     it("should parse a typed arguments", () => {
       expect(checkOrConvertArgument(AccountAddress.ONE, parseTypeTag("address"), 0, [])).toEqual(AccountAddress.ONE);
       expect(checkOrConvertArgument(new Bool(true), parseTypeTag("bool"), 0, [])).toEqual(new Bool(true));


### PR DESCRIPTION
…compatibility

Previously, SDK V1 (i.e `aptos`) let you pass in `Integer` and `Boolean` types as `string`. We removed this support in SDK v2 to have a strong type system in the SDK.

This causes dapps to break as they migrate from SDK V1 to SDK V2 - so adding this support back. 

Reference to SDK V1 support https://github.com/aptos-labs/aptos-core/blob/main/ecosystem/typescript/sdk/src/transaction_builder/builder_utils.ts#L39-L72

### Description
<!-- Please describe your change and its motivation. -->

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->