### PR TITLE
[fix] getAccountCollectionsWithOwnedTokens to remove amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Introduce `AptosObject` API for all Object queries
 - Add `getObjectData` API function to fetch an object data by the object address
 - [`Breaking`] `GetAccountOwnedObjectsResponse` type renamed to `GetObjectDataQueryResponse`
+- [`Fix`] `getAccountCollectionsWithOwnedTokens` no longer uses amount query
 
 # 1.19.0 (2024-06-11)
 

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -347,11 +347,9 @@ export async function getAccountCollectionsWithOwnedTokens(args: {
 
   const whereCondition: {
     owner_address: { _eq: string };
-    amount: { _gt: number };
     current_collection?: { token_standard: { _eq: string } };
   } = {
     owner_address: { _eq: address },
-    amount: { _gt: 0 },
   };
 
   if (options?.tokenStandard) {


### PR DESCRIPTION

### Description
Amount isn't necessary here, so it's been removed

This was reported https://github.com/aptos-labs/aptos-ts-sdk/issues/434

### Test Plan
Tested manually with that code associated there.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->