### PR TITLE
Introduce `AptosObject`  API for all Object queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Introduce `AptosObject` API for all Object queries
+- Add `getObjectData` API function to fetch an object data by the object address
+- [`Breaking`] `GetAccountOwnedObjectsResponse` type renamed to `GetObjectDataQueryResponse`
+
 # 1.19.0 (2024-06-11)
 
 - Add `getFungibleAssetMetadataByCreatorAddress` API function to fetch fungible asset metadata by the creator address

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -8,9 +8,9 @@ import {
   AnyNumber,
   GetAccountCoinsDataResponse,
   GetAccountCollectionsWithOwnedTokenResponse,
-  GetAccountOwnedObjectsResponse,
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
+  GetObjectDataQueryResponse,
   LedgerVersionArg,
   MoveModuleBytecode,
   MoveResource,
@@ -471,8 +471,8 @@ export class Account {
   async getAccountOwnedObjects(args: {
     accountAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
-    options?: PaginationArgs & OrderByArg<GetAccountOwnedObjectsResponse[0]>;
-  }): Promise<GetAccountOwnedObjectsResponse> {
+    options?: PaginationArgs & OrderByArg<GetObjectDataQueryResponse[0]>;
+  }): Promise<GetObjectDataQueryResponse> {
     await waitForIndexerOnVersion({
       config: this.config,
       minimumLedgerVersion: args.minimumLedgerVersion,

--- a/src/api/aptos.ts
+++ b/src/api/aptos.ts
@@ -14,6 +14,7 @@ import { Staking } from "./staking";
 import { Transaction } from "./transaction";
 import { Table } from "./table";
 import { Keyless } from "./keyless";
+import { AptosObject } from "./object";
 
 /**
  * This class is the main entry point into Aptos's
@@ -53,6 +54,8 @@ export class Aptos {
 
   readonly keyless: Keyless;
 
+  readonly object: AptosObject;
+
   constructor(settings?: AptosConfig) {
     this.config = new AptosConfig(settings);
     this.account = new Account(this.config);
@@ -67,6 +70,7 @@ export class Aptos {
     this.transaction = new Transaction(this.config);
     this.table = new Table(this.config);
     this.keyless = new Keyless(this.config);
+    this.object = new AptosObject(this.config);
   }
 }
 
@@ -84,6 +88,7 @@ export interface Aptos
     Keyless,
     Staking,
     Table,
+    AptosObject,
     Omit<Transaction, "build" | "simulate" | "submit" | "batch"> {}
 
 /**
@@ -119,3 +124,4 @@ applyMixin(Aptos, Staking, "staking");
 applyMixin(Aptos, Transaction, "transaction");
 applyMixin(Aptos, Table, "table");
 applyMixin(Aptos, Keyless, "keyless");
+applyMixin(Aptos, AptosObject, "object");

--- a/src/api/object.ts
+++ b/src/api/object.ts
@@ -1,0 +1,43 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { AnyNumber, GetObjectDataQueryResponse, OrderByArg, PaginationArgs } from "../types";
+import { AccountAddressInput } from "../core";
+import { AptosConfig } from "./aptosConfig";
+import { ProcessorType } from "../utils";
+import { waitForIndexerOnVersion } from "./utils";
+import { getObjectData } from "../internal/object";
+
+/**
+ * A class to query all `Object` related queries on Aptos.
+ */
+export class AptosObject {
+  constructor(readonly config: AptosConfig) {}
+
+  /**
+   * Fetch the object data based on the oabject address
+   *
+   * @example
+   * const object = await aptos.getObjectData({objectAddress:"0x123"})
+   *
+   * @param args.objectAddress The object address
+   * @param args.options Configuration options for waitForTransaction
+   *
+   * @returns The object data
+   */
+  async getObjectData(args: {
+    objectAddress: AccountAddressInput;
+    minimumLedgerVersion?: AnyNumber;
+    options?: PaginationArgs & OrderByArg<GetObjectDataQueryResponse[0]>;
+  }): Promise<GetObjectDataQueryResponse> {
+    await waitForIndexerOnVersion({
+      config: this.config,
+      minimumLedgerVersion: args.minimumLedgerVersion,
+      processorType: ProcessorType.OBJECT_PROCESSOR,
+    });
+    return getObjectData({
+      aptosConfig: this.config,
+      ...args,
+    });
+  }
+}

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -18,9 +18,9 @@ import {
   AccountData,
   GetAccountCoinsDataResponse,
   GetAccountCollectionsWithOwnedTokenResponse,
-  GetAccountOwnedObjectsResponse,
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
+  GetObjectDataQueryResponse,
   LedgerVersionArg,
   MoveModuleBytecode,
   MoveResource,
@@ -35,7 +35,7 @@ import {
   GetAccountCoinsCountQuery,
   GetAccountCoinsDataQuery,
   GetAccountCollectionsWithOwnedTokensQuery,
-  GetAccountOwnedObjectsQuery,
+  GetObjectDataQuery,
   GetAccountOwnedTokensFromCollectionQuery,
   GetAccountOwnedTokensQuery,
   GetAccountTokensCountQuery,
@@ -45,7 +45,7 @@ import {
   GetAccountCoinsCount,
   GetAccountCoinsData,
   GetAccountCollectionsWithOwnedTokens,
-  GetAccountOwnedObjects,
+  GetObjectData,
   GetAccountOwnedTokens,
   GetAccountOwnedTokensFromCollection,
   GetAccountTokensCount,
@@ -484,8 +484,8 @@ export async function getAccountCoinsCount(args: {
 export async function getAccountOwnedObjects(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
-  options?: PaginationArgs & OrderByArg<GetAccountOwnedObjectsResponse[0]>;
-}): Promise<GetAccountOwnedObjectsResponse> {
+  options?: PaginationArgs & OrderByArg<GetObjectDataQueryResponse[0]>;
+}): Promise<GetObjectDataQueryResponse> {
   const { aptosConfig, accountAddress, options } = args;
   const address = AccountAddress.from(accountAddress).toStringLong();
 
@@ -493,7 +493,7 @@ export async function getAccountOwnedObjects(args: {
     owner_address: { _eq: address },
   };
   const graphqlQuery = {
-    query: GetAccountOwnedObjects,
+    query: GetObjectData,
     variables: {
       where_condition: whereCondition,
       offset: options?.offset,
@@ -501,7 +501,7 @@ export async function getAccountOwnedObjects(args: {
       order_by: options?.orderBy,
     },
   };
-  const data = await queryIndexer<GetAccountOwnedObjectsQuery>({
+  const data = await queryIndexer<GetObjectDataQuery>({
     aptosConfig,
     query: graphqlQuery,
     originMethod: "getAccountOwnedObjects",

--- a/src/internal/object.ts
+++ b/src/internal/object.ts
@@ -1,0 +1,35 @@
+import { AptosConfig } from "../api/aptosConfig";
+import { AccountAddressInput, AccountAddress } from "../core";
+import { PaginationArgs, OrderByArg, GetObjectDataQueryResponse } from "../types";
+import { GetObjectDataQuery } from "../types/generated/operations";
+import { GetObjectData } from "../types/generated/queries";
+import { queryIndexer } from "./general";
+
+export async function getObjectData(args: {
+  aptosConfig: AptosConfig;
+  objectAddress: AccountAddressInput;
+  options?: PaginationArgs & OrderByArg<GetObjectDataQueryResponse[0]>;
+}): Promise<GetObjectDataQueryResponse> {
+  const { aptosConfig, objectAddress, options } = args;
+  const address = AccountAddress.from(objectAddress).toStringLong();
+
+  const whereCondition: { object_address: { _eq: string } } = {
+    object_address: { _eq: address },
+  };
+  const graphqlQuery = {
+    query: GetObjectData,
+    variables: {
+      where_condition: whereCondition,
+      offset: options?.offset,
+      limit: options?.limit,
+      order_by: options?.orderBy,
+    },
+  };
+  const data = await queryIndexer<GetObjectDataQuery>({
+    aptosConfig,
+    query: graphqlQuery,
+    originMethod: "getObjectData",
+  });
+
+  return data.current_objects;
+}

--- a/src/internal/queries/getObjectData.graphql
+++ b/src/internal/queries/getObjectData.graphql
@@ -1,4 +1,4 @@
-query getAccountOwnedObjects(
+query getObjectData(
   $where_condition: current_objects_bool_exp
   $offset: Int
   $limit: Int

--- a/src/types/generated/operations.ts
+++ b/src/types/generated/operations.ts
@@ -158,25 +158,6 @@ export type GetAccountCollectionsWithOwnedTokensQuery = {
   }>;
 };
 
-export type GetAccountOwnedObjectsQueryVariables = Types.Exact<{
-  where_condition?: Types.InputMaybe<Types.CurrentObjectsBoolExp>;
-  offset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  limit?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  order_by?: Types.InputMaybe<Array<Types.CurrentObjectsOrderBy> | Types.CurrentObjectsOrderBy>;
-}>;
-
-export type GetAccountOwnedObjectsQuery = {
-  current_objects: Array<{
-    allow_ungated_transfer: boolean;
-    state_key_hash: string;
-    owner_address: string;
-    object_address: string;
-    last_transaction_version: any;
-    last_guid_creation_num: any;
-    is_deleted: boolean;
-  }>;
-};
-
 export type GetAccountOwnedTokensQueryVariables = Types.Exact<{
   where_condition: Types.CurrentTokenOwnershipsV2BoolExp;
   offset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
@@ -527,6 +508,25 @@ export type GetNumberOfDelegatorsQueryVariables = Types.Exact<{
 
 export type GetNumberOfDelegatorsQuery = {
   num_active_delegator_per_pool: Array<{ num_active_delegator?: any | null; pool_address?: string | null }>;
+};
+
+export type GetObjectDataQueryVariables = Types.Exact<{
+  where_condition?: Types.InputMaybe<Types.CurrentObjectsBoolExp>;
+  offset?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  limit?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
+  order_by?: Types.InputMaybe<Array<Types.CurrentObjectsOrderBy> | Types.CurrentObjectsOrderBy>;
+}>;
+
+export type GetObjectDataQuery = {
+  current_objects: Array<{
+    allow_ungated_transfer: boolean;
+    state_key_hash: string;
+    owner_address: string;
+    object_address: string;
+    last_transaction_version: any;
+    last_guid_creation_num: any;
+    is_deleted: boolean;
+  }>;
 };
 
 export type GetProcessorStatusQueryVariables = Types.Exact<{

--- a/src/types/generated/queries.ts
+++ b/src/types/generated/queries.ts
@@ -160,24 +160,6 @@ export const GetAccountCollectionsWithOwnedTokens = `
   }
 }
     `;
-export const GetAccountOwnedObjects = `
-    query getAccountOwnedObjects($where_condition: current_objects_bool_exp, $offset: Int, $limit: Int, $order_by: [current_objects_order_by!]) {
-  current_objects(
-    where: $where_condition
-    offset: $offset
-    limit: $limit
-    order_by: $order_by
-  ) {
-    allow_ungated_transfer
-    state_key_hash
-    owner_address
-    object_address
-    last_transaction_version
-    last_guid_creation_num
-    is_deleted
-  }
-}
-    `;
 export const GetAccountOwnedTokens = `
     query getAccountOwnedTokens($where_condition: current_token_ownerships_v2_bool_exp!, $offset: Int, $limit: Int, $order_by: [current_token_ownerships_v2_order_by!]) {
   current_token_ownerships_v2(
@@ -382,6 +364,24 @@ export const GetNumberOfDelegators = `
   }
 }
     `;
+export const GetObjectData = `
+    query getObjectData($where_condition: current_objects_bool_exp, $offset: Int, $limit: Int, $order_by: [current_objects_order_by!]) {
+  current_objects(
+    where: $where_condition
+    offset: $offset
+    limit: $limit
+    order_by: $order_by
+  ) {
+    allow_ungated_transfer
+    state_key_hash
+    owner_address
+    object_address
+    last_transaction_version
+    last_guid_creation_num
+    is_deleted
+  }
+}
+    `;
 export const GetProcessorStatus = `
     query getProcessorStatus($where_condition: processor_status_bool_exp) {
   processor_status(where: $where_condition) {
@@ -541,21 +541,6 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             { ...requestHeaders, ...wrappedRequestHeaders },
           ),
         "getAccountCollectionsWithOwnedTokens",
-        "query",
-        variables,
-      );
-    },
-    getAccountOwnedObjects(
-      variables?: Types.GetAccountOwnedObjectsQueryVariables,
-      requestHeaders?: GraphQLClientRequestHeaders,
-    ): Promise<Types.GetAccountOwnedObjectsQuery> {
-      return withWrapper(
-        (wrappedRequestHeaders) =>
-          client.request<Types.GetAccountOwnedObjectsQuery>(GetAccountOwnedObjects, variables, {
-            ...requestHeaders,
-            ...wrappedRequestHeaders,
-          }),
-        "getAccountOwnedObjects",
         "query",
         variables,
       );
@@ -761,6 +746,21 @@ export function getSdk(client: GraphQLClient, withWrapper: SdkFunctionWrapper = 
             ...wrappedRequestHeaders,
           }),
         "getNumberOfDelegators",
+        "query",
+        variables,
+      );
+    },
+    getObjectData(
+      variables?: Types.GetObjectDataQueryVariables,
+      requestHeaders?: GraphQLClientRequestHeaders,
+    ): Promise<Types.GetObjectDataQuery> {
+      return withWrapper(
+        (wrappedRequestHeaders) =>
+          client.request<Types.GetObjectDataQuery>(GetObjectData, variables, {
+            ...requestHeaders,
+            ...wrappedRequestHeaders,
+          }),
+        "getObjectData",
         "query",
         variables,
       );

--- a/src/types/indexer.ts
+++ b/src/types/indexer.ts
@@ -13,7 +13,7 @@
 
 import {
   GetAccountCoinsDataQuery,
-  GetAccountOwnedObjectsQuery,
+  GetObjectDataQuery,
   GetAccountOwnedTokensQuery,
   GetAccountOwnedTokensFromCollectionQuery,
   GetAccountCollectionsWithOwnedTokensQuery,
@@ -44,7 +44,7 @@ import {
  * These types are used as the return type when calling a sdk api function
  * that calls the function that queries the server (usually under the /api/ folder)
  */
-export type GetAccountOwnedObjectsResponse = GetAccountOwnedObjectsQuery["current_objects"];
+export type GetObjectDataQueryResponse = GetObjectDataQuery["current_objects"];
 
 export type GetAccountOwnedTokensQueryResponse = GetAccountOwnedTokensQuery["current_token_ownerships_v2"];
 

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -64,4 +64,5 @@ export enum ProcessorType {
   // Token V2 processor replaces Token processor (not only for digital assets)
   TOKEN_V2_PROCESSOR = "token_v2_processor",
   USER_TRANSACTION_PROCESSOR = "user_transaction_processor",
+  OBJECT_PROCESSOR = "objects_processor",
 }

--- a/tests/e2e/api/object.test.ts
+++ b/tests/e2e/api/object.test.ts
@@ -1,0 +1,11 @@
+import { getAptosClient } from "../helper";
+
+describe("object", () => {
+  test("it fetches an object data", async () => {
+    const { aptos } = getAptosClient();
+    const object = await aptos.getObjectData({
+      objectAddress: "0x000000000000000000000000000000000000000000000000000000000000000a",
+    });
+    expect(object[0].owner_address).toEqual("0x0000000000000000000000000000000000000000000000000000000000000001");
+  });
+});


### PR DESCRIPTION
### Description
- Introduce `AptosObject` API for all Object queries
- Add `getObjectData` API function to fetch an object data by the object address
- 
### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->