### PR TITLE
[core] Remove `instanceof` where input might come from other bundle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - Make `fundAccount` to wait for the `fungible_asset_processor` indexer processor
+- Removed `instanceof` where input might come from other bundle
 
 # 1.23.0 (2024-07-09)
 

--- a/src/core/accountAddress.ts
+++ b/src/core/accountAddress.ts
@@ -344,13 +344,13 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    * @param input
    */
   static from(input: AccountAddressInput): AccountAddress {
-    if (input instanceof AccountAddress) {
-      return input;
+    if (typeof input === "string") {
+      return AccountAddress.fromString(input);
     }
     if (input instanceof Uint8Array) {
       return new AccountAddress(input);
     }
-    return AccountAddress.fromString(input);
+    return input;
   }
 
   /**
@@ -360,13 +360,13 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    * @param input
    */
   static fromStrict(input: AccountAddressInput): AccountAddress {
-    if (input instanceof AccountAddress) {
-      return input;
+    if (typeof input === "string") {
+      return AccountAddress.fromStringStrict(input);
     }
     if (input instanceof Uint8Array) {
       return new AccountAddress(input);
     }
-    return AccountAddress.fromStringStrict(input);
+    return input;
   }
 
   // ===

--- a/src/core/crypto/ed25519.ts
+++ b/src/core/crypto/ed25519.ts
@@ -9,7 +9,7 @@ import { Hex } from "../hex";
 import { HexInput, SigningScheme as AuthenticationKeyScheme } from "../../types";
 import { CKDPriv, deriveKey, HARDENED_OFFSET, isValidHardenedPath, mnemonicToSeed, splitPath } from "./hdKey";
 import { PrivateKey } from "./privateKey";
-import { AccountPublicKey, VerifySignatureArgs } from "./publicKey";
+import { AccountPublicKey, PublicKey, VerifySignatureArgs } from "./publicKey";
 import { Signature } from "./signature";
 import { convertSigningMessage } from "./utils";
 
@@ -134,6 +134,10 @@ export class Ed25519PublicKey extends AccountPublicKey {
    */
   static isPublicKey(publicKey: AccountPublicKey): publicKey is Ed25519PublicKey {
     return publicKey instanceof Ed25519PublicKey;
+  }
+
+  static isInstance(publicKey: PublicKey): publicKey is Ed25519PublicKey {
+    return "key" in publicKey && (publicKey.key as any)?.data?.length === Ed25519PublicKey.LENGTH;
   }
 }
 

--- a/src/core/crypto/keyless.ts
+++ b/src/core/crypto/keyless.ts
@@ -166,6 +166,15 @@ export class KeylessPublicKey extends AccountPublicKey {
     const uidVal = jwtPayload[uidKey];
     return KeylessPublicKey.create({ iss, uidKey, uidVal, aud, pepper });
   }
+
+  static isInstance(publicKey: PublicKey) {
+    return (
+      "iss" in publicKey &&
+      typeof publicKey.iss === "string" &&
+      "idCommitment" in publicKey &&
+      publicKey.idCommitment instanceof Uint8Array
+    );
+  }
 }
 
 function computeIdCommitment(args: { uidKey: string; uidVal: string; aud: string; pepper: HexInput }): Uint8Array {

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -81,6 +81,10 @@ export class Secp256k1PublicKey extends PublicKey {
   static isPublicKey(publicKey: PublicKey): publicKey is Secp256k1PublicKey {
     return publicKey instanceof Secp256k1PublicKey;
   }
+
+  static isInstance(publicKey: PublicKey): publicKey is Secp256k1PublicKey {
+    return "key" in publicKey && (publicKey.key as any)?.data?.length === Secp256k1PublicKey.LENGTH;
+  }
 }
 
 /**

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -48,9 +48,6 @@ export class Secp256k1PublicKey extends PublicKey {
    */
   verifySignature(args: VerifySignatureArgs): boolean {
     const { message, signature } = args;
-    if (!(signature instanceof Secp256k1Signature)) {
-      return false;
-    }
     const messageToVerify = convertSigningMessage(message);
     const messageBytes = Hex.fromHexInput(messageToVerify).toUint8Array();
     const messageSha3Bytes = sha3_256(messageBytes);

--- a/src/core/crypto/singleKey.ts
+++ b/src/core/crypto/singleKey.ts
@@ -119,6 +119,10 @@ export class AnyPublicKey extends AccountPublicKey {
   isSecp256k1PublicKey(): boolean {
     return this.publicKey instanceof Secp256k1PublicKey;
   }
+
+  static isInstance(publicKey: PublicKey): publicKey is AnyPublicKey {
+    return "publicKey" in publicKey && "variant" in publicKey;
+  }
 }
 
 /**

--- a/src/core/crypto/singleKey.ts
+++ b/src/core/crypto/singleKey.ts
@@ -163,7 +163,7 @@ export class AnySignature extends Signature {
     // TODO: keep this warning around for a bit, and eventually change this to return `this.signature.toUint8Array()`.
     // eslint-disable-next-line no-console
     console.warn(
-      "Calls to AnySignature.toUint8Array() will soon return the underlying signature bytes. " +
+      "[Aptos SDK] Calls to AnySignature.toUint8Array() will soon return the underlying signature bytes. " +
         "Use AnySignature.bcsToBytes() instead.",
     );
     return this.bcsToBytes();

--- a/src/core/crypto/singleKey.ts
+++ b/src/core/crypto/singleKey.ts
@@ -48,7 +48,7 @@ export class AnyPublicKey extends AccountPublicKey {
 
   verifySignature(args: VerifySignatureArgs): boolean {
     const { message, signature } = args;
-    if (!(signature instanceof AnySignature)) {
+    if (!AnySignature.isInstance(signature)) {
       return false;
     }
 
@@ -156,6 +156,12 @@ export class AnySignature extends Signature {
   // region AccountSignature
 
   toUint8Array() {
+    // TODO: keep this warning around for a bit, and eventually change this to return `this.signature.toUint8Array()`.
+    // eslint-disable-next-line no-console
+    console.warn(
+      "Calls to AnySignature.toUint8Array() will soon return the underlying signature bytes. " +
+        "Use AnySignature.bcsToBytes() instead.",
+    );
     return this.bcsToBytes();
   }
 
@@ -188,4 +194,13 @@ export class AnySignature extends Signature {
   }
 
   // endregion
+
+  static isInstance(signature: Signature): signature is AnySignature {
+    return (
+      "signature" in signature &&
+      typeof signature.signature === "object" &&
+      signature.signature !== null &&
+      "toUint8Array" in signature.signature
+    );
+  }
 }

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -1,7 +1,15 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Deserializer, Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, Hex, Serializer } from "../../src";
+import {
+  Deserializer,
+  Ed25519PrivateKey,
+  Ed25519PublicKey,
+  Ed25519Signature,
+  Hex,
+  isCanonicalEd25519Signature,
+  Serializer,
+} from "../../src";
 import { ed25519, wallet } from "./helper";
 
 describe("Ed25519PublicKey", () => {
@@ -55,14 +63,14 @@ describe("Ed25519PublicKey", () => {
       // eslint-disable-next-line max-len
       "0x0000000000000000000000000000000000000000000000000000000000000000edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000010",
     );
-    expect(signature.isCanonicalSignature()).toBe(false);
+    expect(isCanonicalEd25519Signature(signature)).toBe(false);
 
     // We now check with L + 1
     const signature2 = new Ed25519Signature(
       // eslint-disable-next-line max-len
       "0x0000000000000000000000000000000000000000000000000000000000000000edd3f55c1a631258d69cf7a2def9de1400000000000000000000000000000011",
     );
-    expect(signature2.isCanonicalSignature()).toBe(false);
+    expect(isCanonicalEd25519Signature(signature2)).toBe(false);
   });
 
   it("should serialize correctly", () => {

--- a/tests/unit/publicKey.test.ts
+++ b/tests/unit/publicKey.test.ts
@@ -1,0 +1,19 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { AnyPublicKey, Ed25519PublicKey, KeylessPublicKey, Secp256k1PublicKey } from "../../src";
+import { ed25519, secp256k1TestObject } from "./helper";
+
+describe("PublicKey", () => {
+  it.each([
+    ["ed25519", new Ed25519PublicKey(ed25519.publicKey)],
+    ["secp256k1", new Secp256k1PublicKey(secp256k1TestObject.publicKey)],
+    ["singleKey", new AnyPublicKey(new Ed25519PublicKey(ed25519.publicKey))],
+    ["keyless", new KeylessPublicKey("google", ed25519.publicKey)],
+  ])("recognizes %s public keys from other public keys", (_name, publicKey) => {
+    expect(Ed25519PublicKey.isInstance(publicKey)).toBe(publicKey instanceof Ed25519PublicKey);
+    expect(Secp256k1PublicKey.isInstance(publicKey)).toBe(publicKey instanceof Secp256k1PublicKey);
+    expect(AnyPublicKey.isInstance(publicKey)).toBe(publicKey instanceof AnyPublicKey);
+    expect(KeylessPublicKey.isInstance(publicKey)).toBe(publicKey instanceof KeylessPublicKey);
+  });
+});


### PR DESCRIPTION
### Description
The usage of `instanceof` keeps causing a lot of problem, specifically when using the TS sdk from different bundles.
Sometimes this is due to misconfiguration, some other times there's no way around it (e.g. injected wallet plugins).

This PR attempts to remove the usage of `instanceof` from all flows were inputs might come from different bundles:
- When using `Account.from` with an instance of `AccountAddress`
- When verifying a signature using an instance of `Signature`
- When simulating a transaction using an instance of `PublicKey`

### Test Plan
CI, as well as manually testing Wapal that is currently unable to integrate with AptosConnect because of the above problem.
