### PR TITLE
[block] Change block APIs to fetch all transactions in the block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - TypeTag parsing now support references, uppercase types, and more complete error handling
 - Allow simple string inputs as type arguments in move scripts
+- [`Fix`] Block APIs will now pull all associated transactions in the block, not just the first `100`
 
 # 1.16.0 (2024-05-22)
 

--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -3,14 +3,13 @@
 
 import { AptosConfig } from "./aptosConfig";
 import {
-  getBlockByHeight,
-  getBlockByVersion,
   getChainTopUserTransactions,
   getIndexerLastSuccessVersion,
   getLedgerInfo,
   getProcessorStatus,
   queryIndexer,
 } from "../internal/general";
+import { getBlockByHeight, getBlockByVersion } from "../internal/transaction";
 import { view } from "../internal/view";
 import {
   AnyNumber,

--- a/src/internal/general.ts
+++ b/src/internal/general.ts
@@ -10,14 +10,7 @@
 
 import { AptosConfig } from "../api/aptosConfig";
 import { getAptosFullNode, postAptosIndexer } from "../client";
-import {
-  AnyNumber,
-  Block,
-  GetChainTopUserTransactionsResponse,
-  GetProcessorStatusResponse,
-  GraphqlQuery,
-  LedgerInfo,
-} from "../types";
+import { GetChainTopUserTransactionsResponse, GetProcessorStatusResponse, GraphqlQuery, LedgerInfo } from "../types";
 import { GetChainTopUserTransactionsQuery, GetProcessorStatusQuery } from "../types/generated/operations";
 import { GetChainTopUserTransactions, GetProcessorStatus } from "../types/generated/queries";
 import { ProcessorType } from "../utils/const";
@@ -28,36 +21,6 @@ export async function getLedgerInfo(args: { aptosConfig: AptosConfig }): Promise
     aptosConfig,
     originMethod: "getLedgerInfo",
     path: "",
-  });
-  return data;
-}
-
-export async function getBlockByVersion(args: {
-  aptosConfig: AptosConfig;
-  ledgerVersion: AnyNumber;
-  options?: { withTransactions?: boolean };
-}): Promise<Block> {
-  const { aptosConfig, ledgerVersion, options } = args;
-  const { data } = await getAptosFullNode<{}, Block>({
-    aptosConfig,
-    originMethod: "getBlockByVersion",
-    path: `blocks/by_version/${ledgerVersion}`,
-    params: { with_transactions: options?.withTransactions },
-  });
-  return data;
-}
-
-export async function getBlockByHeight(args: {
-  aptosConfig: AptosConfig;
-  blockHeight: AnyNumber;
-  options?: { withTransactions?: boolean };
-}): Promise<Block> {
-  const { aptosConfig, blockHeight, options } = args;
-  const { data } = await getAptosFullNode<{}, Block>({
-    aptosConfig,
-    originMethod: "getBlockByHeight",
-    path: `blocks/by_height/${blockHeight}`,
-    params: { with_transactions: options?.withTransactions },
   });
   return data;
 }

--- a/tests/e2e/api/general.test.ts
+++ b/tests/e2e/api/general.test.ts
@@ -17,18 +17,6 @@ describe("general api", () => {
     expect(chainId).toBe(4);
   });
 
-  test("it fetches block data by block height", async () => {
-    const blockHeight = 1;
-    const blockData = await aptos.getBlockByHeight({ blockHeight });
-    expect(blockData.block_height).toBe(blockHeight.toString());
-  });
-
-  test("it fetches block data by block version", async () => {
-    const blockVersion = 1;
-    const blockData = await aptos.getBlockByVersion({ ledgerVersion: blockVersion });
-    expect(blockData.block_height).toBe(blockVersion.toString());
-  });
-
   describe("View functions", () => {
     test("it fetches view function data", async () => {
       const payload: InputViewFunctionData = {


### PR DESCRIPTION
### Description
Additionally, this breakingly changes the block APIs to be under transaction rather than general, due to a circular dependency.

### Test Plan
I tested this live against Mainnet, which has over 100 transactions per block.  This helped me work out some of the edge conditions of off by 1.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->