### PR TITLE
[abi] Allow overriding View function ABI with a local version

### DIFF
--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -109,7 +109,7 @@ export async function generateTransactionPayload(
   }
   const { moduleAddress, moduleName, functionName } = getFunctionParts(args.function);
 
-  const functionAbi = await fetchAbi({
+  const functionAbi = await fetchOrUseProvidedAbi({
     key: "entry-function",
     moduleAddress,
     moduleName,
@@ -177,7 +177,7 @@ export function generateTransactionPayloadWithABI(
 export async function generateViewFunctionPayload(args: InputViewFunctionDataWithRemoteABI): Promise<EntryFunction> {
   const { moduleAddress, moduleName, functionName } = getFunctionParts(args.function);
 
-  const functionAbi = await fetchAbi({
+  const functionAbi = await fetchOrUseProvidedAbi({
     key: "view-function",
     moduleAddress,
     moduleName,
@@ -188,7 +188,7 @@ export async function generateViewFunctionPayload(args: InputViewFunctionDataWit
   });
 
   // Fill in the ABI
-  return generateViewFunctionPayloadWithABI({ abi: functionAbi, ...args });
+  return generateViewFunctionPayloadWithABI({ ...args, abi: functionAbi });
 }
 
 export function generateViewFunctionPayloadWithABI(args: InputViewFunctionDataWithABI): EntryFunction {
@@ -567,7 +567,7 @@ export function generateUserTransactionHash(args: InputSubmitTransactionData): s
  * @param abi
  * @param fetch
  */
-async function fetchAbi<T extends FunctionABI>({
+async function fetchOrUseProvidedAbi<T extends FunctionABI>({
   key,
   moduleAddress,
   moduleName,
@@ -584,7 +584,7 @@ async function fetchAbi<T extends FunctionABI>({
   abi?: T;
   fetch: (moduleAddress: string, moduleName: string, functionName: string, aptosConfig: AptosConfig) => Promise<T>;
 }): Promise<T> {
-  if (abi !== undefined) {
+  if (abi !== undefined && abi !== null) {
     return abi;
   }
 


### PR DESCRIPTION
### Description
This doesn't allow skipping the ABI, as it still checks inputted types are the proper types, but it should allow for things like private view functions, and skipping the ABI pull, with the type safety of the ABI.

This ABI check was originally added, because of the move to BCS view functions.  This was the only way to allow for more complex arguments to be parsed, without a significantly complex parser on both the fullnode side and the SDK side

The `undefined` checks tend not to do well, when there are multiple systems that parse from one to the next.  Quite often some pieces will return `null` instead of `undefined`, and we will likely need to do some extra handling of that elsewhere too.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->