### PR TITLE
[api] Add viewJson as a way to migrate from the legacy SDK

### DIFF
--- a/src/api/general.ts
+++ b/src/api/general.ts
@@ -10,7 +10,7 @@ import {
   queryIndexer,
 } from "../internal/general";
 import { getBlockByHeight, getBlockByVersion } from "../internal/transaction";
-import { view } from "../internal/view";
+import { view, viewJson } from "../internal/view";
 import {
   AnyNumber,
   Block,
@@ -22,7 +22,7 @@ import {
   MoveValue,
 } from "../types";
 import { ProcessorType } from "../utils/const";
-import { InputViewFunctionData } from "../transactions";
+import { InputViewFunctionData, InputViewFunctionJsonData } from "../transactions";
 
 /**
  * A class to query all `General` Aptos related queries
@@ -130,6 +130,29 @@ export class General {
     options?: LedgerVersionArg;
   }): Promise<T> {
     return view<T>({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Queries for a Move view function with JSON, this provides compatability with the old `aptos` package
+   * @param args.payload Payload for the view function
+   * @param args.options.ledgerVersion The ledger version to query, if not provided it will get the latest version
+   *
+   * @example
+   * const data = await aptos.view({
+   *  payload: {
+   *   function: "0x1::coin::balance",
+   *   typeArguments: ["0x1::aptos_coin::AptosCoin"],
+   *   functionArguments: [accountAddress.toString()],
+   *  }
+   * })
+   *
+   * @returns an array of Move values
+   */
+  async viewJson<T extends Array<MoveValue>>(args: {
+    payload: InputViewFunctionJsonData;
+    options?: LedgerVersionArg;
+  }): Promise<T> {
+    return viewJson<T>({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/internal/view.ts
+++ b/src/internal/view.ts
@@ -3,7 +3,12 @@
 
 import { LedgerVersionArg, MimeType, MoveValue } from "../types";
 import { AptosConfig } from "../api/aptosConfig";
-import { generateViewFunctionPayload, InputViewFunctionData } from "../transactions";
+import {
+  generateViewFunctionPayload,
+  InputViewFunctionData,
+  InputViewFunctionJsonData,
+  ViewFunctionJsonPayload,
+} from "../transactions";
 import { Serializer } from "../bcs";
 import { postAptosFullNode } from "../client";
 
@@ -29,6 +34,27 @@ export async function view<T extends Array<MoveValue> = Array<MoveValue>>(args: 
     contentType: MimeType.BCS_VIEW_FUNCTION,
     params: { ledger_version: options?.ledgerVersion },
     body: bytes,
+  });
+
+  return data as T;
+}
+
+export async function viewJson<T extends Array<MoveValue> = Array<MoveValue>>(args: {
+  aptosConfig: AptosConfig;
+  payload: InputViewFunctionJsonData;
+  options?: LedgerVersionArg;
+}): Promise<T> {
+  const { aptosConfig, payload, options } = args;
+  const { data } = await postAptosFullNode<ViewFunctionJsonPayload, MoveValue[]>({
+    aptosConfig,
+    originMethod: "viewJson",
+    path: "view",
+    params: { ledger_version: options?.ledgerVersion },
+    body: {
+      function: payload.function,
+      type_arguments: payload.typeArguments ?? [],
+      arguments: payload.functionArguments ?? [],
+    },
   });
 
   return data as T;

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -15,7 +15,7 @@ import {
   TransactionPayloadMultiSig,
   TransactionPayloadScript,
 } from "./instances";
-import { AnyNumber, HexInput, MoveFunctionGenericTypeParam, MoveFunctionId } from "../types";
+import { AnyNumber, HexInput, MoveFunctionGenericTypeParam, MoveFunctionId, MoveStructId, MoveValue } from "../types";
 import { TypeTag } from "./typeTag";
 import { AccountAuthenticator } from "./authenticator/account";
 import { SimpleTransaction } from "./instances/simpleTransaction";
@@ -175,6 +175,24 @@ export type InputViewFunctionData = {
   typeArguments?: Array<TypeArgument>;
   functionArguments?: Array<EntryFunctionArgumentTypes | SimpleEntryFunctionArgumentTypes>;
   abi?: ViewFunctionABI;
+};
+
+/**
+ * The data needed to generate a View Function payload in JSON
+ */
+export type InputViewFunctionJsonData = {
+  function: MoveFunctionId;
+  typeArguments?: Array<MoveStructId>;
+  functionArguments?: Array<MoveValue>;
+};
+
+/**
+ *  Payload sent to the fullnode for a JSON view request
+ */
+export type ViewFunctionJsonPayload = {
+  function: MoveFunctionId;
+  typeArguments: Array<MoveStructId>;
+  functionArguments: Array<MoveValue>;
 };
 
 /**


### PR DESCRIPTION
### Description
This keeps the original behavior from the Legacy SDK but as a different function on the SDK.

### Test Plan
See unit tests

### Related Links
<!-- Please link to any relevant issues or pull requests! -->