### PR TITLE
Add digital asset api queries and modify object api query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - Introduce `AptosObject` API for all Object queries
-- Add `getObjectData` API function to fetch an object data by the object address
+- Add `getObjectDataByObjectAddress` API function to fetch an object data by the object address
 - [`Breaking`] `GetAccountOwnedObjectsResponse` type renamed to `GetObjectDataQueryResponse`
+- Add `getCollectionDataByCreatorAddressAndCollectionName` and `getCollectionDataByCreatorAddress` API queries
+- Add `PaginationArgs` argument to `getCollectionDataByCollectionId` API query
+- Mark `getCollectionData` API query as `@deprecated`
 
 # 1.19.0 (2024-06-11)
 

--- a/src/api/digitalAsset.ts
+++ b/src/api/digitalAsset.ts
@@ -12,7 +12,6 @@ import {
   OrderByArg,
   PaginationArgs,
   TokenStandardArg,
-  WhereArg,
 } from "../types";
 import { AccountAddress, AccountAddressInput } from "../core";
 import { Account } from "../account";
@@ -108,7 +107,10 @@ export class DigitalAsset {
    * can pass an optional `tokenStandard` parameter to query a specific standard
    *
    * @example
-   * const collection = await aptos.getCollectionDataByCreatorAddressAndCollectionName({creatorAddress:"0x123",collectionName:"myCollection"})
+   * const collection = await aptos.getCollectionDataByCreatorAddressAndCollectionName({
+   *   creatorAddress:"0x123",
+   *   collectionName:"myCollection"
+   * })
    *
    * @param args.creatorAddress the address of the collection's creator
    * @param args.collectionName the name of the collection

--- a/src/api/digitalAsset.ts
+++ b/src/api/digitalAsset.ts
@@ -12,6 +12,7 @@ import {
   OrderByArg,
   PaginationArgs,
   TokenStandardArg,
+  WhereArg,
 } from "../types";
 import { AccountAddress, AccountAddressInput } from "../core";
 import { Account } from "../account";
@@ -25,6 +26,8 @@ import {
   freezeDigitalAssetTransferTransaction,
   getCollectionData,
   getCollectionDataByCollectionId,
+  getCollectionDataByCreatorAddress,
+  getCollectionDataByCreatorAddressAndCollectionName,
   getCollectionId,
   getCurrentDigitalAssetOwnership,
   getDigitalAssetActivity,
@@ -55,6 +58,9 @@ export class DigitalAsset {
   constructor(readonly config: AptosConfig) {}
 
   /**
+   * @deprecated use getCollectionDataByCreatorAddressAndCollectionName - this function
+   * will be removed in the next major release
+   *
    * Queries data of a specific collection by the collection creator address and the collection name.
    *
    * If, for some reason, a creator account has 2 collections with the same name in v1 and v2,
@@ -80,7 +86,78 @@ export class DigitalAsset {
       minimumLedgerVersion: args.minimumLedgerVersion,
       processorType: ProcessorType.TOKEN_V2_PROCESSOR,
     });
-    return getCollectionData({ aptosConfig: this.config, ...args });
+
+    const { creatorAddress, collectionName, options } = args;
+    const address = AccountAddress.from(creatorAddress);
+
+    const whereCondition: any = {
+      collection_name: { _eq: collectionName },
+      creator_address: { _eq: address.toStringLong() },
+    };
+    if (options?.tokenStandard) {
+      whereCondition.token_standard = { _eq: options?.tokenStandard ?? "v2" };
+    }
+
+    return getCollectionData({ aptosConfig: this.config, options: { where: whereCondition } });
+  }
+
+  /**
+   * Queries data of a specific collection by the collection creator address and the collection name.
+   *
+   * If, for some reason, a creator account has 2 collections with the same name in v1 and v2,
+   * can pass an optional `tokenStandard` parameter to query a specific standard
+   *
+   * @example
+   * const collection = await aptos.getCollectionDataByCreatorAddressAndCollectionName({creatorAddress:"0x123",collectionName:"myCollection"})
+   *
+   * @param args.creatorAddress the address of the collection's creator
+   * @param args.collectionName the name of the collection
+   * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
+   * @param args.options.tokenStandard the token standard to query
+   * @returns GetCollectionDataResponse response type
+   */
+  async getCollectionDataByCreatorAddressAndCollectionName(args: {
+    creatorAddress: AccountAddressInput;
+    collectionName: string;
+    minimumLedgerVersion?: AnyNumber;
+    options?: TokenStandardArg & PaginationArgs;
+  }): Promise<GetCollectionDataResponse> {
+    await waitForIndexerOnVersion({
+      config: this.config,
+      minimumLedgerVersion: args.minimumLedgerVersion,
+      processorType: ProcessorType.TOKEN_V2_PROCESSOR,
+    });
+
+    return getCollectionDataByCreatorAddressAndCollectionName({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Queries data of a specific collection by the collection creator address and the collection name.
+   *
+   * If, for some reason, a creator account has 2 collections with the same name in v1 and v2,
+   * can pass an optional `tokenStandard` parameter to query a specific standard
+   *
+   * @example
+   * const collection = await aptos.getCollectionDataByCreatorAddressAnd({creatorAddress:"0x123"})
+   *
+   * @param args.creatorAddress the address of the collection's creator
+   * @param args.collectionName the name of the collection
+   * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
+   * @param args.options.tokenStandard the token standard to query
+   * @returns GetCollectionDataResponse response type
+   */
+  async getCollectionDataByCreatorAddress(args: {
+    creatorAddress: AccountAddressInput;
+    minimumLedgerVersion?: AnyNumber;
+    options?: TokenStandardArg & PaginationArgs;
+  }): Promise<GetCollectionDataResponse> {
+    await waitForIndexerOnVersion({
+      config: this.config,
+      minimumLedgerVersion: args.minimumLedgerVersion,
+      processorType: ProcessorType.TOKEN_V2_PROCESSOR,
+    });
+
+    return getCollectionDataByCreatorAddress({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -96,6 +173,7 @@ export class DigitalAsset {
   async getCollectionDataByCollectionId(args: {
     collectionId: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
+    options?: TokenStandardArg & PaginationArgs;
   }): Promise<GetCollectionDataResponse> {
     await waitForIndexerOnVersion({
       config: this.config,

--- a/src/api/object.ts
+++ b/src/api/object.ts
@@ -6,7 +6,7 @@ import { AccountAddressInput } from "../core";
 import { AptosConfig } from "./aptosConfig";
 import { ProcessorType } from "../utils";
 import { waitForIndexerOnVersion } from "./utils";
-import { getObjectData } from "../internal/object";
+import { getObjectDataByObjectAddress } from "../internal/object";
 
 /**
  * A class to query all `Object` related queries on Aptos.
@@ -18,24 +18,24 @@ export class AptosObject {
    * Fetch the object data based on the oabject address
    *
    * @example
-   * const object = await aptos.getObjectData({objectAddress:"0x123"})
+   * const object = await aptos.getObjectDataByObjectAddress({objectAddress:"0x123"})
    *
    * @param args.objectAddress The object address
    * @param args.options Configuration options for waitForTransaction
    *
    * @returns The object data
    */
-  async getObjectData(args: {
+  async getObjectDataByObjectAddress(args: {
     objectAddress: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
     options?: PaginationArgs & OrderByArg<GetObjectDataQueryResponse[0]>;
-  }): Promise<GetObjectDataQueryResponse> {
+  }): Promise<GetObjectDataQueryResponse[0]> {
     await waitForIndexerOnVersion({
       config: this.config,
       minimumLedgerVersion: args.minimumLedgerVersion,
       processorType: ProcessorType.OBJECT_PROCESSOR,
     });
-    return getObjectData({
+    return getObjectDataByObjectAddress({
       aptosConfig: this.config,
       ...args,
     });

--- a/src/internal/object.ts
+++ b/src/internal/object.ts
@@ -1,25 +1,21 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { AccountAddressInput, AccountAddress } from "../core";
-import { PaginationArgs, OrderByArg, GetObjectDataQueryResponse } from "../types";
+import { PaginationArgs, OrderByArg, GetObjectDataQueryResponse, WhereArg } from "../types";
 import { GetObjectDataQuery } from "../types/generated/operations";
 import { GetObjectData } from "../types/generated/queries";
+import { CurrentObjectsBoolExp } from "../types/generated/types";
 import { queryIndexer } from "./general";
 
 export async function getObjectData(args: {
   aptosConfig: AptosConfig;
-  objectAddress: AccountAddressInput;
-  options?: PaginationArgs & OrderByArg<GetObjectDataQueryResponse[0]>;
+  options?: PaginationArgs & OrderByArg<GetObjectDataQueryResponse[0]> & WhereArg<CurrentObjectsBoolExp>;
 }): Promise<GetObjectDataQueryResponse> {
-  const { aptosConfig, objectAddress, options } = args;
-  const address = AccountAddress.from(objectAddress).toStringLong();
+  const { aptosConfig, options } = args;
 
-  const whereCondition: { object_address: { _eq: string } } = {
-    object_address: { _eq: address },
-  };
   const graphqlQuery = {
     query: GetObjectData,
     variables: {
-      where_condition: whereCondition,
+      where_condition: options?.where,
       offset: options?.offset,
       limit: options?.limit,
       order_by: options?.orderBy,
@@ -32,4 +28,18 @@ export async function getObjectData(args: {
   });
 
   return data.current_objects;
+}
+
+export async function getObjectDataByObjectAddress(args: {
+  aptosConfig: AptosConfig;
+  objectAddress: AccountAddressInput;
+  options?: PaginationArgs & OrderByArg<GetObjectDataQueryResponse[0]>;
+}): Promise<GetObjectDataQueryResponse[0]> {
+  const { aptosConfig, objectAddress, options } = args;
+  const address = AccountAddress.from(objectAddress).toStringLong();
+
+  const whereCondition: { object_address: { _eq: string } } = {
+    object_address: { _eq: address },
+  };
+  return (await getObjectData({ aptosConfig, options: { ...options, where: whereCondition } }))[0];
 }

--- a/src/internal/queries/getCollectionData.graphql
+++ b/src/internal/queries/getCollectionData.graphql
@@ -1,7 +1,12 @@
-query getCollectionData(
-  $where_condition: current_collections_v2_bool_exp!
-) {
+query getCollectionData($where_condition: current_collections_v2_bool_exp!) {
   current_collections_v2(where: $where_condition) {
+    uri
+    total_minted_v2
+    token_standard
+    table_handle_v1
+    mutable_uri
+    mutable_description
+    max_supply
     collection_id
     collection_name
     creator_address
@@ -9,12 +14,16 @@ query getCollectionData(
     description
     last_transaction_timestamp
     last_transaction_version
-    max_supply
-    mutable_description
-    mutable_uri
-    table_handle_v1
-    token_standard
-    total_minted_v2
-    uri
+    cdn_asset_uris {
+      cdn_image_uri
+      asset_uri
+      animation_optimizer_retry_count
+      cdn_animation_uri
+      cdn_json_uri
+      image_optimizer_retry_count
+      json_parser_retry_count
+      raw_animation_uri
+      raw_image_uri
+    }
   }
 }

--- a/src/types/generated/operations.ts
+++ b/src/types/generated/operations.ts
@@ -356,6 +356,13 @@ export type GetCollectionDataQueryVariables = Types.Exact<{
 
 export type GetCollectionDataQuery = {
   current_collections_v2: Array<{
+    uri: string;
+    total_minted_v2?: any | null;
+    token_standard: string;
+    table_handle_v1?: string | null;
+    mutable_uri?: boolean | null;
+    mutable_description?: boolean | null;
+    max_supply?: any | null;
     collection_id: string;
     collection_name: string;
     creator_address: string;
@@ -363,13 +370,17 @@ export type GetCollectionDataQuery = {
     description: string;
     last_transaction_timestamp: any;
     last_transaction_version: any;
-    max_supply?: any | null;
-    mutable_description?: boolean | null;
-    mutable_uri?: boolean | null;
-    table_handle_v1?: string | null;
-    token_standard: string;
-    total_minted_v2?: any | null;
-    uri: string;
+    cdn_asset_uris?: {
+      cdn_image_uri?: string | null;
+      asset_uri: string;
+      animation_optimizer_retry_count: number;
+      cdn_animation_uri?: string | null;
+      cdn_json_uri?: string | null;
+      image_optimizer_retry_count: number;
+      json_parser_retry_count: number;
+      raw_animation_uri?: string | null;
+      raw_image_uri?: string | null;
+    } | null;
   }>;
 };
 

--- a/src/types/generated/queries.ts
+++ b/src/types/generated/queries.ts
@@ -228,6 +228,13 @@ export const GetChainTopUserTransactions = `
 export const GetCollectionData = `
     query getCollectionData($where_condition: current_collections_v2_bool_exp!) {
   current_collections_v2(where: $where_condition) {
+    uri
+    total_minted_v2
+    token_standard
+    table_handle_v1
+    mutable_uri
+    mutable_description
+    max_supply
     collection_id
     collection_name
     creator_address
@@ -235,13 +242,17 @@ export const GetCollectionData = `
     description
     last_transaction_timestamp
     last_transaction_version
-    max_supply
-    mutable_description
-    mutable_uri
-    table_handle_v1
-    token_standard
-    total_minted_v2
-    uri
+    cdn_asset_uris {
+      cdn_image_uri
+      asset_uri
+      animation_optimizer_retry_count
+      cdn_animation_uri
+      cdn_json_uri
+      image_optimizer_retry_count
+      json_parser_retry_count
+      raw_animation_uri
+      raw_image_uri
+    }
   }
 }
     `;

--- a/src/types/generated/types.ts
+++ b/src/types/generated/types.ts
@@ -4565,6 +4565,184 @@ export type CurrentTokenPendingClaimsStreamCursorValueInput = {
   token_data_id_hash?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+/** columns and relationships of "current_unified_fungible_asset_balances_to_be_renamed" */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamed = {
+  amount?: Maybe<Scalars["numeric"]["output"]>;
+  asset_type?: Maybe<Scalars["String"]["output"]>;
+  is_frozen: Scalars["Boolean"]["output"];
+  is_primary?: Maybe<Scalars["Boolean"]["output"]>;
+  last_transaction_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["bigint"]["output"]>;
+  /** An object relationship */
+  metadata?: Maybe<FungibleAssetMetadata>;
+  owner_address: Scalars["String"]["output"];
+  storage_id: Scalars["String"]["output"];
+};
+
+/** aggregated selection of "current_unified_fungible_asset_balances_to_be_renamed" */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedAggregate = {
+  aggregate?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedAggregateFields>;
+  nodes: Array<CurrentUnifiedFungibleAssetBalancesToBeRenamed>;
+};
+
+/** aggregate fields of "current_unified_fungible_asset_balances_to_be_renamed" */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedAggregateFields = {
+  avg?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedAvgFields>;
+  count: Scalars["Int"]["output"];
+  max?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedMaxFields>;
+  min?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedMinFields>;
+  stddev?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedStddevFields>;
+  stddev_pop?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedStddevPopFields>;
+  stddev_samp?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedStddevSampFields>;
+  sum?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedSumFields>;
+  var_pop?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedVarPopFields>;
+  var_samp?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedVarSampFields>;
+  variance?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedVarianceFields>;
+};
+
+/** aggregate fields of "current_unified_fungible_asset_balances_to_be_renamed" */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedAggregateFieldsCountArgs = {
+  columns?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedSelectColumn>>;
+  distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
+/** aggregate avg on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedAvgFields = {
+  amount?: Maybe<Scalars["Float"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** Boolean expression to filter rows from the table "current_unified_fungible_asset_balances_to_be_renamed". All fields are combined with a logical 'AND'. */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp = {
+  _and?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp>>;
+  _not?: InputMaybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp>;
+  _or?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp>>;
+  amount?: InputMaybe<NumericComparisonExp>;
+  asset_type?: InputMaybe<StringComparisonExp>;
+  is_frozen?: InputMaybe<BooleanComparisonExp>;
+  is_primary?: InputMaybe<BooleanComparisonExp>;
+  last_transaction_timestamp?: InputMaybe<TimestampComparisonExp>;
+  last_transaction_version?: InputMaybe<BigintComparisonExp>;
+  metadata?: InputMaybe<FungibleAssetMetadataBoolExp>;
+  owner_address?: InputMaybe<StringComparisonExp>;
+  storage_id?: InputMaybe<StringComparisonExp>;
+};
+
+/** aggregate max on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedMaxFields = {
+  amount?: Maybe<Scalars["numeric"]["output"]>;
+  asset_type?: Maybe<Scalars["String"]["output"]>;
+  last_transaction_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["bigint"]["output"]>;
+  owner_address?: Maybe<Scalars["String"]["output"]>;
+  storage_id?: Maybe<Scalars["String"]["output"]>;
+};
+
+/** aggregate min on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedMinFields = {
+  amount?: Maybe<Scalars["numeric"]["output"]>;
+  asset_type?: Maybe<Scalars["String"]["output"]>;
+  last_transaction_timestamp?: Maybe<Scalars["timestamp"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["bigint"]["output"]>;
+  owner_address?: Maybe<Scalars["String"]["output"]>;
+  storage_id?: Maybe<Scalars["String"]["output"]>;
+};
+
+/** Ordering options when selecting data from "current_unified_fungible_asset_balances_to_be_renamed". */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedOrderBy = {
+  amount?: InputMaybe<OrderBy>;
+  asset_type?: InputMaybe<OrderBy>;
+  is_frozen?: InputMaybe<OrderBy>;
+  is_primary?: InputMaybe<OrderBy>;
+  last_transaction_timestamp?: InputMaybe<OrderBy>;
+  last_transaction_version?: InputMaybe<OrderBy>;
+  metadata?: InputMaybe<FungibleAssetMetadataOrderBy>;
+  owner_address?: InputMaybe<OrderBy>;
+  storage_id?: InputMaybe<OrderBy>;
+};
+
+/** select columns of table "current_unified_fungible_asset_balances_to_be_renamed" */
+export enum CurrentUnifiedFungibleAssetBalancesToBeRenamedSelectColumn {
+  /** column name */
+  Amount = "amount",
+  /** column name */
+  AssetType = "asset_type",
+  /** column name */
+  IsFrozen = "is_frozen",
+  /** column name */
+  IsPrimary = "is_primary",
+  /** column name */
+  LastTransactionTimestamp = "last_transaction_timestamp",
+  /** column name */
+  LastTransactionVersion = "last_transaction_version",
+  /** column name */
+  OwnerAddress = "owner_address",
+  /** column name */
+  StorageId = "storage_id",
+}
+
+/** aggregate stddev on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedStddevFields = {
+  amount?: Maybe<Scalars["Float"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate stddev_pop on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedStddevPopFields = {
+  amount?: Maybe<Scalars["Float"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate stddev_samp on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedStddevSampFields = {
+  amount?: Maybe<Scalars["Float"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** Streaming cursor of the table "current_unified_fungible_asset_balances_to_be_renamed" */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedStreamCursorInput = {
+  /** Stream column input with initial value */
+  initial_value: CurrentUnifiedFungibleAssetBalancesToBeRenamedStreamCursorValueInput;
+  /** cursor ordering */
+  ordering?: InputMaybe<CursorOrdering>;
+};
+
+/** Initial value of the column from where the streaming should start */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedStreamCursorValueInput = {
+  amount?: InputMaybe<Scalars["numeric"]["input"]>;
+  asset_type?: InputMaybe<Scalars["String"]["input"]>;
+  is_frozen?: InputMaybe<Scalars["Boolean"]["input"]>;
+  is_primary?: InputMaybe<Scalars["Boolean"]["input"]>;
+  last_transaction_timestamp?: InputMaybe<Scalars["timestamp"]["input"]>;
+  last_transaction_version?: InputMaybe<Scalars["bigint"]["input"]>;
+  owner_address?: InputMaybe<Scalars["String"]["input"]>;
+  storage_id?: InputMaybe<Scalars["String"]["input"]>;
+};
+
+/** aggregate sum on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedSumFields = {
+  amount?: Maybe<Scalars["numeric"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["bigint"]["output"]>;
+};
+
+/** aggregate var_pop on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedVarPopFields = {
+  amount?: Maybe<Scalars["Float"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate var_samp on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedVarSampFields = {
+  amount?: Maybe<Scalars["Float"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+};
+
+/** aggregate variance on columns */
+export type CurrentUnifiedFungibleAssetBalancesToBeRenamedVarianceFields = {
+  amount?: Maybe<Scalars["Float"]["output"]>;
+  last_transaction_version?: Maybe<Scalars["Float"]["output"]>;
+};
+
 /** ordering argument of a cursor */
 export enum CursorOrdering {
   /** ascending ordering of the cursor */
@@ -5636,19 +5814,19 @@ export type LedgerInfosStreamCursorValueInput = {
   chain_id?: InputMaybe<Scalars["bigint"]["input"]>;
 };
 
-/** columns and relationships of "move_resources" */
+/** columns and relationships of "legacy_migration_v1.move_resources" */
 export type MoveResources = {
-  address: Scalars["String"]["output"];
-  transaction_version: Scalars["bigint"]["output"];
+  address?: Maybe<Scalars["String"]["output"]>;
+  transaction_version?: Maybe<Scalars["bigint"]["output"]>;
 };
 
-/** aggregated selection of "move_resources" */
+/** aggregated selection of "legacy_migration_v1.move_resources" */
 export type MoveResourcesAggregate = {
   aggregate?: Maybe<MoveResourcesAggregateFields>;
   nodes: Array<MoveResources>;
 };
 
-/** aggregate fields of "move_resources" */
+/** aggregate fields of "legacy_migration_v1.move_resources" */
 export type MoveResourcesAggregateFields = {
   avg?: Maybe<MoveResourcesAvgFields>;
   count: Scalars["Int"]["output"];
@@ -5663,7 +5841,7 @@ export type MoveResourcesAggregateFields = {
   variance?: Maybe<MoveResourcesVarianceFields>;
 };
 
-/** aggregate fields of "move_resources" */
+/** aggregate fields of "legacy_migration_v1.move_resources" */
 export type MoveResourcesAggregateFieldsCountArgs = {
   columns?: InputMaybe<Array<MoveResourcesSelectColumn>>;
   distinct?: InputMaybe<Scalars["Boolean"]["input"]>;
@@ -5674,7 +5852,7 @@ export type MoveResourcesAvgFields = {
   transaction_version?: Maybe<Scalars["Float"]["output"]>;
 };
 
-/** Boolean expression to filter rows from the table "move_resources". All fields are combined with a logical 'AND'. */
+/** Boolean expression to filter rows from the table "legacy_migration_v1.move_resources". All fields are combined with a logical 'AND'. */
 export type MoveResourcesBoolExp = {
   _and?: InputMaybe<Array<MoveResourcesBoolExp>>;
   _not?: InputMaybe<MoveResourcesBoolExp>;
@@ -5695,13 +5873,13 @@ export type MoveResourcesMinFields = {
   transaction_version?: Maybe<Scalars["bigint"]["output"]>;
 };
 
-/** Ordering options when selecting data from "move_resources". */
+/** Ordering options when selecting data from "legacy_migration_v1.move_resources". */
 export type MoveResourcesOrderBy = {
   address?: InputMaybe<OrderBy>;
   transaction_version?: InputMaybe<OrderBy>;
 };
 
-/** select columns of table "move_resources" */
+/** select columns of table "legacy_migration_v1.move_resources" */
 export enum MoveResourcesSelectColumn {
   /** column name */
   Address = "address",
@@ -7081,6 +7259,12 @@ export type QueryRoot = {
   current_token_pending_claims: Array<CurrentTokenPendingClaims>;
   /** fetch data from the table: "current_token_pending_claims" using primary key columns */
   current_token_pending_claims_by_pk?: Maybe<CurrentTokenPendingClaims>;
+  /** fetch data from the table: "current_unified_fungible_asset_balances_to_be_renamed" */
+  current_unified_fungible_asset_balances_to_be_renamed: Array<CurrentUnifiedFungibleAssetBalancesToBeRenamed>;
+  /** fetch aggregated fields from the table: "current_unified_fungible_asset_balances_to_be_renamed" */
+  current_unified_fungible_asset_balances_to_be_renamed_aggregate: CurrentUnifiedFungibleAssetBalancesToBeRenamedAggregate;
+  /** fetch data from the table: "current_unified_fungible_asset_balances_to_be_renamed" using primary key columns */
+  current_unified_fungible_asset_balances_to_be_renamed_by_pk?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamed>;
   /** An array relationship */
   delegated_staking_activities: Array<DelegatedStakingActivities>;
   /** fetch data from the table: "delegated_staking_activities" using primary key columns */
@@ -7119,9 +7303,9 @@ export type QueryRoot = {
   ledger_infos: Array<LedgerInfos>;
   /** fetch data from the table: "ledger_infos" using primary key columns */
   ledger_infos_by_pk?: Maybe<LedgerInfos>;
-  /** fetch data from the table: "move_resources" */
+  /** fetch data from the table: "legacy_migration_v1.move_resources" */
   move_resources: Array<MoveResources>;
-  /** fetch aggregated fields from the table: "move_resources" */
+  /** fetch aggregated fields from the table: "legacy_migration_v1.move_resources" */
   move_resources_aggregate: MoveResourcesAggregate;
   /** fetch data from the table: "nft_marketplace_v2.current_nft_marketplace_auctions" */
   nft_marketplace_v2_current_nft_marketplace_auctions: Array<NftMarketplaceV2CurrentNftMarketplaceAuctions>;
@@ -7626,6 +7810,26 @@ export type QueryRootCurrentTokenPendingClaimsByPkArgs = {
   property_version: Scalars["numeric"]["input"];
   to_address: Scalars["String"]["input"];
   token_data_id_hash: Scalars["String"]["input"];
+};
+
+export type QueryRootCurrentUnifiedFungibleAssetBalancesToBeRenamedArgs = {
+  distinct_on?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedOrderBy>>;
+  where?: InputMaybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp>;
+};
+
+export type QueryRootCurrentUnifiedFungibleAssetBalancesToBeRenamedAggregateArgs = {
+  distinct_on?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedOrderBy>>;
+  where?: InputMaybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp>;
+};
+
+export type QueryRootCurrentUnifiedFungibleAssetBalancesToBeRenamedByPkArgs = {
+  storage_id: Scalars["String"]["input"];
 };
 
 export type QueryRootDelegatedStakingActivitiesArgs = {
@@ -8318,6 +8522,14 @@ export type SubscriptionRoot = {
   current_token_pending_claims_by_pk?: Maybe<CurrentTokenPendingClaims>;
   /** fetch data from the table in a streaming manner: "current_token_pending_claims" */
   current_token_pending_claims_stream: Array<CurrentTokenPendingClaims>;
+  /** fetch data from the table: "current_unified_fungible_asset_balances_to_be_renamed" */
+  current_unified_fungible_asset_balances_to_be_renamed: Array<CurrentUnifiedFungibleAssetBalancesToBeRenamed>;
+  /** fetch aggregated fields from the table: "current_unified_fungible_asset_balances_to_be_renamed" */
+  current_unified_fungible_asset_balances_to_be_renamed_aggregate: CurrentUnifiedFungibleAssetBalancesToBeRenamedAggregate;
+  /** fetch data from the table: "current_unified_fungible_asset_balances_to_be_renamed" using primary key columns */
+  current_unified_fungible_asset_balances_to_be_renamed_by_pk?: Maybe<CurrentUnifiedFungibleAssetBalancesToBeRenamed>;
+  /** fetch data from the table in a streaming manner: "current_unified_fungible_asset_balances_to_be_renamed" */
+  current_unified_fungible_asset_balances_to_be_renamed_stream: Array<CurrentUnifiedFungibleAssetBalancesToBeRenamed>;
   /** An array relationship */
   delegated_staking_activities: Array<DelegatedStakingActivities>;
   /** fetch data from the table: "delegated_staking_activities" using primary key columns */
@@ -8374,11 +8586,11 @@ export type SubscriptionRoot = {
   ledger_infos_by_pk?: Maybe<LedgerInfos>;
   /** fetch data from the table in a streaming manner: "ledger_infos" */
   ledger_infos_stream: Array<LedgerInfos>;
-  /** fetch data from the table: "move_resources" */
+  /** fetch data from the table: "legacy_migration_v1.move_resources" */
   move_resources: Array<MoveResources>;
-  /** fetch aggregated fields from the table: "move_resources" */
+  /** fetch aggregated fields from the table: "legacy_migration_v1.move_resources" */
   move_resources_aggregate: MoveResourcesAggregate;
-  /** fetch data from the table in a streaming manner: "move_resources" */
+  /** fetch data from the table in a streaming manner: "legacy_migration_v1.move_resources" */
   move_resources_stream: Array<MoveResources>;
   /** fetch data from the table: "nft_marketplace_v2.current_nft_marketplace_auctions" */
   nft_marketplace_v2_current_nft_marketplace_auctions: Array<NftMarketplaceV2CurrentNftMarketplaceAuctions>;
@@ -9093,6 +9305,32 @@ export type SubscriptionRootCurrentTokenPendingClaimsStreamArgs = {
   batch_size: Scalars["Int"]["input"];
   cursor: Array<InputMaybe<CurrentTokenPendingClaimsStreamCursorInput>>;
   where?: InputMaybe<CurrentTokenPendingClaimsBoolExp>;
+};
+
+export type SubscriptionRootCurrentUnifiedFungibleAssetBalancesToBeRenamedArgs = {
+  distinct_on?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedOrderBy>>;
+  where?: InputMaybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp>;
+};
+
+export type SubscriptionRootCurrentUnifiedFungibleAssetBalancesToBeRenamedAggregateArgs = {
+  distinct_on?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedSelectColumn>>;
+  limit?: InputMaybe<Scalars["Int"]["input"]>;
+  offset?: InputMaybe<Scalars["Int"]["input"]>;
+  order_by?: InputMaybe<Array<CurrentUnifiedFungibleAssetBalancesToBeRenamedOrderBy>>;
+  where?: InputMaybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp>;
+};
+
+export type SubscriptionRootCurrentUnifiedFungibleAssetBalancesToBeRenamedByPkArgs = {
+  storage_id: Scalars["String"]["input"];
+};
+
+export type SubscriptionRootCurrentUnifiedFungibleAssetBalancesToBeRenamedStreamArgs = {
+  batch_size: Scalars["Int"]["input"];
+  cursor: Array<InputMaybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedStreamCursorInput>>;
+  where?: InputMaybe<CurrentUnifiedFungibleAssetBalancesToBeRenamedBoolExp>;
 };
 
 export type SubscriptionRootDelegatedStakingActivitiesArgs = {

--- a/tests/e2e/api/digitalAsset.test.ts
+++ b/tests/e2e/api/digitalAsset.test.ts
@@ -118,6 +118,15 @@ describe("DigitalAsset", () => {
     expect(data.mutable_uri).toEqual(true);
     expect(data.token_standard).toEqual("v2");
 
+    const collectionDataByCreatorAddressAndCollectionName =
+      await aptos.getCollectionDataByCreatorAddressAndCollectionName({ collectionName, creatorAddress });
+    expect(data.collection_name).toEqual(collectionDataByCreatorAddressAndCollectionName.collection_name);
+
+    const collectionDataByCreatorAddress = await aptos.getCollectionDataByCreatorAddress({
+      creatorAddress: creatorAddress,
+    });
+    expect(data.collection_name).toEqual(collectionDataByCreatorAddress.collection_name);
+
     expect(data).toHaveProperty("max_supply");
     expect(data).toHaveProperty("collection_id");
     expect(data).toHaveProperty("last_transaction_timestamp");
@@ -127,6 +136,9 @@ describe("DigitalAsset", () => {
 
     const address = await aptos.getCollectionId({ collectionName, creatorAddress });
     expect(address).toEqual(data.collection_id);
+
+    const collectionDataByCollectionId = await aptos.getCollectionDataByCollectionId({ collectionId: address });
+    expect(address).toEqual(collectionDataByCollectionId.collection_id);
   });
 
   test("it freezes transfer ability", async () => {

--- a/tests/e2e/api/digitalAsset.test.ts
+++ b/tests/e2e/api/digitalAsset.test.ts
@@ -123,7 +123,7 @@ describe("DigitalAsset", () => {
     expect(data.collection_name).toEqual(collectionDataByCreatorAddressAndCollectionName.collection_name);
 
     const collectionDataByCreatorAddress = await aptos.getCollectionDataByCreatorAddress({
-      creatorAddress: creatorAddress,
+      creatorAddress,
     });
     expect(data.collection_name).toEqual(collectionDataByCreatorAddress.collection_name);
 

--- a/tests/e2e/api/object.test.ts
+++ b/tests/e2e/api/object.test.ts
@@ -3,9 +3,9 @@ import { getAptosClient } from "../helper";
 describe("object", () => {
   test("it fetches an object data", async () => {
     const { aptos } = getAptosClient();
-    const object = await aptos.getObjectData({
+    const object = await aptos.getObjectDataByObjectAddress({
       objectAddress: "0x000000000000000000000000000000000000000000000000000000000000000a",
     });
-    expect(object[0].owner_address).toEqual("0x0000000000000000000000000000000000000000000000000000000000000001");
+    expect(object.owner_address).toEqual("0x0000000000000000000000000000000000000000000000000000000000000001");
   });
 });


### PR DESCRIPTION
### Description
- Add `getCollectionDataByCreatorAddressAndCollectionName` and `getCollectionDataByCreatorAddress` API queries
- Add `PaginationArgs` argument to `getCollectionDataByCollectionId` API query
- Mark `getCollectionData` API query as `@deprecated`
- Rename `getObjectData` query to `getObjectDataByObjectAddress` (hasn't release yet)

### Test Plan
testa are passing - can see no breaking changes

### Related Links
