### PR TITLE
Introduce a `buildPublishPayload` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - Change the `stop()` function on `LocalNode` to return a `Promise` so we can wait for the processes to be killed
+- Introduce `buildPublishPayload` CLI function to build a publication transaction payload and store it in a JSON output file
 
 # 1.24.0 (2024-07-12)
 

--- a/examples/typescript/local_node.ts
+++ b/examples/typescript/local_node.ts
@@ -9,6 +9,7 @@
 const cli = require("@aptos-labs/ts-sdk/dist/common/cli/index.js");
 
 let localNode: any;
+const move = new cli.Move();
 
 // Run local node
 async function runLocalNode() {
@@ -18,8 +19,6 @@ async function runLocalNode() {
 
 // initialize current directory for Aptos
 async function init() {
-  const move = new cli.Move();
-
   await move.init({
     network: "local",
     profile: "default",
@@ -28,8 +27,6 @@ async function init() {
 
 // compile a package
 async function compile() {
-  const move = new cli.Move();
-
   await move.compile({
     packageDirectoryPath: "move/moonCoin",
     namedAddresses: {
@@ -40,8 +37,6 @@ async function compile() {
 
 // run Move unit tests for a package
 async function tests() {
-  const move = new cli.Move();
-
   await move.test({
     packageDirectoryPath: "move/moonCoin",
     namedAddresses: {
@@ -52,8 +47,6 @@ async function tests() {
 
 // publish the Move package to the publisher's account
 async function publish() {
-  const move = new cli.Move();
-
   await move.publish({
     packageDirectoryPath: "move/moonCoin",
     namedAddresses: {
@@ -65,8 +58,6 @@ async function publish() {
 
 // create a new object and publish a Move package to it
 async function createObjectAndPublishPackage() {
-  const move = new cli.Move();
-
   await move.createObjectAndPublishPackage({
     packageDirectoryPath: "move/moonCoin",
     addressName: "MoonCoin",
@@ -79,8 +70,6 @@ async function createObjectAndPublishPackage() {
 
 // upgrade a Move packaged published to an object
 async function upgradeObjectPackage() {
-  const move = new cli.Move();
-
   await move.upgradeObjectPackage({
     packageDirectoryPath: "move/moonCoin",
     // please replace the address with the actual address of object that the package was published to
@@ -94,10 +83,19 @@ async function upgradeObjectPackage() {
 
 // run a Move script
 async function runScript() {
-  const move = new cli.Move();
-
   await move.runScript({
     compiledScriptPath: "move/moonCoin/build/MoonCoin/bytecode_scripts/register.mv",
+  });
+}
+
+// build a publication transaction payload and store it in a JSON output file
+async function buildPublishPayload() {
+  await move.buildPublishPayload({
+    outputFile: "move/moonCoin/test-package.json",
+    packageDirectoryPath: "move/moonCoin",
+    namedAddresses: {
+      MoonCoin: "0x123",
+    },
   });
 }
 
@@ -123,6 +121,7 @@ async function run() {
   await createObjectAndPublishPackage();
   await upgradeObjectPackage();
   await runScript();
+  await buildPublishPayload();
 
   // stop the localnet
   await stopLocalNode();

--- a/src/cli/move.ts
+++ b/src/cli/move.ts
@@ -201,6 +201,42 @@ export class Move {
   }
 
   /**
+   * Build a publication transaction payload and store it in a JSON output file
+   *
+   * @param args.packageDirectoryPath Path to a move package (the folder with a Move.toml file)
+   * @param args.outputFile Output file to write publication transaction to
+   * @param args.namedAddresses  Named addresses for the move binary
+   * @example
+   * {
+   *  alice:0x1234, bob:0x5678
+   * }
+   *
+   * @returns stdout
+   */
+  async buildPublishPayload(args: {
+    packageDirectoryPath: string;
+    outputFile: string;
+    namedAddresses: Record<string, AccountAddress>;
+  }) {
+    const { outputFile, packageDirectoryPath, namedAddresses } = args;
+    const cliArgs = [
+      "aptos",
+      "move",
+      "build-publish-payload",
+      "--json-output-file",
+      outputFile,
+      "--package-dir",
+      packageDirectoryPath,
+    ];
+
+    const addressesMap = this.parseNamedAddresses(namedAddresses);
+
+    cliArgs.push(...this.prepareNamedAddresses(addressesMap));
+
+    return this.runCommand(cliArgs);
+  }
+
+  /**
    * Function to run a Move script, please run compile before running this
    *
    * @param args.compiledScriptPath Path to a compiled Move script bytecode file


### PR DESCRIPTION
### Description
Introduce `buildPublishPayload` CLI function to build a publication transaction payload and store it in a JSON output file

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->