### PR TITLE
[fungibleAssets] Ensure query for coin balances uses correct query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- [`Fix`] Support migrated coins in coin balance lookup indexer queries
+
 # 1.22.2 (2024-06-26)
 
 - Release an updated build to npm due to issues with latest release

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -439,12 +439,15 @@ export class Account {
    *
    * @param args.accountAddress The account address we want to get the total count for
    * @param args.coinType The coin type to query
+   * @param args.faMetadataAddress The fungible asset metadata address to query.
+   *        Note: coinType will automatically fill this in if not provided when migrated to fungible assets
    * @param args.minimumLedgerVersion Optional ledger version to sync up to, before querying
    * @returns Current amount of account's coin
    */
   async getAccountCoinAmount(args: {
     accountAddress: AccountAddressInput;
-    coinType: MoveStructId;
+    coinType?: MoveStructId;
+    faMetadataAddress?: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
   }): Promise<number> {
     await waitForIndexerOnVersion({

--- a/src/core/accountAddress.ts
+++ b/src/core/accountAddress.ts
@@ -65,6 +65,8 @@ export class AccountAddress extends Serializable implements TransactionArgument 
 
   static FOUR: AccountAddress = AccountAddress.from("0x4");
 
+  static A: AccountAddress = AccountAddress.from("0xA");
+
   /**
    * Creates an instance of AccountAddress from a Uint8Array.
    *


### PR DESCRIPTION
### Description
For migrated coins, they need to query both the address and the coin type associated.


### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->