### PR TITLE
Add the `NoAccountAuthenticator` variant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ examples/typescript/facoin/facoin.json
 
 # Vim swap files
 *.swp
+/.fleet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Allow optional provision of public keys in transaction simulation
+- Update the multisig v2 example to demonstrate a new way to pre-check a multisig payload before it is created on-chain
 
 # 1.32.1 (2024-11-11)
 - Add support for Firebase issuers in the `updateFederatedKeylessJwkSetTransaction` function

--- a/src/api/transactionSubmission/helpers.ts
+++ b/src/api/transactionSubmission/helpers.ts
@@ -97,12 +97,6 @@ export function ValidateFeePayerDataOnSimulation(target: unknown, propertyKey: s
   const originalMethod = descriptor.value;
   /* eslint-disable-next-line func-names, no-param-reassign */
   descriptor.value = async function (...args: any[]) {
-    const [methodArgs] = args;
-
-    if (methodArgs.transaction.feePayerAddress && !methodArgs.feePayerPublicKey) {
-      throw new Error("You are simulating a Fee Payer transaction but missing the feePayerPublicKey");
-    }
-
     return originalMethod.apply(this, args);
   };
 

--- a/src/api/transactionSubmission/simulate.ts
+++ b/src/api/transactionSubmission/simulate.ts
@@ -47,7 +47,7 @@ export class Simulate {
    * This function helps you understand the outcome of a transaction before executing it on the blockchain.
    *
    * @param args - The parameters for simulating the transaction.
-   * @param args.signerPublicKey - The public key of the signer for the transaction.
+   * @param args.signerPublicKey - The public key of the signer for the transaction (optional).
    * @param args.transaction - The raw transaction data to simulate.
    * @param args.feePayerPublicKey - The public key of the fee payer (optional).
    * @param args.options - Additional options for simulating the transaction (optional).
@@ -100,7 +100,7 @@ export class Simulate {
    */
   @ValidateFeePayerDataOnSimulation
   async simple(args: {
-    signerPublicKey: PublicKey;
+    signerPublicKey?: PublicKey;
     transaction: AnyRawTransaction;
     feePayerPublicKey?: PublicKey;
     options?: InputSimulateTransactionOptions;
@@ -113,11 +113,12 @@ export class Simulate {
    * This function helps in understanding the outcome of a transaction involving multiple signers before it is executed.
    *
    * @param args - The parameters for simulating the transaction.
-   * @param args.signerPublicKey - The public key of the primary signer.
+   * @param args.signerPublicKey - The public key of the primary signer (optional).
    * @param args.transaction - The raw transaction to be simulated.
-   * @param args.secondarySignersPublicKeys - An array of public keys for secondary signers.
-   * @param args.feePayerPublicKey - (Optional) The public key of the fee payer.
-   * @param args.options - (Optional) Options for simulating the transaction.
+   * @param args.secondarySignersPublicKeys - An array of public keys for secondary signers (optional).
+   *        Each element of the array can be optional, allowing the corresponding key check to be skipped.
+   * @param args.feePayerPublicKey - The public key of the fee payer (optional).
+   * @param args.options - Options for simulating the transaction (optional).
    *
    * @example
    * ```typescript
@@ -176,9 +177,9 @@ export class Simulate {
    */
   @ValidateFeePayerDataOnSimulation
   async multiAgent(args: {
-    signerPublicKey: PublicKey;
+    signerPublicKey?: PublicKey;
     transaction: AnyRawTransaction;
-    secondarySignersPublicKeys: Array<PublicKey>;
+    secondarySignersPublicKeys?: Array<PublicKey | undefined>;
     feePayerPublicKey?: PublicKey;
     options?: InputSimulateTransactionOptions;
   }): Promise<Array<UserTransactionResponse>> {

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -258,7 +258,7 @@ export function signAsFeePayer(args: { signer: Account; transaction: AnyRawTrans
  * @param args The arguments for simulating the transaction.
  * @param args.aptosConfig The configuration for the Aptos network.
  * @param args.transaction The raw transaction to simulate.
- * @param args.signerPublicKey The signer public key.
+ * @param args.signerPublicKey Optional. The signer public key.
  * @param args.secondarySignersPublicKeys Optional. For when the transaction involves multiple signers.
  * @param args.feePayerPublicKey Optional. For when the transaction is sponsored by a fee payer.
  * @param args.options Optional. A configuration object to customize the simulation process.

--- a/src/transactions/authenticator/account.ts
+++ b/src/transactions/authenticator/account.ts
@@ -37,6 +37,8 @@ export abstract class AccountAuthenticator extends Serializable {
         return AccountAuthenticatorSingleKey.load(deserializer);
       case AccountAuthenticatorVariant.MultiKey:
         return AccountAuthenticatorMultiKey.load(deserializer);
+      case AccountAuthenticatorVariant.NoAccountAuthenticator:
+        return AccountAuthenticatorNoAccountAuthenticator.load(deserializer);
       default:
         throw new Error(`Unknown variant index for AccountAuthenticator: ${index}`);
     }
@@ -216,5 +218,22 @@ export class AccountAuthenticatorMultiKey extends AccountAuthenticator {
     const public_keys = MultiKey.deserialize(deserializer);
     const signatures = MultiKeySignature.deserialize(deserializer);
     return new AccountAuthenticatorMultiKey(public_keys, signatures);
+  }
+}
+
+/**
+ * AccountAuthenticatorNoAccountAuthenticator for no account authenticator
+ * It represents the absence of a public key for transaction simulation.
+ * It allows skipping the public/auth key check during the simulation.
+ */
+export class AccountAuthenticatorNoAccountAuthenticator extends AccountAuthenticator {
+  // eslint-disable-next-line class-methods-use-this
+  serialize(serializer: Serializer): void {
+    serializer.serializeU32AsUleb128(AccountAuthenticatorVariant.NoAccountAuthenticator);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  static load(deserializer: Deserializer): AccountAuthenticatorNoAccountAuthenticator {
+    return new AccountAuthenticatorNoAccountAuthenticator();
   }
 }

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -30,6 +30,7 @@ import {
   AccountAuthenticator,
   AccountAuthenticatorEd25519,
   AccountAuthenticatorMultiKey,
+  AccountAuthenticatorNoAccountAuthenticator,
   AccountAuthenticatorSingleKey,
 } from "../authenticator/account";
 import {
@@ -479,15 +480,16 @@ export function generateSignedTransactionForSimulation(args: InputSimulateTransa
       transaction.feePayerAddress,
     );
     let secondaryAccountAuthenticators: Array<AccountAuthenticator> = [];
-    if (secondarySignersPublicKeys) {
-      secondaryAccountAuthenticators = secondarySignersPublicKeys.map((publicKey) =>
-        getAuthenticatorForSimulation(publicKey),
-      );
-    }
-    if (!feePayerPublicKey) {
-      throw new Error(
-        "Must provide a feePayerPublicKey argument to generate a signed fee payer transaction for simulation",
-      );
+    if (transaction.secondarySignerAddresses) {
+      if (secondarySignersPublicKeys) {
+        secondaryAccountAuthenticators = secondarySignersPublicKeys.map((publicKey) =>
+          getAuthenticatorForSimulation(publicKey),
+        );
+      } else {
+        secondaryAccountAuthenticators = Array.from({ length: transaction.secondarySignerAddresses.length }, () =>
+          getAuthenticatorForSimulation(undefined),
+        );
+      }
     }
     const feePayerAuthenticator = getAuthenticatorForSimulation(feePayerPublicKey);
 
@@ -512,15 +514,15 @@ export function generateSignedTransactionForSimulation(args: InputSimulateTransa
 
     let secondaryAccountAuthenticators: Array<AccountAuthenticator> = [];
 
-    if (!secondarySignersPublicKeys) {
-      throw new Error(
-        "Must provide a secondarySignersPublicKeys argument to generate a signed multi agent transaction for simulation",
+    if (secondarySignersPublicKeys) {
+      secondaryAccountAuthenticators = secondarySignersPublicKeys.map((publicKey) =>
+        getAuthenticatorForSimulation(publicKey),
+      );
+    } else {
+      secondaryAccountAuthenticators = Array.from({ length: transaction.secondarySignerAddresses.length }, () =>
+        getAuthenticatorForSimulation(undefined),
       );
     }
-
-    secondaryAccountAuthenticators = secondarySignersPublicKeys.map((publicKey) =>
-      getAuthenticatorForSimulation(publicKey),
-    );
 
     const transactionAuthenticator = new TransactionAuthenticatorMultiAgent(
       accountAuthenticator,
@@ -543,13 +545,19 @@ export function generateSignedTransactionForSimulation(args: InputSimulateTransa
     accountAuthenticator instanceof AccountAuthenticatorMultiKey
   ) {
     transactionAuthenticator = new TransactionAuthenticatorSingleSender(accountAuthenticator);
+  } else if (accountAuthenticator instanceof AccountAuthenticatorNoAccountAuthenticator) {
+    transactionAuthenticator = new TransactionAuthenticatorSingleSender(accountAuthenticator);
   } else {
     throw new Error("Invalid public key");
   }
   return new SignedTransaction(transaction.rawTransaction, transactionAuthenticator).bcsToBytes();
 }
 
-export function getAuthenticatorForSimulation(publicKey: PublicKey) {
+export function getAuthenticatorForSimulation(publicKey?: PublicKey) {
+  if (!publicKey) {
+    return new AccountAuthenticatorNoAccountAuthenticator();
+  }
+
   // Wrap the public key types below with AnyPublicKey as they are only support through single sender.
   // Learn more about AnyPublicKey here - https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-55.md
   const convertToAnyPublicKey =

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -307,12 +307,13 @@ export type InputSimulateTransactionData = {
   transaction: AnyRawTransaction;
   /**
    * For a single signer transaction
+   * This is optional and can be undefined to skip the public/auth key check during the transaction simulation.
    */
-  signerPublicKey: PublicKey;
+  signerPublicKey?: PublicKey;
   /**
    * For a fee payer or multi-agent transaction that requires additional signers in
    */
-  secondarySignersPublicKeys?: Array<PublicKey>;
+  secondarySignersPublicKeys?: Array<PublicKey | undefined>;
   /**
    * For a fee payer transaction (aka Sponsored Transaction)
    */

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -105,6 +105,7 @@ export enum AccountAuthenticatorVariant {
   MultiEd25519 = 1,
   SingleKey = 2,
   MultiKey = 3,
+  NoAccountAuthenticator = 4,
 }
 
 /**

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -17,6 +17,7 @@ import { MAX_U64_BIG_INT } from "../../../src/bcs/consts";
 import { longTestTimeout } from "../../unit/helper";
 import { getAptosClient } from "../helper";
 import { fundAccounts, multiSignerScriptBytecode, publishTransferPackage, singleSignerScriptBytecode } from "./helper";
+import { AccountAuthenticatorNoAccountAuthenticator } from "../../../src/transactions";
 
 const { aptos } = getAptosClient();
 
@@ -885,6 +886,34 @@ describe("transaction submission", () => {
       });
 
       expect(submittedTransaction.success).toBe(true);
+    });
+  });
+
+  describe("transactions with no account authenticator", () => {
+    test("it fails to submit a transaction when authenticator in not provided", async () => {
+      const transaction = await aptos.transaction.build.simple({
+        sender: singleSignerED25519SenderAccount.accountAddress,
+        data: {
+          bytecode: singleSignerScriptBytecode,
+          functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
+        },
+      });
+      const authenticator = new AccountAuthenticatorNoAccountAuthenticator();
+      try {
+        const response = await aptos.transaction.submit.simple({
+          transaction,
+          senderAuthenticator: authenticator,
+        });
+        await aptos.waitForTransaction({
+          transactionHash: response.hash,
+        });
+        fail("Expected an error to be thrown");
+      } catch (error: any) {
+        const errorStr = error.toString();
+        expect(errorStr).toContain("Invalid transaction");
+        expect(errorStr).toContain("INVALID_SIGNATURE");
+        expect(errorStr).toContain("vm_error");
+      }
     });
   });
 });


### PR DESCRIPTION
### Description
This PR updates the TypeScript SDK to support the simulation enhancement AIP: https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-92.md.

Key Changes:

Simulation API Update: Allows users to simulate transactions without providing public keys by updating simulateTransaction to accept `PublicKey | null` instead of `PublicKey`. If null is provided, `NoAccountAuthenticator` is used as an authenticator. This new authenticator variant is supported by the Aptos VM as per [this PR](https://github.com/aptos-labs/aptos-core/pull/13714).

Multisig V2 Example Update: The multisig v2 example (multisig_v2.ts) is updated to reflect the change in the multisig transaction simulation behavior. To pre-check the multisig payload before creation, an entry function payload simulation with the multisig account as the sender and 0x0 as the fee payer is used.

### Test Plan
This PR includes the following test scenarios:
* Simulate a transaction without checking the authentication key when the public key is not provided (i.e., public key is null).
* Simulate a fee payer transaction with fee payer as `0x0` and no public key of the fee payer provided.
* Fail to execute a transaction when `NoAccountAuthenticator` is used.

### Related Links
N.A.