### PR TITLE
upgrade to irys 0.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tweetnacl": "^1.0.3"
   },
   "peerDependencies": {
-    "@irys/sdk": ">=0.1.15"
+    "@irys/sdk": ">=0.2.9"
   },
   "peerDependenciesMeta": {
     "@irys/sdk": {
@@ -76,7 +76,7 @@
     "@graphql-codegen/typescript": "^4.0.1",
     "@graphql-codegen/typescript-graphql-request": "^6.0.1",
     "@graphql-codegen/typescript-operations": "^4.0.1",
-    "@irys/sdk": "0.1.15",
+    "@irys/sdk": "0.2.9",
     "@types/base-64": "^1.0.2",
     "@types/jest": "^29.5.11",
     "@types/jsonwebtoken": "^9.0.6",
@@ -98,7 +98,7 @@
     "ts-jest": "^29.1.1",
     "ts-loader": "^9.5.1",
     "ts-node": "^10.9.2",
-    "tsup": "^8.0.1",
+    "tsup": "^8.1.0",
     "typedoc": "^0.25.4",
     "typescript": "5.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ devDependencies:
     specifier: ^4.0.1
     version: 4.2.2(graphql@16.9.0)
   '@irys/sdk':
-    specifier: 0.1.15
-    version: 0.1.15(arweave@1.15.1)
+    specifier: 0.2.9
+    version: 0.2.9(arweave@1.15.1)
   '@types/base-64':
     specifier: ^1.0.2
     version: 1.0.2
@@ -128,7 +128,7 @@ devDependencies:
     specifier: ^10.9.2
     version: 10.9.2(@types/node@20.14.9)(typescript@5.3.3)
   tsup:
-    specifier: ^8.0.1
+    specifier: ^8.1.0
     version: 8.1.0(ts-node@10.9.2)(typescript@5.3.3)
   typedoc:
     specifier: ^0.25.4
@@ -160,8 +160,8 @@ packages:
     transitivePeerDependencies:
       - debug
 
-  /@aptos-labs/ts-sdk@1.22.2:
-    resolution: {integrity: sha512-EUGFT6Emyrc8xqBxZB7fO6Xha98+Q3WWJNw56IOVbiMYaga5w7Dzj8rTYYHxvxyBfEbnNQHn4QcQfaciU2N4qA==}
+  /@aptos-labs/ts-sdk@1.26.0:
+    resolution: {integrity: sha512-zScAiEuvADE9PsxgpqR7JAZOMdbTyl5AvgbsGGn56Mc8moa8Y7nyyPDxs83HQnqmZ0V/mghLVAaJ1pa7N+V3IQ==}
     engines: {node: '>=11.0.0'}
     dependencies:
       '@aptos-labs/aptos-cli': 0.1.9
@@ -2227,8 +2227,8 @@ packages:
       - debug
     dev: true
 
-  /@irys/query@0.0.3:
-    resolution: {integrity: sha512-M5njzHfda496dyXQUKlrfC3MoBc+sDrG8GFOuWM/JgMhOWpOVU78nIdL00KAaxsVAYqKTp78llCHOM1Q91XhyA==}
+  /@irys/query@0.0.8:
+    resolution: {integrity: sha512-J8zCZDos2vFogSbroCJHZJq5gnPZEal01Iy3duXAotjIMgrI2ElDANiqEbaP1JAImR1jdUo1ChJnZB7MRLN9Hw==}
     engines: {node: '>=16.10.0'}
     dependencies:
       async-retry: 1.3.3
@@ -2237,17 +2237,17 @@ packages:
       - debug
     dev: true
 
-  /@irys/sdk@0.1.15(arweave@1.15.1):
-    resolution: {integrity: sha512-/VVs2hX5BSXZGPLjbnHxwWjPwkvbcDtH6Hqq1u4otd+oBnadsHVDbw9gmZE+s8Iy38rtX1xg5l4JguJuOGEqww==}
+  /@irys/sdk@0.2.9(arweave@1.15.1):
+    resolution: {integrity: sha512-0o7PUd8GzKIhuoEJ44Ui9OPcSOE8stDYZrdnNcTURyDffa/Xv/Nwh6E1HrH1ZgeOySnieOGTlt3lvdIKyAaEQg==}
     engines: {node: '>=16.10.0'}
     hasBin: true
     dependencies:
-      '@aptos-labs/ts-sdk': 1.22.2
+      '@aptos-labs/ts-sdk': 1.26.0
       '@ethersproject/bignumber': 5.7.0
       '@ethersproject/contracts': 5.7.0
       '@ethersproject/providers': 5.7.2
       '@ethersproject/wallet': 5.7.0
-      '@irys/query': 0.0.3
+      '@irys/query': 0.0.8
       '@near-js/crypto': 0.0.3
       '@near-js/keystores-browser': 0.0.3
       '@near-js/providers': 0.0.4
@@ -2255,7 +2255,7 @@ packages:
       '@solana/web3.js': 1.94.0
       '@supercharge/promise-pool': 3.2.0
       algosdk: 1.24.1
-      arbundles: 0.10.1(arweave@1.15.1)
+      arbundles: 0.11.1(arweave@1.15.1)
       async-retry: 1.3.3
       axios: 1.7.2
       base64url: 3.0.1
@@ -3635,8 +3635,8 @@ packages:
       picomatch: 2.3.1
     dev: true
 
-  /arbundles@0.10.1(arweave@1.15.1):
-    resolution: {integrity: sha512-QYFepxessLCirvRkQK9iQmjxjHz+s50lMNGRwZwpyPWLohuf6ISyj1gkFXJHlMT+rNSrsHxb532glHnKbjwu3A==}
+  /arbundles@0.11.1(arweave@1.15.1):
+    resolution: {integrity: sha512-H1hyI98VTggH7pyxaa6jKuzB3UYHKSwRQChT2pJp8uGGv20FQEQjug/n+mza4yM8dMcLHwXji0PLpmKQKoJs+g==}
     dependencies:
       '@ethersproject/bytes': 5.7.0
       '@ethersproject/hash': 5.7.0

--- a/src/plugins/assetUploader/irys.ts
+++ b/src/plugins/assetUploader/irys.ts
@@ -74,11 +74,9 @@ export class IrysAssetUploader implements IAssetUploader {
         // Irys does not support Aptos' devnet
         throw new Error("Irys does not support Aptos' devnet");
       case Network.TESTNET:
-        return { irysNode: "devnet", providerUrl: Network.TESTNET };
+        return { irysNode: "https://arweave.devnet.irys.xyz", providerUrl: Network.TESTNET };
       case Network.MAINNET:
-        // Irys supports node1 and node2, there is no major difference between
-        // those and it is recommended to simply use node1
-        return { irysNode: "node1", providerUrl: Network.MAINNET };
+        return { irysNode: "https://arweave.mainnet.irys.xyz", providerUrl: Network.MAINNET };
       default:
         throw new Error(`${this.config.network} network is not supported`);
     }

--- a/src/plugins/assetUploader/types.ts
+++ b/src/plugins/assetUploader/types.ts
@@ -2,7 +2,7 @@ import type { FundResponse, UploadResponse, CreateAndUploadOptions } from "@irys
 import type { TaggedFile } from "@irys/sdk/build/cjs/web/upload";
 import type { NodeIrys } from "@irys/sdk/build/cjs/node/irys";
 import type { WebIrys } from "@irys/sdk/build/cjs/web/irys";
-import { Account } from "../../account";
+import type { Account } from "../../account/Account";
 
 export { FundResponse, UploadResponse, TaggedFile, CreateAndUploadOptions, NodeIrys, WebIrys };
 


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
1. irys `0.29.0` takes in new interface `url` which points to either `https://arweave.devnet.irys.xyz` or `https://arweave.mainnet.irys.xyz`
2. verified asset uploading was fixed on the irys side cuz our sdk api changed on `generateSigningMessage` so irys upgraded to use `generateSigningMessageForTransaction` instead

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
successful txn hash: `0xe6ec1ca38679a2412dd4eb575b2f219fc813e550c92558035f9c14fd8d8cfbe8`


### Related Links
<!-- Please link to any relevant issues or pull requests! -->