### PR TITLE
[keyless] Add KeylessSignature when simulating KeylessPublicKey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- [`Fix`] Fixes transactions simulations using an `AnyPublicKey` with a `KeylessPublicKey` 
+  
 # 1.26.0 (2024-07-18)
 
 - Suport `extraArguments` optional property on the cli Move commnads

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -9,7 +9,7 @@
 import { sha3_256 as sha3Hash } from "@noble/hashes/sha3";
 import { AptosConfig } from "../../api/aptosConfig";
 import { AccountAddress, AccountAddressInput, Hex, PublicKey } from "../../core";
-import { AnyPublicKey, AnySignature, KeylessPublicKey, Secp256k1PublicKey } from "../../core/crypto";
+import { AnyPublicKey, AnySignature, KeylessPublicKey, KeylessSignature, Secp256k1PublicKey } from "../../core/crypto";
 import { Ed25519PublicKey, Ed25519Signature } from "../../core/crypto/ed25519";
 import { getInfo } from "../../internal/account";
 import { getLedgerInfo } from "../../internal/general";
@@ -453,6 +453,9 @@ export function getAuthenticatorForSimulation(publicKey: PublicKey) {
   }
 
   if (AnyPublicKey.isInstance(publicKey)) {
+    if (KeylessPublicKey.isInstance(publicKey.publicKey)) {
+      return new AccountAuthenticatorSingleKey(publicKey, new AnySignature(KeylessSignature.getSimulationSignature()));
+    }
     return new AccountAuthenticatorSingleKey(publicKey, new AnySignature(invalidSignature));
   }
 


### PR DESCRIPTION
### Description
Regression in this PR https://github.com/aptos-labs/aptos-ts-sdk/commit/cb7e8bb8c6242eca6d488bb361bdd483dc1a421d#diff-97f79e1249bb5dfd1fc52b16da86fbcd1d517e8897c7cc0d70c79e73c61ecf3cR456 left out Keyless signatures which broke simulations leading to underpriced transactions.

### Test Plan
Tested simulation in custom builds

### Related Links
N/A