### PR TITLE
Fix publish scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,7 @@ This command gives us a preview of what we will be releasing to NPM, make sure i
 Then, when we are ready to publish to NPM, simply run:
 
 ```bash
-pnpm run publish
+npm publish
 ```
 
-This command will build the SDK and run the publish command to publish it to NPM registry
+This command will build the SDK and publish it to NPM registry

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "scripts": {
     "build:clean": "rm -rf dist",
     "build": "pnpm build:clean && tsup",
-    "publish": "pnpm run build && npm publish",
+    "prepublishOnly": "pnpm run build",
     "_fmt": "prettier 'src/**/*.ts' 'tests/**/*.ts' 'examples/**/*.js' 'examples/**/*.ts' '.eslintrc.js'",
     "fmt": "pnpm _fmt --write",
     "lint": "eslint 'src/**/*.ts' 'tests/**/*.ts' 'examples/**/*.ts'",


### PR DESCRIPTION
### Description
Weird endless loop bug with https://github.com/aptos-labs/aptos-ts-sdk/pull/448 when running `npm publish --dry-run`, fixing it to only run the built-in `prepublishOnly` npm script to build the SDK before running `npm publish --dry-run` or `npm publish`. Updated the CONTRIBUTING guide also.

Will look at using `pnpm` only later

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->