### PR TITLE
Add TypeTagString

### DIFF
--- a/src/transactions/typeTag/index.ts
+++ b/src/transactions/typeTag/index.ts
@@ -340,6 +340,12 @@ export class TypeTagStruct extends TypeTag {
   }
 }
 
+export class TypeTagString extends TypeTagStruct {
+  constructor() {
+    super(new StructTag(AccountAddress.ONE, new Identifier("string"), new Identifier("String"), []));
+  }
+}
+
 export class StructTag extends Serializable {
   public readonly address: AccountAddress;
 


### PR DESCRIPTION
### Description
`0x1::string::String` is pretty commonly used, so I think it would be nice to provide an export that calls into `TypeTagStruct`

### Test Plan
