### PR TITLE
Fixed double await bug for Charlie's initial balance in your_fungible_asset.ts

### DIFF
--- a/examples/typescript/your_fungible_asset.ts
+++ b/examples/typescript/your_fungible_asset.ts
@@ -174,7 +174,7 @@ async function main() {
   console.log("All the balances in this exmaple refer to balance in primary fungible stores of each account.");
   console.log(`Alice's initial FACoin balance: ${await getFaBalance(alice, metadataAddress)}.`);
   console.log(`Bob's initial FACoin balance: ${await getFaBalance(bob, metadataAddress)}.`);
-  console.log(`Charlie's initial balance: ${await await getFaBalance(charlie, metadataAddress)}.`);
+  console.log(`Charlie's initial balance: ${await getFaBalance(charlie, metadataAddress)}.`);
 
   console.log("Alice mints Charlie 100 coins.");
   const mintCoinTransactionHash = await mintCoin(alice, charlie, 100);


### PR DESCRIPTION
### Description
Fixed double await bug for Charlie's initial balance

### Test Plan
Tested locally. It fixes the ending test balances as mentioned on [this discussion forum post](https://github.com/aptos-labs/aptos-developer-discussions/discussions/309#discussioncomment-10068675). 

### Related Links
https://github.com/aptos-labs/aptos-developer-discussions/discussions/309#discussioncomment-10068675