### PR TITLE
ensure that errors have a meaningful message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - [`Fix`] Support migrated coins in coin balance lookup indexer queries
 - Add support for BlockEpilogueTransaction
 - [`Fix`] Fixes a bug with ANS not returning subdomains with an expiration policy of 1 when the subdomain is expired but the parent domain is not.
+- Marked AptosApiError.constructor function as @internal and changed its signature
+- AptosApiError.message contains a more descriptive and more detailed error message to ease troubleshooting
 
 # 1.22.2 (2024-06-26)
 

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -8,20 +8,6 @@ import { AnyNumber, AptosRequest, Client, ClientRequest, ClientResponse, MimeTyp
 import { AptosApiType } from "../utils";
 
 /**
- * Meaningful errors map
- */
-const errors: Record<number, string> = {
-  400: "Bad Request",
-  401: "Unauthorized",
-  403: "Forbidden",
-  404: "Not Found",
-  429: "Too Many Requests",
-  500: "Internal Server Error",
-  502: "Bad Gateway",
-  503: "Service Unavailable",
-};
-
-/**
  * Given a url and method, sends the request with axios and
  * returns the response.
  */
@@ -58,71 +44,58 @@ export async function request<Req, Res>(options: ClientRequest<Req>, client: Cli
 /**
  * The main function to use when doing an API request.
  *
- * @param options AptosRequest
+ * @param aptosRequestOpts AptosRequest
  * @param aptosConfig The config information for the SDK client instance
  * @returns the response or AptosApiError
  */
 export async function aptosRequest<Req extends {}, Res extends {}>(
-  options: AptosRequest,
+  aptosRequestOpts: AptosRequest,
   aptosConfig: AptosConfig,
   apiType: AptosApiType,
 ): Promise<AptosResponse<Req, Res>> {
-  const { url, path } = options;
+  const { url, path } = aptosRequestOpts;
   const fullUrl = path ? `${url}/${path}` : url;
-  const response = await request<Req, Res>({ ...options, url: fullUrl }, aptosConfig.client);
+  const clientResponse = await request<Req, Res>({ ...aptosRequestOpts, url: fullUrl }, aptosConfig.client);
 
-  const result: AptosResponse<Req, Res> = {
-    status: response.status,
-    statusText: response.statusText!,
-    data: response.data,
-    headers: response.headers,
-    config: response.config,
-    request: response.request,
+  const aptosResponse: AptosResponse<Req, Res> = {
+    status: clientResponse.status,
+    statusText: clientResponse.statusText!,
+    data: clientResponse.data,
+    headers: clientResponse.headers,
+    config: clientResponse.config,
+    request: clientResponse.request,
     url: fullUrl,
   };
 
   // Handle case for `Unauthorized` error (i.e API_KEY error)
-  if (result.status === 401) {
-    throw new AptosApiError(options, result, `Error: ${result.data}`);
+  if (aptosResponse.status === 401) {
+    throw new AptosApiError({ apiType, aptosRequest: aptosRequestOpts, aptosResponse });
   }
 
   // to support both fullnode and indexer responses,
   // check if it is an indexer query, and adjust response.data
   if (apiType === AptosApiType.INDEXER) {
-    const indexerResponse = result.data as any;
+    const indexerResponse = aptosResponse.data as any;
     // Handle Indexer general errors
     if (indexerResponse.errors) {
-      throw new AptosApiError(
-        options,
-        result,
-        `Indexer error: ${indexerResponse.errors[0].message}` ??
-          `Indexer unhandled Error ${response.status} : ${response.statusText}`,
-      );
+      throw new AptosApiError({
+        apiType,
+        aptosRequest: aptosRequestOpts,
+        aptosResponse,
+      });
     }
-    result.data = indexerResponse.data as Res;
+    aptosResponse.data = indexerResponse.data as Res;
   } else if (apiType === AptosApiType.PEPPER || apiType === AptosApiType.PROVER) {
-    if (result.status >= 400) {
-      throw new AptosApiError(options, result, `${response.data}`);
+    if (aptosResponse.status >= 400) {
+      throw new AptosApiError({ apiType, aptosRequest: aptosRequestOpts, aptosResponse });
     }
   }
 
-  if (result.status >= 200 && result.status < 300) {
-    return result;
-  }
-
-  let errorMessage: string;
-
-  if (result && result.data && "message" in result.data && "error_code" in result.data) {
-    errorMessage = JSON.stringify(result.data);
-  } else if (result.status in errors) {
-    // If it's not an API type, it must come form infra, these are prehandled
-    errorMessage = errors[result.status];
-  } else {
-    // Everything else is unhandled
-    errorMessage = `Unhandled Error ${result.status} : ${result.statusText}`;
+  if (aptosResponse.status >= 200 && aptosResponse.status < 300) {
+    return aptosResponse;
   }
 
   // We have to explicitly check for all request types, because if the error is a non-indexer error, but
   // comes from an indexer request (e.g. 404), we'll need to mention it appropriately
-  throw new AptosApiError(options, result, `${apiType} error: ${errorMessage}`);
+  throw new AptosApiError({ apiType, aptosRequest: aptosRequestOpts, aptosResponse });
 }

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { AptosRequest } from "../types";
+import { AptosApiType } from "../utils/const.js";
 
 /**
  * The API response type
@@ -24,6 +25,12 @@ export interface AptosResponse<Req, Res> {
   request?: Req;
 }
 
+type AptosApiErrorOpts = {
+  apiType: AptosApiType;
+  aptosRequest: AptosRequest;
+  aptosResponse: AptosResponse<any, any>;
+};
+
 /**
  * The type returned from an API error
  *
@@ -45,14 +52,60 @@ export class AptosApiError extends Error {
 
   readonly request: AptosRequest;
 
-  constructor(request: AptosRequest, response: AptosResponse<any, any>, message: string) {
-    super(message);
+  /** @internal this constructor is for sdk internal use - do not instantiate outside of the SDK codebase */
+  constructor({ apiType, aptosRequest, aptosResponse }: AptosApiErrorOpts) {
+    super(deriveErrorMessage({ apiType, aptosRequest, aptosResponse }));
 
     this.name = "AptosApiError";
-    this.url = response.url;
-    this.status = response.status;
-    this.statusText = response.statusText;
-    this.data = response.data;
-    this.request = request;
+    this.url = aptosResponse.url;
+    this.status = aptosResponse.status;
+    this.statusText = aptosResponse.statusText;
+    this.data = aptosResponse.data;
+    this.request = aptosRequest;
   }
+}
+
+function deriveErrorMessage({ apiType, aptosRequest, aptosResponse }: AptosApiErrorOpts): string {
+  // extract the W3C trace_id from the response headers if it exists. Some services set this in the response and it's useful for debugging.
+  // See https://www.w3.org/TR/trace-context/#relationship-between-the-headers .
+  const traceId = aptosResponse.headers?.traceparent?.split("-")[1];
+  const traceIdString = traceId ? `(trace_id:${traceId}) ` : "";
+
+  const errorPrelude: string = `Request to [${apiType}]: ${aptosRequest.method} ${
+    aptosResponse.url ?? aptosRequest.url
+  } ${traceIdString}failed with`;
+
+  // handle graphql responses from indexer api and extract the error message of the first error
+  if (apiType === AptosApiType.INDEXER && aptosResponse.data?.errors?.[0]?.message != null) {
+    return `${errorPrelude}: ${aptosResponse.data.errors[0].message}`;
+  }
+
+  // Received well-known structured error response body - simply serialize and return it.
+  // We don't need http status codes etc. in this case.
+  if (aptosResponse.data?.message != null && aptosResponse.data?.error_code != null) {
+    return `${errorPrelude}: ${JSON.stringify(aptosResponse.data)}`;
+  }
+
+  // This is the generic/catch-all case. We received some response from the API but it doesn't appear to be a well-known structure.
+  // We print http status codes and the response body (after some trimming),
+  // in the hope that this gives enough context what went wrong without printing overly huge messages.
+  return `${errorPrelude} status: ${aptosResponse.statusText}(code:${
+    aptosResponse.status
+  }) and response body: ${serializeAnyPayloadForErrorMessage(aptosResponse.data)}`;
+}
+
+const SERIALIZED_PAYLOAD_TRIM_TO_MAX_LENGTH = 400;
+
+// this function accepts a payload of any type (probably an object) and serializes it to a string
+// Since we don't know the type or size of the payload and we don't want to add a huge object in full to the error message
+// we limit the to the first 200 and last 200 characters of the serialized payload and put a "..." in the middle.
+function serializeAnyPayloadForErrorMessage(payload: any): string {
+  const serializedPayload = JSON.stringify(payload);
+  if (serializedPayload.length <= SERIALIZED_PAYLOAD_TRIM_TO_MAX_LENGTH) {
+    return serializedPayload;
+  }
+  return `truncated(original_size:${serializedPayload.length}): ${serializedPayload.slice(
+    0,
+    SERIALIZED_PAYLOAD_TRIM_TO_MAX_LENGTH / 2,
+  )}...${serializedPayload.slice(-SERIALIZED_PAYLOAD_TRIM_TO_MAX_LENGTH / 2)}`;
 }

--- a/tests/unit/__snapshots__/client.test.ts.snap
+++ b/tests/unit/__snapshots__/client.test.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AptosApiError should generate pretty error messages 1`] = `"Request to [Pepper]: POST http://blabla.com/my/api:8080 failed with status: Bad Request(code:400) and response body: {"error":"something went wrong"}"`;
+
+exports[`AptosApiError should generate pretty error messages 2`] = `"Request to [Indexer]: POST http://blabla.com/my/api:8080 failed with: Your graphql query is invalid."`;
+
+exports[`AptosApiError should generate pretty error messages 3`] = `"Request to [Indexer]: POST http://blabla.com/my/api:8080 (trace_id:4312e4b208ab6749e42fc534e8590424) failed with status: OK(code:200) and response body: truncated(original_size:973): {"foo":"bar","bar":"baz","nested":{"asssdf":"asdf","asdf":["asdfadsafds","Asdfadafs"],"assssdf":"asdf","afsdf":["asdfadsafds","Asdfadafs"],"assassdf":"asdf","asasfdssdf":"asdf","asdff":["asdfadsafds",...dafsasfdssdf":"asdf","asadsfasdfdf":["asdfadsafds","Asdfadafs"],"assasdfadfssdf":"asdf","assadsfafdsfddf":["asdfadsaasfdfds","Asdfadafs"],"asdadffasfssdf":"asdf","asdfss":["asdfadsafds","Asdfadafs"]}}"`;

--- a/tests/unit/client.test.ts
+++ b/tests/unit/client.test.ts
@@ -1,0 +1,102 @@
+import { AptosApiType } from "../../src/utils/const.js";
+import { AptosApiError } from "../../src/client/types.js";
+
+describe(AptosApiError.name, () => {
+  it("should generate pretty error messages", () => {
+    const err = new AptosApiError({
+      apiType: AptosApiType.PEPPER,
+      aptosRequest: {
+        url: "http://blabla.com/my/api:8080",
+        method: "POST",
+      },
+      aptosResponse: {
+        data: { error: "something went wrong" },
+        status: 400,
+        statusText: "Bad Request",
+        url: "http://blabla.com/my/api:8080",
+        headers: {},
+      },
+    });
+
+    expect(err.message).toMatchSnapshot();
+
+    const err2 = new AptosApiError({
+      apiType: AptosApiType.INDEXER,
+      aptosRequest: {
+        url: "http://blabla.com/my/api:8080",
+        method: "POST",
+      },
+      aptosResponse: {
+        data: {
+          data: null,
+          errors: [
+            {
+              message: "Your graphql query is invalid.",
+            },
+          ],
+        },
+        status: 200,
+        statusText: "OK",
+        url: "http://blabla.com/my/api:8080",
+        headers: {},
+      },
+    });
+
+    expect(err2.message).toMatchSnapshot();
+
+    const err3 = new AptosApiError({
+      apiType: AptosApiType.INDEXER,
+      aptosRequest: {
+        url: "http://blabla.com/my/api:8080",
+        method: "POST",
+      },
+      aptosResponse: {
+        data: {
+          // some kinda large response payload
+          foo: "bar",
+          bar: "baz",
+          nested: {
+            asssdf: "asdf",
+            asdf: ["asdfadsafds", "Asdfadafs"],
+            assssdf: "asdf",
+            afsdf: ["asdfadsafds", "Asdfadafs"],
+            assassdf: "asdf",
+            asasfdssdf: "asdf",
+            asdff: ["asdfadsafds", "Asdfadafs"],
+            assfsdf: "asdf",
+            assfddf: ["asdfadsaasfdfds", "Asdfadafs"],
+            asdfssdf: "asdf",
+            asasdfdf: ["asdfadsafds", "Asdfadafs"],
+            a2sdf: ["asdfadsafds", "Asdfadafs"],
+            a2ssssdf: "asdf",
+            ccasdfasdfsaasdf: ["asdfadsafds", "Asdfadafs"],
+            cassssdf: "asdf",
+            caasasfdssdf: "asdf",
+            assdf: ["asdfadsafds", "Asdfadafs"],
+            assafadsfsssdf: "asdf",
+            asssasadfsfddf: ["asdfadsaasfdfds", "Asdfadafs"],
+            asfdfssdf: "asdf",
+            asaasdfsdfdf: ["asdfadsafds", "Asdfadafs"],
+            afsasdfadfdf: ["asdfadsafds", "Asdfadafs"],
+            assasdfsafdssdf: "asdf",
+            asfdf: ["asdfadsafds", "Asdfadafs"],
+            afadsfsssssdf: "asdf",
+            aasfdafsasfdssdf: "asdf",
+            asadsfasdfdf: ["asdfadsafds", "Asdfadafs"],
+            assasdfadfssdf: "asdf",
+            assadsfafdsfddf: ["asdfadsaasfdfds", "Asdfadafs"],
+            asdadffasfssdf: "asdf",
+            asdfss: ["asdfadsafds", "Asdfadafs"],
+          },
+        },
+        status: 200,
+        statusText: "OK",
+        url: "http://blabla.com/my/api:8080",
+        headers: {
+          traceparent: "00-4312e4b208ab6749e42fc534e8590424-e94f817439ef9429-01",
+        },
+      },
+    });
+    expect(err3.message).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
This improves the error message handling in the SDK. Previously we would receive `AptosApiError: [object Object]` and other non-descriptive errors in some cases. This came up in debugging the keyless e2e tests specifically.
