### PR TITLE
Implement a base version of verifySignature for KeylessAccounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Adds a base implementation of verify signature for Keyless Accounts
+
 # 1.22.2 (2024-06-26)
 
 - Release an updated build to npm due to issues with latest release

--- a/src/account/KeylessAccount.ts
+++ b/src/account/KeylessAccount.ts
@@ -268,10 +268,26 @@ export class KeylessAccount extends Serializable implements Account {
     const signMess = txnAndProof.hash();
     return this.sign(signMess);
   }
-
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars, class-methods-use-this
-  verifySignature(args: { message: HexInput; signature: Signature }): boolean {
-    throw new Error("Not implemented");
+  /**
+   * Note - This function is currently incomplete and should only be used to verify ownership of the KeylessAccount
+   * 
+   * Verifies a signature given the message.
+   * 
+   * TODO: Groth16 proof verification
+   * 
+   * @param args.message the message that was signed.
+   * @param args.signature the KeylessSignature to verify 
+   * @returns boolean
+   */
+  verifySignature(args: { message: HexInput; signature: KeylessSignature }): boolean {
+    const { message, signature } = args;
+    if (this.isExpired()) {
+      return false;
+    }
+    if (!this.ephemeralKeyPair.getPublicKey().verifySignature({ message, signature: signature.ephemeralSignature })) {
+      return false;
+    }
+    return true;
   }
 
   static fromBytes(bytes: Uint8Array): KeylessAccount {

--- a/src/account/KeylessAccount.ts
+++ b/src/account/KeylessAccount.ts
@@ -267,6 +267,7 @@ export class KeylessAccount extends Serializable implements Account {
     const signMess = txnAndProof.hash();
     return this.sign(signMess);
   }
+
   /**
    * Note - This function is currently incomplete and should only be used to verify ownership of the KeylessAccount
    *

--- a/src/account/KeylessAccount.ts
+++ b/src/account/KeylessAccount.ts
@@ -11,7 +11,6 @@ import {
   KeylessPublicKey,
   KeylessSignature,
   EphemeralCertificate,
-  Signature,
   ZeroKnowledgeSig,
   ZkProof,
 } from "../core/crypto";
@@ -270,13 +269,13 @@ export class KeylessAccount extends Serializable implements Account {
   }
   /**
    * Note - This function is currently incomplete and should only be used to verify ownership of the KeylessAccount
-   * 
+   *
    * Verifies a signature given the message.
-   * 
+   *
    * TODO: Groth16 proof verification
-   * 
+   *
    * @param args.message the message that was signed.
-   * @param args.signature the KeylessSignature to verify 
+   * @param args.signature the KeylessSignature to verify
    * @returns boolean
    */
   verifySignature(args: { message: HexInput; signature: KeylessSignature }): boolean {

--- a/src/core/crypto/ephemeral.ts
+++ b/src/core/crypto/ephemeral.ts
@@ -52,7 +52,7 @@ export class EphemeralPublicKey extends PublicKey {
    */
   verifySignature(args: { message: HexInput; signature: EphemeralSignature }): boolean {
     const { message, signature } = args;
-    return this.publicKey.verifySignature({ message, signature });
+    return this.publicKey.verifySignature({ message, signature: signature.signature });
   }
 
   serialize(serializer: Serializer): void {

--- a/tests/e2e/api/keyless.test.ts
+++ b/tests/e2e/api/keyless.test.ts
@@ -204,6 +204,19 @@ describe("keyless api", () => {
     );
 
     test(
+      "keyless account verifies signature for arbitrary message correctly",
+      async () => {
+        // Select a random test token.  Using the same one may encounter rate limits
+        const jwt = TEST_JWT_TOKENS[Math.floor(Math.random() * TEST_JWT_TOKENS.length)];
+        const sender = await aptos.deriveKeylessAccount({ jwt, ephemeralKeyPair });
+        const message = "hello world"
+        const signature = sender.sign(message);
+        expect(sender.verifySignature({message, signature})).toBe(true);
+      },
+      KEYLESS_TEST_TIMEOUT,
+    );
+
+    test(
       "serializes and deserializes",
       async () => {
         // Select a random test token.  Using the same one may encounter rate limits

--- a/tests/e2e/api/keyless.test.ts
+++ b/tests/e2e/api/keyless.test.ts
@@ -209,9 +209,9 @@ describe("keyless api", () => {
         // Select a random test token.  Using the same one may encounter rate limits
         const jwt = TEST_JWT_TOKENS[Math.floor(Math.random() * TEST_JWT_TOKENS.length)];
         const sender = await aptos.deriveKeylessAccount({ jwt, ephemeralKeyPair });
-        const message = "hello world"
+        const message = "hello world";
         const signature = sender.sign(message);
-        expect(sender.verifySignature({message, signature})).toBe(true);
+        expect(sender.verifySignature({ message, signature })).toBe(true);
       },
       KEYLESS_TEST_TIMEOUT,
     );


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
This adds very basic signature verification in order to enable sign and verify for the wallet adapter.  This implementation is incomplete as it only checks the ephemeral signature.  

Full verification of the proof and training wheels will be done later as it requires querying the chain and the right bn254 library to deserialize the g1/g2 points of the VK.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Added e2e test

### Related Links
<!-- Please link to any relevant issues or pull requests! -->