### PR TITLE
[remoteAbi] Fixes some issues in the type tag parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
-- [`Fix`] Allow for empty string "" as `0x0` for AccountAddress in argument parsing for backwards compatibility reasons
 - [`Fix`] Allow for empty array in MoveVector.U8
 - [`Fix`] Correctly type MoveOption when empty for some cases
 - [`Fix`] Add better error handling for empty string "" when used for a u8-u32 argument input type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- [`Fix`] Allow for empty string "" as `none` for an Option in simple function arguments
+- [`Fix`] Allow for empty array in MoveVector.U8
+- [`Fix`] Correctly type MoveOption when empty for some cases
+
 # 1.18.1 (2024-06-05)
 
 - [`Fix`] Keyless transaction simulation now reports gas correctly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
-- [`Fix`] Allow for empty string "" as `none` for an Option in simple function arguments
+- [`Fix`] Allow for empty string "" as `0x0` for AccountAddress in argument parsing for backwards compatibility reasons
 - [`Fix`] Allow for empty array in MoveVector.U8
 - [`Fix`] Correctly type MoveOption when empty for some cases
+- [`Fix`] Add better error handling for empty string "" when used for a u8-u32 argument input type
 
 # 1.18.1 (2024-06-05)
 

--- a/src/bcs/serializable/moveStructs.ts
+++ b/src/bcs/serializable/moveStructs.ts
@@ -90,7 +90,10 @@ export class MoveVector<T extends Serializable & EntryFunctionArgument>
   static U8(values: Array<number> | HexInput): MoveVector<U8> {
     let numbers: Array<number>;
 
-    if (Array.isArray(values) && typeof values[0] === "number") {
+    if (Array.isArray(values) && values.length === 0) {
+      // Handle empty array, since it won't have a "first value"
+      numbers = [];
+    } else if (Array.isArray(values) && typeof values[0] === "number") {
       numbers = values;
     } else if (typeof values === "string") {
       const hex = Hex.fromHexInput(values);
@@ -98,7 +101,7 @@ export class MoveVector<T extends Serializable & EntryFunctionArgument>
     } else if (values instanceof Uint8Array) {
       numbers = Array.from(values);
     } else {
-      throw new Error("Invalid input type");
+      throw new Error("Invalid input type, must be an number[], Uint8Array, or hex string");
     }
 
     return new MoveVector<U8>(numbers.map((v) => new U8(v)));

--- a/src/transactions/transactionBuilder/helpers.ts
+++ b/src/transactions/transactionBuilder/helpers.ts
@@ -24,12 +24,23 @@ export function isNumber(arg: SimpleEntryFunctionArgumentTypes): arg is number {
   return typeof arg === "number";
 }
 
+export function convertNumber(arg: SimpleEntryFunctionArgumentTypes): number | undefined {
+  if (isNumber(arg)) {
+    return arg;
+  }
+  if (isString(arg) && arg !== "") {
+    return Number.parseInt(arg, 10);
+  }
+
+  return undefined;
+}
+
 export function isLargeNumber(arg: SimpleEntryFunctionArgumentTypes): arg is number | bigint | string {
   return typeof arg === "number" || typeof arg === "bigint" || typeof arg === "string";
 }
 
-export function isEmptyOption(arg: SimpleEntryFunctionArgumentTypes): arg is null | undefined | "" {
-  return arg === null || arg === undefined || arg === "";
+export function isEmptyOption(arg: SimpleEntryFunctionArgumentTypes): arg is null | undefined {
+  return arg === null || arg === undefined;
 }
 
 export function isEncodedEntryFunctionArgument(

--- a/src/transactions/transactionBuilder/helpers.ts
+++ b/src/transactions/transactionBuilder/helpers.ts
@@ -28,8 +28,8 @@ export function isLargeNumber(arg: SimpleEntryFunctionArgumentTypes): arg is num
   return typeof arg === "number" || typeof arg === "bigint" || typeof arg === "string";
 }
 
-export function isNull(arg: SimpleEntryFunctionArgumentTypes): arg is null | undefined {
-  return arg === null || arg === undefined;
+export function isEmptyOption(arg: SimpleEntryFunctionArgumentTypes): arg is null | undefined | "" {
+  return arg === null || arg === undefined || arg === "";
 }
 
 export function isEncodedEntryFunctionArgument(

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -41,9 +41,9 @@ import {
   isEncodedEntryFunctionArgument,
   isLargeNumber,
   isEmptyOption,
-  isNumber,
   isString,
   throwTypeMismatch,
+  convertNumber,
 } from "./helpers";
 import { MoveFunction } from "../../types";
 
@@ -239,36 +239,35 @@ function parseArg(
   // TODO: support uint8array?
   if (param.isAddress()) {
     if (isString(arg)) {
+      // There is a very specific special case here, that was supported in the Legacy SDK
+      if (arg === "") {
+        return AccountAddress.ZERO;
+      }
+
       return AccountAddress.fromString(arg);
     }
     throwTypeMismatch("string | AccountAddress", position);
   }
   if (param.isU8()) {
-    if (isNumber(arg)) {
-      return new U8(arg);
+    const num = convertNumber(arg);
+    if (num !== undefined) {
+      return new U8(num);
     }
-    if (isString(arg)) {
-      return new U8(Number.parseInt(arg, 10));
-    }
-    throwTypeMismatch("number", position);
+    throwTypeMismatch("number | string", position);
   }
   if (param.isU16()) {
-    if (isNumber(arg)) {
-      return new U16(arg);
+    const num = convertNumber(arg);
+    if (num !== undefined) {
+      return new U16(num);
     }
-    if (isString(arg)) {
-      return new U16(Number.parseInt(arg, 10));
-    }
-    throwTypeMismatch("number", position);
+    throwTypeMismatch("number | string", position);
   }
   if (param.isU32()) {
-    if (isNumber(arg)) {
-      return new U32(arg);
+    const num = convertNumber(arg);
+    if (num !== undefined) {
+      return new U32(num);
     }
-    if (isString(arg)) {
-      return new U32(Number.parseInt(arg, 10));
-    }
-    throwTypeMismatch("number", position);
+    throwTypeMismatch("number | string", position);
   }
   if (param.isU64()) {
     if (isLargeNumber(arg)) {

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -336,9 +336,6 @@ function parseArg(
     }
 
     if (param.isOption()) {
-      // Empty option must be handled specially
-      // Note: Empty String for an empty option is for backwards compatibility, this does have the tradeoff
-      // where Some("") is not possible, without using BCS arguments directly.
       if (isEmptyOption(arg)) {
         // Here we attempt to reconstruct the underlying type
         // Note, for some reason the `isBool` etc. does not work with the compiler

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -239,11 +239,6 @@ function parseArg(
   // TODO: support uint8array?
   if (param.isAddress()) {
     if (isString(arg)) {
-      // There is a very specific special case here, that was supported in the Legacy SDK
-      if (arg === "") {
-        return AccountAddress.ZERO;
-      }
-
       return AccountAddress.fromString(arg);
     }
     throwTypeMismatch("string | AccountAddress", position);

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -2,7 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { parseTypeTag } from "../typeTag/parser";
-import { TypeTag, TypeTagStruct } from "../typeTag";
+import {
+  TypeTag,
+  TypeTagAddress,
+  TypeTagBool,
+  TypeTagStruct,
+  TypeTagU128,
+  TypeTagU16,
+  TypeTagU256,
+  TypeTagU32,
+  TypeTagU64,
+  TypeTagU8,
+} from "../typeTag";
 import { AptosConfig } from "../../api/aptosConfig";
 import {
   EntryFunctionArgumentTypes,
@@ -29,7 +40,7 @@ import {
   isBool,
   isEncodedEntryFunctionArgument,
   isLargeNumber,
-  isNull,
+  isEmptyOption,
   isNumber,
   isString,
   throwTypeMismatch,
@@ -167,6 +178,7 @@ export async function fetchViewFunctionAbi(
  * @param functionAbi
  * @param arg
  * @param position
+ * @param genericTypeParams
  */
 export function convertArgument(
   functionName: string,
@@ -331,9 +343,40 @@ function parseArg(
 
     if (param.isOption()) {
       // Empty option must be handled specially
-      if (isNull(arg)) {
+      // Note: Empty String for an empty option is for backwards compatibility, this does have the tradeoff
+      // where Some("") is not possible, without using BCS arguments directly.
+      if (isEmptyOption(arg)) {
+        // Here we attempt to reconstruct the underlying type
+        // Note, for some reason the `isBool` etc. does not work with the compiler
+        const innerParam = param.value.typeArgs[0];
+        if (innerParam instanceof TypeTagBool) {
+          return new MoveOption<Bool>(null);
+        }
+        if (innerParam instanceof TypeTagAddress) {
+          return new MoveOption<AccountAddress>(null);
+        }
+        if (innerParam instanceof TypeTagU8) {
+          return new MoveOption<U8>(null);
+        }
+        if (innerParam instanceof TypeTagU16) {
+          return new MoveOption<U16>(null);
+        }
+        if (innerParam instanceof TypeTagU32) {
+          return new MoveOption<U32>(null);
+        }
+        if (innerParam instanceof TypeTagU64) {
+          return new MoveOption<U64>(null);
+        }
+        if (innerParam instanceof TypeTagU128) {
+          return new MoveOption<U128>(null);
+        }
+        if (innerParam instanceof TypeTagU256) {
+          return new MoveOption<U256>(null);
+        }
+
+        // In all other cases, we will use a placeholder, it doesn't actually matter what the type is, but it will be obvious
         // Note: This is a placeholder U8 type, and does not match the actual type, as that can't be dynamically grabbed
-        return new MoveOption<U8>(null);
+        return new MoveOption<MoveString>(null);
       }
 
       return new MoveOption(checkOrConvertArgument(arg, param.value.typeArgs[0], position, genericTypeParams));

--- a/tests/e2e/transaction/transactionArguments.test.ts
+++ b/tests/e2e/transaction/transactionArguments.test.ts
@@ -24,13 +24,11 @@ import {
   convertArgument,
   FunctionABI,
   TypeTagBool,
-  optionStructTag,
-  TypeTagStruct,
   TypeTagVector,
   TypeTagU8,
-  stringStructTag,
   TypeTagU16,
   TypeTagU32,
+  TypeTagAddress,
 } from "../../../src";
 import {
   MAX_U128_BIG_INT,
@@ -215,28 +213,24 @@ describe("various transaction arguments", () => {
     backwardsCompatibleArgs = [
       "true", // True
       "false", // False
-      "", // Empty option vector<u8>
-      "", // Empty option string
-      "", // Empty option u8
       "1", // U8
       "2", // U16
       "3", // U32
       "ABC", // Vector<u8>
       "", // Vector<u8>
+      "", // Address
     ];
     backwardsCompatibleAbi = {
       typeParameters: [],
       parameters: [
         new TypeTagBool(),
         new TypeTagBool(),
-        new TypeTagStruct(optionStructTag(new TypeTagVector(new TypeTagU8()))),
-        new TypeTagStruct(optionStructTag(new TypeTagStruct(stringStructTag()))),
-        new TypeTagStruct(optionStructTag(new TypeTagU8())),
         new TypeTagU8(),
         new TypeTagU16(),
         new TypeTagU32(),
         new TypeTagVector(new TypeTagU8()),
         new TypeTagVector(new TypeTagU8()),
+        new TypeTagAddress(),
       ],
     };
   });
@@ -328,14 +322,12 @@ describe("various transaction arguments", () => {
         expect(converted).toEqual([
           new Bool(true),
           new Bool(false),
-          new MoveOption<MoveString>(), // This is supposed to be Vector<U8>, but the type can't be reconstructed easily
-          new MoveOption<MoveString>(),
-          new MoveOption<U8>(),
           new U8(1),
           new U16(2),
           new U32(3),
           MoveVector.U8([65, 66, 67]),
           MoveVector.U8([]),
+          AccountAddress.ZERO,
         ]);
       });
 

--- a/tests/e2e/transaction/transactionArguments.test.ts
+++ b/tests/e2e/transaction/transactionArguments.test.ts
@@ -28,7 +28,6 @@ import {
   TypeTagU8,
   TypeTagU16,
   TypeTagU32,
-  TypeTagAddress,
 } from "../../../src";
 import {
   MAX_U128_BIG_INT,

--- a/tests/e2e/transaction/transactionArguments.test.ts
+++ b/tests/e2e/transaction/transactionArguments.test.ts
@@ -218,7 +218,6 @@ describe("various transaction arguments", () => {
       "3", // U32
       "ABC", // Vector<u8>
       "", // Vector<u8>
-      "", // Address
     ];
     backwardsCompatibleAbi = {
       typeParameters: [],
@@ -230,7 +229,6 @@ describe("various transaction arguments", () => {
         new TypeTagU32(),
         new TypeTagVector(new TypeTagU8()),
         new TypeTagVector(new TypeTagU8()),
-        new TypeTagAddress(),
       ],
     };
   });
@@ -327,7 +325,6 @@ describe("various transaction arguments", () => {
           new U32(3),
           MoveVector.U8([65, 66, 67]),
           MoveVector.U8([]),
-          AccountAddress.ZERO,
         ]);
       });
 


### PR DESCRIPTION
### Description
- Fixes `MoveVector.U8([])` to not error out
- Adds testing for backwards compatible cases
- Adds better handling around `""` for a number input type

### Test Plan
See unit tests

### Related Links
<!-- Please link to any relevant issues or pull requests! -->