### PR TITLE
fix named address in cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - [`Fix`] Keyless transaction simulation now reports gas correctly
-- Fix when there is more than 1 named addresses in cli
+- [`Fix`] Fix cli move commands when multiple names addresses are given
 
 # 1.18.0 (2024-06-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - [`Fix`] Keyless transaction simulation now reports gas correctly
+- Fix when there is more than 1 named addresses in cli
 
 # 1.18.0 (2024-06-03)
 

--- a/src/cli/move.ts
+++ b/src/cli/move.ts
@@ -164,12 +164,12 @@ export class Move {
     let concatenatedNamedAddresses = "";
     let idx = 0;
     namedAddresses.forEach((value, key) => {
-      idx += 1;
       let toAppend = `${key}=${value.toString()}`;
       if (idx < totalNames - 1) {
         toAppend += ",";
       }
       concatenatedNamedAddresses = concatenatedNamedAddresses.concat(toAppend);
+      idx += 1;
     });
     newArgs.push(`"${concatenatedNamedAddresses}"`);
 

--- a/src/cli/move.ts
+++ b/src/cli/move.ts
@@ -161,6 +161,7 @@ export class Move {
 
     newArgs.push("--named-addresses");
 
+    let concatenatedNamedAddresses = "";
     let idx = 0;
     namedAddresses.forEach((value, key) => {
       idx += 1;
@@ -168,8 +169,10 @@ export class Move {
       if (idx < totalNames - 1) {
         toAppend += ",";
       }
-      newArgs.push(toAppend);
+      concatenatedNamedAddresses = concatenatedNamedAddresses.concat(toAppend);
     });
+    newArgs.push(`"${concatenatedNamedAddresses}"`);
+
     return newArgs;
   }
 


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
When there is more than 1 named addresses, they need to surrounded by "".
Here's the cli version
```
OUTPUT=$(aptos move create-object-and-publish-package \
  --skip-fetch-latest-git-deps \
  --package-dir move \
  --address-name launchpad_addr \
  --named-addresses "launchpad_addr=$PUBLISHER_ADDR,minter=$MINTER_ADDR"\
  --profile $PUBLISHER_PROFILE \
  --assume-yes)
```


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->