### PR TITLE
[bcs] Add BCS Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Update Indexer GraphQL schema
 - Add `convertAmountFromHumanReadableToOnChain` and `convertAmountFromOnChainToHumanReadable` helper methods
 - Export `helpers.ts` file
+- Add `remaining()` function to deserializer, to tell remaining byte size
 
 # 1.26.0 (2024-07-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Add `convertAmountFromHumanReadableToOnChain` and `convertAmountFromOnChainToHumanReadable` helper methods
 - Export `helpers.ts` file
 - Add `remaining()` function to deserializer, to tell remaining byte size
+- Add BCS spec for testing purposes with Cucumber
 
 # 1.26.0 (2024-07-18)
 

--- a/cucumber.js
+++ b/cucumber.js
@@ -1,0 +1,11 @@
+// cucumber.js
+let common = [
+  'tests/features/**/*.feature',                // Specify our feature files
+  '--loader ts-node/esm',
+  '--import tests/step-definitions/**/*.mts',   // Load step definitions
+  '--format progress-bar',                // Load custom formatter
+].join(' ');
+
+module.exports = {
+  default: common
+};

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "check-version": "scripts/checkVersion.sh",
     "update-version": "scripts/updateVersion.sh && pnpm doc",
     "spec": "pnpm build && pnpm _spec",
-    "_spec": "./node_modules/.bin/cucumber-js -p default"
+    "_spec": "cucumber-js -p default"
   },
   "dependencies": {
     "@aptos-labs/aptos-cli": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -45,11 +45,13 @@
     "indexer-codegen": "graphql-codegen --config ./src/types/codegen.yaml && pnpm fmt",
     "doc": "scripts/generateDocs.sh",
     "check-version": "scripts/checkVersion.sh",
-    "update-version": "scripts/updateVersion.sh && pnpm doc"
+    "update-version": "scripts/updateVersion.sh && pnpm doc",
+    "spec": "pnpm build && pnpm _spec",
+    "_spec": "./node_modules/.bin/cucumber-js -p default"
   },
   "dependencies": {
-    "@aptos-labs/aptos-client": "^0.1.0",
     "@aptos-labs/aptos-cli": "^0.2.0",
+    "@aptos-labs/aptos-client": "^0.1.0",
     "@noble/curves": "^1.4.0",
     "@noble/hashes": "^1.4.0",
     "@scure/bip32": "^1.4.0",
@@ -62,6 +64,7 @@
   },
   "devDependencies": {
     "@babel/traverse": "^7.23.6",
+    "@cucumber/cucumber": "^10.8.0",
     "@graphql-codegen/cli": "^5.0.0",
     "@graphql-codegen/import-types-preset": "^3.0.0",
     "@graphql-codegen/typescript": "^4.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ devDependencies:
   '@babel/traverse':
     specifier: ^7.23.6
     version: 7.24.6
+  '@cucumber/cucumber':
+    specifier: ^10.8.0
+    version: 10.8.0
   '@graphql-codegen/cli':
     specifier: ^5.0.0
     version: 5.0.2(@types/node@20.12.13)(graphql@16.8.1)(typescript@5.4.5)
@@ -222,7 +225,7 @@ packages:
       '@babel/traverse': 7.24.6
       '@babel/types': 7.24.6
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -834,7 +837,7 @@ packages:
       '@babel/helper-split-export-declaration': 7.24.6
       '@babel/parser': 7.24.6
       '@babel/types': 7.24.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -853,11 +856,137 @@ packages:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
     dev: true
 
+  /@colors/colors@1.5.0:
+    resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
+    engines: {node: '>=0.1.90'}
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@cspotcode/source-map-support@0.8.1:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+    dev: true
+
+  /@cucumber/ci-environment@10.0.1:
+    resolution: {integrity: sha512-/+ooDMPtKSmvcPMDYnMZt4LuoipfFfHaYspStI4shqw8FyKcfQAmekz6G+QKWjQQrvM+7Hkljwx58MEwPCwwzg==}
+    dev: true
+
+  /@cucumber/cucumber-expressions@17.1.0:
+    resolution: {integrity: sha512-PCv/ppsPynniKPWJr5v566daCVe+pbxQpHGrIu/Ev57cCH9Rv+X0F6lio4Id3Z64TaG7btCRLUGewIgLwmrwOA==}
+    dependencies:
+      regexp-match-indices: 1.0.2
+    dev: true
+
+  /@cucumber/cucumber@10.8.0:
+    resolution: {integrity: sha512-o8SR6MRQVCKKw4tytWqCqOjfX4cASj9dqpdHKHMi09rZWBCNQHBwH1TO9wj7NKjOa6RfUOTcgvDlayTcjyCH4A==}
+    engines: {node: 18 || >=20}
+    hasBin: true
+    dependencies:
+      '@cucumber/ci-environment': 10.0.1
+      '@cucumber/cucumber-expressions': 17.1.0
+      '@cucumber/gherkin': 28.0.0
+      '@cucumber/gherkin-streams': 5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1)(@cucumber/messages@24.1.0)
+      '@cucumber/gherkin-utils': 9.0.0
+      '@cucumber/html-formatter': 21.3.1(@cucumber/messages@24.1.0)
+      '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
+      '@cucumber/messages': 24.1.0
+      '@cucumber/tag-expressions': 6.1.0
+      assertion-error-formatter: 3.0.0
+      capital-case: 1.0.4
+      chalk: 4.1.2
+      cli-table3: 0.6.3
+      commander: 10.0.1
+      debug: 4.3.4(supports-color@8.1.1)
+      error-stack-parser: 2.1.4
+      figures: 3.2.0
+      glob: 10.4.1
+      has-ansi: 4.0.1
+      indent-string: 4.0.0
+      is-installed-globally: 0.4.0
+      is-stream: 2.0.1
+      knuth-shuffle-seeded: 1.0.6
+      lodash.merge: 4.6.2
+      lodash.mergewith: 4.6.2
+      luxon: 3.2.1
+      mkdirp: 2.1.6
+      mz: 2.7.0
+      progress: 2.0.3
+      read-pkg-up: 7.0.1
+      resolve-pkg: 2.0.0
+      semver: 7.5.3
+      string-argv: 0.3.1
+      strip-ansi: 6.0.1
+      supports-color: 8.1.1
+      tmp: 0.2.3
+      type-fest: 4.23.0
+      util-arity: 1.1.0
+      xmlbuilder: 15.1.1
+      yaml: 2.4.2
+      yup: 1.2.0
+    dev: true
+
+  /@cucumber/gherkin-streams@5.0.1(@cucumber/gherkin@28.0.0)(@cucumber/message-streams@4.0.1)(@cucumber/messages@24.1.0):
+    resolution: {integrity: sha512-/7VkIE/ASxIP/jd4Crlp4JHXqdNFxPGQokqWqsaCCiqBiu5qHoKMxcWNlp9njVL/n9yN4S08OmY3ZR8uC5x74Q==}
+    hasBin: true
+    peerDependencies:
+      '@cucumber/gherkin': '>=22.0.0'
+      '@cucumber/message-streams': '>=4.0.0'
+      '@cucumber/messages': '>=17.1.1'
+    dependencies:
+      '@cucumber/gherkin': 28.0.0
+      '@cucumber/message-streams': 4.0.1(@cucumber/messages@24.1.0)
+      '@cucumber/messages': 24.1.0
+      commander: 9.1.0
+      source-map-support: 0.5.21
+    dev: true
+
+  /@cucumber/gherkin-utils@9.0.0:
+    resolution: {integrity: sha512-clk4q39uj7pztZuZtyI54V8lRsCUz0Y/p8XRjIeHh7ExeEztpWkp4ca9q1FjUOPfQQ8E7OgqFbqoQQXZ1Bx7fw==}
+    hasBin: true
+    dependencies:
+      '@cucumber/gherkin': 28.0.0
+      '@cucumber/messages': 24.1.0
+      '@teppeis/multimaps': 3.0.0
+      commander: 12.0.0
+      source-map-support: 0.5.21
+    dev: true
+
+  /@cucumber/gherkin@28.0.0:
+    resolution: {integrity: sha512-Ee6zJQq0OmIUPdW0mSnsCsrWA2PZAELNDPICD2pLfs0Oz7RAPgj80UsD2UCtqyAhw2qAR62aqlktKUlai5zl/A==}
+    dependencies:
+      '@cucumber/messages': 24.1.0
+    dev: true
+
+  /@cucumber/html-formatter@21.3.1(@cucumber/messages@24.1.0):
+    resolution: {integrity: sha512-M1zbre7e8MsecXheqNv62BKY5J06YJSv1LmsD7sJ3mu5t1jirLjj2It1HqPsX5CQAfg9n69xFRugPgLMSte9TA==}
+    peerDependencies:
+      '@cucumber/messages': '>=18'
+    dependencies:
+      '@cucumber/messages': 24.1.0
+    dev: true
+
+  /@cucumber/message-streams@4.0.1(@cucumber/messages@24.1.0):
+    resolution: {integrity: sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==}
+    peerDependencies:
+      '@cucumber/messages': '>=17.1.1'
+    dependencies:
+      '@cucumber/messages': 24.1.0
+    dev: true
+
+  /@cucumber/messages@24.1.0:
+    resolution: {integrity: sha512-hxVHiBurORcobhVk80I9+JkaKaNXkW6YwGOEFIh/2aO+apAN+5XJgUUWjng9NwqaQrW1sCFuawLB1AuzmBaNdQ==}
+    dependencies:
+      '@types/uuid': 9.0.8
+      class-transformer: 0.5.1
+      reflect-metadata: 0.2.1
+      uuid: 9.0.1
+    dev: true
+
+  /@cucumber/tag-expressions@6.1.0:
+    resolution: {integrity: sha512-+3DwRumrCJG27AtzCIL37A/X+A/gSfxOPLg8pZaruh5SLumsTmpvilwroVWBT2fPzmno/tGXypeK5a7NHU4RzA==}
     dev: true
 
   /@esbuild/aix-ppc64@0.19.12:
@@ -1087,7 +1216,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.1
@@ -1697,7 +1826,7 @@ packages:
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.9.17
       chalk: 4.1.2
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       dotenv: 16.4.5
       graphql: 16.8.1
       graphql-request: 6.1.0(graphql@16.8.1)
@@ -1845,7 +1974,7 @@ packages:
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -2394,6 +2523,11 @@ packages:
       defer-to-connect: 2.0.1
     dev: false
 
+  /@teppeis/multimaps@3.0.0:
+    resolution: {integrity: sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==}
+    engines: {node: '>=14'}
+    dev: true
+
   /@tsconfig/node10@1.0.11:
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
     dev: true
@@ -2532,6 +2666,10 @@ packages:
     dependencies:
       undici-types: 5.26.5
 
+  /@types/normalize-package-data@2.4.4:
+    resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+    dev: true
+
   /@types/responselike@1.0.3:
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
     dependencies:
@@ -2544,6 +2682,10 @@ packages:
 
   /@types/stack-utils@2.0.3:
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+    dev: true
+
+  /@types/uuid@9.0.8:
+    resolution: {integrity: sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==}
     dev: true
 
   /@types/ws@8.5.10:
@@ -2579,7 +2721,7 @@ packages:
       '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.1
@@ -2605,7 +2747,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       typescript: 5.4.5
     transitivePeerDependencies:
@@ -2632,7 +2774,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.4.5)
       '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.4.5)
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
       ts-api-utils: 1.3.0(typescript@5.4.5)
       typescript: 5.4.5
@@ -2656,7 +2798,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -2891,7 +3033,7 @@ packages:
     resolution: {integrity: sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==}
     engines: {node: '>= 14'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2926,6 +3068,11 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       type-fest: 0.21.3
+    dev: true
+
+  /ansi-regex@4.1.1:
+    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
+    engines: {node: '>=6'}
     dev: true
 
   /ansi-regex@5.0.1:
@@ -3074,6 +3221,14 @@ packages:
       pvtsutils: 1.3.5
       pvutils: 1.1.3
       tslib: 2.6.2
+    dev: true
+
+  /assertion-error-formatter@3.0.0:
+    resolution: {integrity: sha512-6YyAVLrEze0kQ7CmJfUgrLHb+Y7XghmL2Ie7ijVa2Y9ynP3LV+VDiwFk62Dn0qtqbmY0BT0ss6p1xxpiF2PYbQ==}
+    dependencies:
+      diff: 4.0.2
+      pad-right: 0.2.2
+      repeat-string: 1.6.1
     dev: true
 
   /astral-regex@2.0.0:
@@ -3485,6 +3640,10 @@ packages:
     resolution: {integrity: sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q==}
     dev: true
 
+  /class-transformer@0.5.1:
+    resolution: {integrity: sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==}
+    dev: true
+
   /clean-stack@2.2.0:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
@@ -3500,6 +3659,15 @@ packages:
   /cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
     engines: {node: '>=6'}
+    dev: true
+
+  /cli-table3@0.6.3:
+    resolution: {integrity: sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==}
+    engines: {node: 10.* || >= 12.*}
+    dependencies:
+      string-width: 4.2.3
+    optionalDependencies:
+      '@colors/colors': 1.5.0
     dev: true
 
   /cli-truncate@2.1.0:
@@ -3584,6 +3752,16 @@ packages:
       delayed-stream: 1.0.0
     dev: false
 
+  /commander@10.0.1:
+    resolution: {integrity: sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==}
+    engines: {node: '>=14'}
+    dev: true
+
+  /commander@12.0.0:
+    resolution: {integrity: sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==}
+    engines: {node: '>=18'}
+    dev: true
+
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
     dev: true
@@ -3591,6 +3769,11 @@ packages:
   /commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
+    dev: true
+
+  /commander@9.1.0:
+    resolution: {integrity: sha512-i0/MaqBtdbnJ4XQs4Pmyb+oFQl+q0lsAmokVUH92SlSw4fkeAcG3bVon+Qt7hmtF+u3Het6o4VgrcY3qAoEB6w==}
+    engines: {node: ^12.20.0 || >=14}
     dev: true
 
   /common-tags@1.8.2:
@@ -3727,7 +3910,7 @@ packages:
       ms: 2.1.3
     dev: true
 
-  /debug@4.3.4:
+  /debug@4.3.4(supports-color@8.1.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -3737,6 +3920,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+      supports-color: 8.1.1
     dev: true
 
   /decamelize@1.2.0:
@@ -3911,6 +4095,12 @@ packages:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
     dependencies:
       is-arrayish: 0.2.1
+    dev: true
+
+  /error-stack-parser@2.1.4:
+    resolution: {integrity: sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==}
+    dependencies:
+      stackframe: 1.3.4
     dev: true
 
   /es-abstract@1.23.3:
@@ -4213,7 +4403,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.3
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -4613,6 +4803,13 @@ packages:
       path-is-absolute: 1.0.1
     dev: true
 
+  /global-dirs@3.0.1:
+    resolution: {integrity: sha512-NBcGGFbBA9s1VzD41QXDG+3++t9Mn5t1FpLdhESY6oKY4gYTFpX4wO3sqGUa0Srjtbfj3szX0RnemmrVRUdULA==}
+    engines: {node: '>=10'}
+    dependencies:
+      ini: 2.0.0
+    dev: true
+
   /globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
@@ -4742,6 +4939,13 @@ packages:
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     dev: true
 
+  /has-ansi@4.0.1:
+    resolution: {integrity: sha512-Qr4RtTm30xvEdqUXbSBVWDu+PrTokJOwe/FU+VdfJPk+MXAPoeOzKpRyrDTnZIJwAkQ4oBLTU53nu0HrkF/Z2A==}
+    engines: {node: '>=8'}
+    dependencies:
+      ansi-regex: 4.1.1
+    dev: true
+
   /has-bigints@1.0.2:
     resolution: {integrity: sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==}
     dev: true
@@ -4793,6 +4997,10 @@ packages:
       tslib: 2.6.2
     dev: true
 
+  /hosted-git-info@2.8.9:
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
+    dev: true
+
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
@@ -4806,7 +5014,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4824,7 +5032,7 @@ packages:
     engines: {node: '>= 14'}
     dependencies:
       agent-base: 7.1.1
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -4897,6 +5105,11 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
+
+  /ini@2.0.0:
+    resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
+    engines: {node: '>=10'}
     dev: true
 
   /inquirer@8.2.6:
@@ -5021,6 +5234,14 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: 2.1.1
+    dev: true
+
+  /is-installed-globally@0.4.0:
+    resolution: {integrity: sha512-iwGqO3J21aaSkC7jWnHP/difazwS7SFeIqxv6wEtLU8Y5KlzFTjyqcSIT0d8s4+dDhKytsk9PJZ2BkS5eZwQRQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      global-dirs: 3.0.1
+      is-path-inside: 3.0.3
     dev: true
 
   /is-interactive@1.0.0:
@@ -5193,7 +5414,7 @@ packages:
     resolution: {integrity: sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==}
     engines: {node: '>=10'}
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -5766,6 +5987,12 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /knuth-shuffle-seeded@1.0.6:
+    resolution: {integrity: sha512-9pFH0SplrfyKyojCLxZfMcvkhf5hH0d+UwR9nTVJ/DDQJGuzcXjTwB7TP7sDfehSudlGGaOLblmEWqv04ERVWg==}
+    dependencies:
+      seed-random: 2.2.0
+    dev: true
+
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -5863,6 +6090,10 @@ packages:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
     dev: true
 
+  /lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+    dev: true
+
   /lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
     dev: true
@@ -5928,8 +6159,20 @@ packages:
       yallist: 3.1.1
     dev: true
 
+  /lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+    dependencies:
+      yallist: 4.0.0
+    dev: true
+
   /lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+    dev: true
+
+  /luxon@3.2.1:
+    resolution: {integrity: sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==}
+    engines: {node: '>=12'}
     dev: true
 
   /make-dir@4.0.0:
@@ -6050,6 +6293,12 @@ packages:
     engines: {node: '>=16 || 14 >=14.17'}
     dev: true
 
+  /mkdirp@2.1.6:
+    resolution: {integrity: sha512-+hEnITedc8LAtIP9u3HJDFIdcLV2vXP33sqLLIzkv1Db1zO/1OxbvYf0Y1OC/S/Qo5dxHXepofhmxL02PsKe+A==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dev: true
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -6103,6 +6352,15 @@ packages:
 
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
+    dev: true
+
+  /normalize-package-data@2.5.0:
+    resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
+    dependencies:
+      hosted-git-info: 2.8.9
+      resolve: 1.22.8
+      semver: 5.7.2
+      validate-npm-package-license: 3.0.4
     dev: true
 
   /normalize-path@2.1.1:
@@ -6283,6 +6541,13 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
+  /pad-right@0.2.2:
+    resolution: {integrity: sha512-4cy8M95ioIGolCoMmm2cMntGR1lPLEbOMzOKu8bzjuJP6JpzEMQcDHmh7hHLYGgob+nKe1YHFMaG4V59HQa89g==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      repeat-string: 1.6.1
+    dev: true
+
   /param-case@3.0.4:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
@@ -6441,6 +6706,11 @@ packages:
       react-is: 18.3.1
     dev: true
 
+  /progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
   /promise@7.3.1:
     resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
     dependencies:
@@ -6453,6 +6723,10 @@ packages:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+    dev: true
+
+  /property-expr@2.0.6:
+    resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
     dev: true
 
   /proxy-from-env@1.1.0:
@@ -6509,6 +6783,25 @@ packages:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
     dev: true
 
+  /read-pkg-up@7.0.1:
+    resolution: {integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==}
+    engines: {node: '>=8'}
+    dependencies:
+      find-up: 4.1.0
+      read-pkg: 5.2.0
+      type-fest: 0.8.1
+    dev: true
+
+  /read-pkg@5.2.0:
+    resolution: {integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==}
+    engines: {node: '>=8'}
+    dependencies:
+      '@types/normalize-package-data': 2.4.4
+      normalize-package-data: 2.5.0
+      parse-json: 5.2.0
+      type-fest: 0.6.0
+    dev: true
+
   /readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
@@ -6525,8 +6818,24 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /reflect-metadata@0.2.1:
+    resolution: {integrity: sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==}
+    deprecated: This version has a critical bug in fallback handling. Please upgrade to reflect-metadata@0.2.2 or newer.
+    dev: true
+
   /regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
+    dev: true
+
+  /regexp-match-indices@1.0.2:
+    resolution: {integrity: sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==}
+    dependencies:
+      regexp-tree: 0.1.27
+    dev: true
+
+  /regexp-tree@0.1.27:
+    resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
+    hasBin: true
     dev: true
 
   /regexp.prototype.flags@1.5.2:
@@ -6561,6 +6870,11 @@ packages:
     resolution: {integrity: sha512-O3vsMYfWighyFbTd8hk8VaSj9UAGENxAtX+//ugIst2RMk5e03h6RoIS+0ylsFxY1gvmPuAY/PO4It+gPEeySA==}
     dev: true
 
+  /repeat-string@1.6.1:
+    resolution: {integrity: sha512-PV0dzCYDNfRi1jCDbJzpW7jNNDRuCOG/jI5ctQcGKt/clZD+YcPS3yIlWuTJMmESC8aevCFmWJy5wjAFgNqN6w==}
+    engines: {node: '>=0.10'}
+    dev: true
+
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -6589,6 +6903,13 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+    dev: true
+
+  /resolve-pkg@2.0.0:
+    resolution: {integrity: sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==}
+    engines: {node: '>=8'}
+    dependencies:
+      resolve-from: 5.0.0
     dev: true
 
   /resolve.exports@2.0.2:
@@ -6719,9 +7040,26 @@ packages:
     resolution: {integrity: sha512-MuCAyrGZcTLfQoH2XoBlQ8C6bzwN88XT/0slOGz0pn8+gIP85BOAfYa44ZXQUTOwRwPU0QvgU+V+OSajl/59Xg==}
     dev: true
 
+  /seed-random@2.2.0:
+    resolution: {integrity: sha512-34EQV6AAHQGhoc0tn/96a9Fsi6v2xdqe/dMUwljGRaFOzR3EgRmECvD0O8vi8X+/uQ50LGHfkNu/Eue5TPKZkQ==}
+    dev: true
+
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+    hasBin: true
+    dev: true
+
   /semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
+    dev: true
+
+  /semver@7.5.3:
+    resolution: {integrity: sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
     dev: true
 
   /semver@7.6.2:
@@ -6887,6 +7225,28 @@ packages:
       whatwg-url: 7.1.0
     dev: true
 
+  /spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.18
+    dev: true
+
+  /spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+    dev: true
+
+  /spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.18
+    dev: true
+
+  /spdx-license-ids@3.0.18:
+    resolution: {integrity: sha512-xxRs31BqRYHwiMzudOrpSiHtZ8i/GeionCBDSilhYRj+9gIcI8wCZTlXZKu9vZIVqViP3dcp9qE5G6AlIaD+TQ==}
+    dev: true
+
   /sponge-case@1.0.1:
     resolution: {integrity: sha512-dblb9Et4DAtiZ5YSUZHLl4XhH4uK80GhAZrVXdN4O2P4gQ40Wa5UIOPUHlA/nFd2PLblBZWUioLMMAVrgpoYcA==}
     dependencies:
@@ -6904,9 +7264,18 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
+  /stackframe@1.3.4:
+    resolution: {integrity: sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==}
+    dev: true
+
   /streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
+    dev: true
+
+  /string-argv@0.3.1:
+    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
+    engines: {node: '>=0.6.19'}
     dev: true
 
   /string-env-interpolation@1.0.1:
@@ -7123,6 +7492,10 @@ packages:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
     dev: true
 
+  /tiny-case@1.0.3:
+    resolution: {integrity: sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==}
+    dev: true
+
   /title-case@3.0.3:
     resolution: {integrity: sha512-e1zGYRvbffpcHIrnuqT0Dh+gEJtDaxDSoG4JAIpq4oDFyooziLBIiYQv0GBT4FUAnUop5uZ1hiIAj7oAF6sOCA==}
     dependencies:
@@ -7134,6 +7507,11 @@ packages:
     engines: {node: '>=0.6.0'}
     dependencies:
       os-tmpdir: 1.0.2
+    dev: true
+
+  /tmp@0.2.3:
+    resolution: {integrity: sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==}
+    engines: {node: '>=14.14'}
     dev: true
 
   /tmpl@1.0.5:
@@ -7150,6 +7528,10 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+    dev: true
+
+  /toposort@2.0.2:
+    resolution: {integrity: sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==}
     dev: true
 
   /tr46@0.0.3:
@@ -7308,7 +7690,7 @@ packages:
       bundle-require: 4.1.0(esbuild@0.19.12)
       cac: 6.7.14
       chokidar: 3.6.0
-      debug: 4.3.4
+      debug: 4.3.4(supports-color@8.1.1)
       esbuild: 0.19.12
       execa: 5.1.1
       globby: 11.1.0
@@ -7345,6 +7727,26 @@ packages:
   /type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
     engines: {node: '>=10'}
+    dev: true
+
+  /type-fest@0.6.0:
+    resolution: {integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /type-fest@0.8.1:
+    resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
+    engines: {node: '>=8'}
+    dev: true
+
+  /type-fest@2.19.0:
+    resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
+    engines: {node: '>=12.20'}
+    dev: true
+
+  /type-fest@4.23.0:
+    resolution: {integrity: sha512-ZiBujro2ohr5+Z/hZWHESLz3g08BBdrdLMieYFULJO+tWc437sn8kQsWLJoZErY8alNhxre9K4p3GURAG11n+w==}
+    engines: {node: '>=16'}
     dev: true
 
   /typed-array-buffer@1.0.2:
@@ -7476,8 +7878,17 @@ packages:
     resolution: {integrity: sha512-Qp95D4TPJl1kC9SKigDcqgyM2VDVO4RiJc2d4qe5GrYm+zbIQCWWKAFaJNQ4BhdFeDGwBmAxqJBwWSJDb9T3BQ==}
     dev: true
 
+  /util-arity@1.1.0:
+    resolution: {integrity: sha512-kkyIsXKwemfSy8ZEoaIz06ApApnWsk5hQO0vLjZS6UkBiGiW++Jsyb8vSBoc0WKlffGoGs5yYy/j5pp8zckrFA==}
+    dev: true
+
   /util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+    dev: true
+
+  /uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
     dev: true
 
   /v8-compile-cache-lib@3.0.1:
@@ -7491,6 +7902,13 @@ packages:
       '@jridgewell/trace-mapping': 0.3.25
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
+    dev: true
+
+  /validate-npm-package-license@3.0.4:
+    resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+    dependencies:
+      spdx-correct: 3.2.0
+      spdx-expression-parse: 3.0.1
     dev: true
 
   /value-or-promise@1.0.12:
@@ -7698,6 +8116,11 @@ packages:
         optional: true
     dev: true
 
+  /xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+    dev: true
+
   /y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
     dev: true
@@ -7709,6 +8132,10 @@ packages:
 
   /yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+    dev: true
+
+  /yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
     dev: true
 
   /yaml-ast-parser@0.0.43:
@@ -7772,4 +8199,13 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+    dev: true
+
+  /yup@1.2.0:
+    resolution: {integrity: sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==}
+    dependencies:
+      property-expr: 2.0.6
+      tiny-case: 1.0.3
+      toposort: 2.0.2
+      type-fest: 2.19.0
     dev: true

--- a/src/bcs/deserializer.ts
+++ b/src/bcs/deserializer.ts
@@ -38,6 +38,15 @@ export class Deserializer {
   }
 
   /**
+   * Returns the number of bytes remaining in the buffer.
+   *
+   * Useful to tell if there's more data to be read.
+   */
+  remaining(): number {
+    return this.buffer.byteLength - this.offset;
+  }
+
+  /**
    * Deserializes a string. UTF8 string is supported. Reads the string's bytes length "l" first,
    * and then reads "l" bytes of content. Decodes the byte array into a string.
    *

--- a/tests/features/bcs_deserialization.feature
+++ b/tests/features/bcs_deserialization.feature
@@ -1,0 +1,267 @@
+Feature: Binary Canonical Serialization(BCS) Deserialization
+
+"""
+  TODO List:
+    * Add a struct for testing
+    * Add possible invalid input number scenarios?  It's really language specific though
+    * Add invalid UTF-8 string deserialization
+    * Add invalid sequence item deserialization
+    * Add invalid struct deserialization
+    * Add invalid custom error struct deserialization
+"""
+
+  Scenario Outline: It must be able to deserialize <label> as an address
+    Given bytes <bytes>
+    When I deserialize as address
+    Then the result should be address <value>
+
+    Examples:
+      | label                         | value                                                              | bytes                                                              |
+      | address zero                  | 0x0                                                                | 0x0000000000000000000000000000000000000000000000000000000000000000 |
+      | address one                   | 0x1                                                                | 0x0000000000000000000000000000000000000000000000000000000000000001 |
+      | an address with leading zeros | 0x123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF  | 0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF |
+      | a full address                | 0xA123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF | 0xA123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF |
+
+  Scenario Outline: It must be able to deserialize <value> as a bool
+    Given bytes <bytes>
+    When I deserialize as bool
+    Then the result should be bool <value>
+
+    Examples:
+      | value | bytes |
+      | false | 0x00  |
+      | true  | 0x01  |
+
+  Scenario Outline: It must not succeed if the bool type is not 0x00 or 0x01
+    Given bytes <bytes>
+    When I deserialize as bool
+    Then the deserialization should fail
+
+    Examples:
+      | bytes |
+      | 0x02  |
+      | 0xFF  |
+
+  Scenario Outline: It must be able to deserialize <label> as an u8
+    Given bytes <bytes>
+    When I deserialize as u8
+    Then the result should be u8 <value>
+
+    Examples:
+      | label                    | value | bytes |
+      | zero                     | 0     | 0x00  |
+      | one                      | 1     | 0x01  |
+      | the highest value (0xFF) | 255   | 0xFF  |
+
+  Scenario Outline: It must be able to deserialize <label> as an u16
+    Given bytes <bytes>
+    When I deserialize as u16
+    Then the result should be u16 <value>
+
+    Examples:
+      | label                      | value | bytes  |
+      | zero                       | 0     | 0x0000 |
+      | one                        | 1     | 0x0100 |
+      | 0xFF                       | 255   | 0xFF00 |
+      | 0x100                      | 256   | 0x0001 |
+      | the highest value (0xFFFF) | 65535 | 0xFFFF |
+
+  Scenario Outline: It must be able to deserialize <label> as an u32
+    Given bytes <bytes>
+    When I deserialize as u32
+    Then the result should be u32 <value>
+
+    Examples:
+      | label                          | value      | bytes      |
+      | zero                           | 0          | 0x00000000 |
+      | one                            | 1          | 0x01000000 |
+      | 0xFF                           | 255        | 0xFF000000 |
+      | 0x100                          | 256        | 0x00010000 |
+      | 0xFFFF                         | 65535      | 0xFFFF0000 |
+      | 0x100000                       | 65536      | 0x00000100 |
+      | 0xFFFFFF                       | 16777215   | 0xFFFFFF00 |
+      | 0x1000000                      | 16777216   | 0x00000001 |
+      | the highest value (0xFFFFFFFF) | 4294967295 | 0xFFFFFFFF |
+
+  Scenario Outline: It must be able to deserialize <label> as an u64
+    Given bytes <bytes>
+    When I deserialize as u64
+    Then the result should be u64 <value>
+
+    Examples:
+      | label                                 | value                | bytes              |
+      | zero                                  | 0                    | 0x0000000000000000 |
+      | one                                   | 1                    | 0x0100000000000000 |
+      | 0xFF                                  | 255                  | 0xFF00000000000000 |
+      | 0x100                                 | 256                  | 0x0001000000000000 |
+      | 0xFFFF                                | 65535                | 0xFFFF000000000000 |
+      | 0x10000                               | 65536                | 0x0000010000000000 |
+      | 0xFFFFFF                              | 16777215             | 0xFFFFFF0000000000 |
+      | 0x1000000                             | 16777216             | 0x0000000100000000 |
+      | 0xFFFFFFFF                            | 4294967295           | 0xFFFFFFFF00000000 |
+      | 0x100000000                           | 4294967296           | 0x0000000001000000 |
+      | the highest value(0xFFFFFFFFFFFFFFFF) | 18446744073709551615 | 0xFFFFFFFFFFFFFFFF |
+
+  Scenario Outline: It must be able to deserialize <label> as an u128
+    Given bytes <bytes>
+    When I deserialize as u128
+    Then the result should be u128 <value>
+
+    Examples:
+      | label                                                  | value                                   | bytes                              |
+      | zero                                                   | 0                                       | 0x00000000000000000000000000000000 |
+      | one                                                    | 1                                       | 0x01000000000000000000000000000000 |
+      | 0xFF                                                   | 255                                     | 0xFF000000000000000000000000000000 |
+      | 0x100                                                  | 256                                     | 0x00010000000000000000000000000000 |
+      | 0xFFFF                                                 | 65535                                   | 0xFFFF0000000000000000000000000000 |
+      | 0x10000                                                | 65536                                   | 0x00000100000000000000000000000000 |
+      | 0xFFFFFFFF                                             | 4294967295                              | 0xFFFFFFFF000000000000000000000000 |
+      | 0x100000000                                            | 4294967296                              | 0x00000000010000000000000000000000 |
+      | the highest value (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) | 340282366920938463463374607431768211455 | 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF |
+
+  Scenario Outline: It must be able to deserialize <label> as an u256
+    Given bytes <bytes>
+    When I deserialize as u256
+    Then the result should be u256 <value>
+
+    Examples:
+      | label                                                                                  | value                                                                          | bytes                                                              |
+      | zero                                                                                   | 0                                                                              | 0x0000000000000000000000000000000000000000000000000000000000000000 |
+      | one                                                                                    | 1                                                                              | 0x0100000000000000000000000000000000000000000000000000000000000000 |
+      | 0xFF                                                                                   | 255                                                                            | 0xFF00000000000000000000000000000000000000000000000000000000000000 |
+      | 0x1000                                                                                 | 256                                                                            | 0x0001000000000000000000000000000000000000000000000000000000000000 |
+      | the highest value (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) | 115792089237316195423570985008687907853269984665640564039457584007913129639935 | 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF |
+
+
+  Scenario Outline: It must be able to deserialize <label> as an uleb128
+    Given bytes <bytes>
+    When I deserialize as uleb128
+    Then the result should be u32 <value>
+
+    Examples:
+      | label                      | value      | bytes        |
+      | zero                       | 0          | 0x00         |
+      | one                        | 1          | 0x01         |
+      | largest single byte (127)  | 127        | 0x7F         |
+      | smallest double byte (128) | 128        | 0x8001       |
+      | other double byte (240)    | 240        | 0xF001       |
+      | 255                        | 255        | 0xFF01       |
+      | three bytes (65535)        | 65535      | 0xFFFF03     |
+      | four bytes (16777215)      | 16777215   | 0xFFFFFF07   |
+      | max u32 (4294966295)       | 4294967295 | 0xFFFFFFFF0F |
+
+  Scenario Outline: It must not succeed if the uleb128 type is not a valid uleb128 <label>
+    Given bytes <bytes>
+    When I deserialize as uleb128
+    Then the deserialization should fail
+
+    Examples:
+      | label             | bytes        |
+      | Missing next byte | 0x80         |
+      | Too large         | 0xFFFFFFFF10 |
+
+  Scenario Outline: It must be able to deserialize <label> as fixed bytes with length <length>
+    Given bytes <bytes>
+    When I deserialize as fixed bytes with length <length>
+    Then the result should be bytes <value>
+
+    Examples:
+      | label             | value  | bytes  | length |
+      | zero length fixed | 0x     | 0x     | 0      |
+      | zero single byte  | 0x00   | 0x00   | 1      |
+      | single byte       | 0x7F   | 0x7F   | 1      |
+      | two bytes         | 0x0102 | 0x0102 | 2      |
+
+  Scenario: It must not succeed deserializing fixed bytes, if the input is too short
+    Given bytes 0x00
+    When I deserialize as fixed bytes with length 2
+    Then the deserialization should fail
+
+  Scenario Outline: It must be able to deserialize <label> as bytes
+    Given bytes <bytes>
+    When I deserialize as bytes
+    Then the result should be bytes <value>
+
+    Examples:
+      | label                                             | value                                                                                                                                                                                                                                                              | bytes                                                                                                                                                                                                                                                                  |
+      | zero byte                                         | 0x00                                                                                                                                                                                                                                                               | 0x0100                                                                                                                                                                                                                                                                 |
+      | single byte                                       | 0x7F                                                                                                                                                                                                                                                               | 0x017F                                                                                                                                                                                                                                                                 |
+      | two bytes                                         | 0x0102                                                                                                                                                                                                                                                             | 0x020102                                                                                                                                                                                                                                                               |
+      | long bytes with one length byte (127 characters)  | 0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCD   | 0x7F0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCD     |
+      | long bytes with two length bytes (128 characters) | 0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF | 0x80010123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF |
+
+
+  Scenario Outline: It must be able to deserialize <label> as a string <value> from <bytes>
+    Given bytes <bytes>
+    When I deserialize as string
+    Then the result should be string <value>
+
+    Examples:
+      | label                  | value      | bytes                |
+      | empty string           | ""         | 0x00                 |
+      | uppercase A            | "A"        | 0x0141               |
+      | lowercase a            | "a"        | 0x0161               |
+      | three character string | "abc"      | 0x03616263           |
+      | four character string  | "abcd"     | 0x0461626364         |
+      | numbers and letters    | "1234abcd" | 0x083132333461626364 |
+      | emojis                 | "😀🚀"     | 0x08F09F9880F09F9A80 |
+
+  Scenario Outline: It must be able to deserialize <label> as a sequence of <type>
+    Given bytes <bytes>
+    When I deserialize as sequence of <type>
+    Then the result should be sequence of <type> <value>
+
+    Examples:
+      | label          | type    | value        | bytes                                                                                                                                |
+      | no bool        | bool    | []           | 0x00                                                                                                                                 |
+      | single bool    | bool    | [true]       | 0x0101                                                                                                                               |
+      | double bool    | bool    | [false,true] | 0x020001                                                                                                                             |
+      | no u8          | u8      | []           | 0x00                                                                                                                                 |
+      | single u8      | u8      | [0]          | 0x0100                                                                                                                               |
+      | double u8      | u8      | [1,3]        | 0x020103                                                                                                                             |
+      | no u16         | u16     | []           | 0x00                                                                                                                                 |
+      | single u16     | u16     | [0]          | 0x010000                                                                                                                             |
+      | double u16     | u16     | [1,3]        | 0x0201000300                                                                                                                         |
+      | no u32         | u32     | []           | 0x00                                                                                                                                 |
+      | single u32     | u32     | [0]          | 0x0100000000                                                                                                                         |
+      | double u32     | u32     | [1,3]        | 0x020100000003000000                                                                                                                 |
+      | no u64         | u64     | []           | 0x00                                                                                                                                 |
+      | single u64     | u64     | [0]          | 0x010000000000000000                                                                                                                 |
+      | double u64     | u64     | [1,3]        | 0x0201000000000000000300000000000000                                                                                                 |
+      | no u128        | u128    | []           | 0x00                                                                                                                                 |
+      | single u128    | u128    | [0]          | 0x0100000000000000000000000000000000                                                                                                 |
+      | double u128    | u128    | [1,3]        | 0x020100000000000000000000000000000003000000000000000000000000000000                                                                 |
+      | no u256        | u256    | []           | 0x00                                                                                                                                 |
+      | single u256    | u256    | [0]          | 0x010000000000000000000000000000000000000000000000000000000000000000                                                                 |
+      | double u256    | u256    | [1,3]        | 0x0201000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000 |
+      | no uleb128     | uleb128 | []           | 0x00                                                                                                                                 |
+      | single uleb128 | uleb128 | [0]          | 0x0100                                                                                                                               |
+      | double uleb128 | uleb128 | [128,127]    | 0x0280017F                                                                                                                           |
+      | no address     | address | []           | 0x00                                                                                                                                 |
+      | single address | address | [0x1]        | 0x010000000000000000000000000000000000000000000000000000000000000001                                                                 |
+      | double address | address | [0x2,0x0]    | 0x0200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000 |
+      | no string      | string  | []           | 0x00                                                                                                                                 |
+      | single string  | string  | ["😀🚀"]     | 0x0108F09F9880F09F9A80                                                                                                               |
+      | double string  | string  | ["a","b"]    | 0x0201610162                                                                                                                         |
+
+  Scenario Outline: It must not succeed if there are not enough bytes to deserialize <label>
+    Given bytes <bytes>
+    When I deserialize as <type>
+    Then the deserialization should fail
+
+    Examples:
+      | label                            | type    | bytes                                                            |
+      | bool                             | bool    | 0x                                                               |
+      | u8                               | u8      | 0x                                                               |
+      | u16                              | u16     | 0x00                                                             |
+      | u32                              | u32     | 0x000000                                                         |
+      | u64                              | u64     | 0x00000000000000                                                 |
+      | u128                             | u128    | 0x000000000000000000000000000000                                 |
+      | u256                             | u256    | 0x00000000000000000000000000000000000000000000000000000000000000 |
+      | address                          | address | 0x00000000000000000000000000000000000000000000000000000000000000 |
+      | short address                    | address | 0x01                                                              |
+      | bytes without length             | bytes   | 0x                                                               |
+      | bytes with length and no values  | bytes   | 0x01                                                             |
+      | string without length            | string  | 0x                                                               |
+      | string with length and no values | string  | 0x01                                                             |
+    # TODO check similar for sequences

--- a/tests/features/bcs_serialization.feature
+++ b/tests/features/bcs_serialization.feature
@@ -1,0 +1,223 @@
+Feature: Binary Canonical Serialization(BCS) Serialization
+
+"""
+  TODO List:
+  * Add a struct for testing
+  * Add some more test cases for each
+  * Add struct sequence tests
+  * Add for custom error handling on structs?
+  * Do we add a fixed length test that doesn't match length of input (disallowed in Go entirely)
+  """
+
+  # TODO Do we merge all of the primitives into one big scenario outline?
+
+  Scenario Outline: It must be able to serialize <label> as an address
+    Given address <value>
+    When I serialize as address
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label                         | value                                                              | bytes                                                              |
+      | address zero                  | 0x0                                                                | 0x0000000000000000000000000000000000000000000000000000000000000000 |
+      | address one                   | 0x1                                                                | 0x0000000000000000000000000000000000000000000000000000000000000001 |
+      | an address with leading zeros | 0x123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF  | 0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF |
+      | a full address                | 0xA123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF | 0xA123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF |
+
+  Scenario Outline: It must be able to serialize <value> as a bool
+    Given bool <value>
+    When I serialize as bool
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | value | bytes |
+      | false | 0x00  |
+      | true  | 0x01  |
+
+  Scenario Outline: It must be able to serialize <label> as an u8
+    Given u8 <value>
+    When I serialize as u8
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label                    | value | bytes |
+      | zero                     | 0     | 0x00  |
+      | one                      | 1     | 0x01  |
+      | the highest value (0xFF) | 255   | 0xFF  |
+
+  Scenario Outline: It must be able to serialize <label> as an u16
+    Given u16 <value>
+    When I serialize as u16
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label                      | value | bytes  |
+      | zero                       | 0     | 0x0000 |
+      | one                        | 1     | 0x0100 |
+      | 0xFF                       | 255   | 0xFF00 |
+      | 0x100                      | 256   | 0x0001 |
+      | the highest value (0xFFFF) | 65535 | 0xFFFF |
+
+  Scenario Outline: It must be able to serialize <label> as an u32
+    Given u32 <value>
+    When I serialize as u32
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label                          | value      | bytes      |
+      | zero                           | 0          | 0x00000000 |
+      | one                            | 1          | 0x01000000 |
+      | 0xFF                           | 255        | 0xFF000000 |
+      | 0x100                          | 256        | 0x00010000 |
+      | 0xFFFF                         | 65535      | 0xFFFF0000 |
+      | 0x100000                       | 65536      | 0x00000100 |
+      | 0xFFFFFF                       | 16777215   | 0xFFFFFF00 |
+      | 0x1000000                      | 16777216   | 0x00000001 |
+      | the highest value (0xFFFFFFFF) | 4294967295 | 0xFFFFFFFF |
+
+  Scenario Outline: It must be able to serialize <label> as an u64
+    Given u64 <value>
+    When I serialize as u64
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label                                 | value                | bytes              |
+      | zero                                  | 0                    | 0x0000000000000000 |
+      | one                                   | 1                    | 0x0100000000000000 |
+      | 0xFF                                  | 255                  | 0xFF00000000000000 |
+      | 0x100                                 | 256                  | 0x0001000000000000 |
+      | 0xFFFF                                | 65535                | 0xFFFF000000000000 |
+      | 0x10000                               | 65536                | 0x0000010000000000 |
+      | 0xFFFFFF                              | 16777215             | 0xFFFFFF0000000000 |
+      | 0x1000000                             | 16777216             | 0x0000000100000000 |
+      | 0xFFFFFFFF                            | 4294967295           | 0xFFFFFFFF00000000 |
+      | 0x100000000                           | 4294967296           | 0x0000000001000000 |
+      | the highest value(0xFFFFFFFFFFFFFFFF) | 18446744073709551615 | 0xFFFFFFFFFFFFFFFF |
+
+  Scenario Outline: It must be able to serialize <label> as an u128
+    Given u128 <value>
+    When I serialize as u128
+    Then the result should be bytes <bytes>
+
+    # TODO Fill in more examples
+    Examples:
+      | label                                                  | value                                   | bytes                              |
+      | zero                                                   | 0                                       | 0x00000000000000000000000000000000 |
+      | one                                                    | 1                                       | 0x01000000000000000000000000000000 |
+      | 0xFF                                                   | 255                                     | 0xFF000000000000000000000000000000 |
+      | 0x100                                                  | 256                                     | 0x00010000000000000000000000000000 |
+      | 0xFFFF                                                 | 65535                                   | 0xFFFF0000000000000000000000000000 |
+      | 0x10000                                                | 65536                                   | 0x00000100000000000000000000000000 |
+      | 0xFFFFFFFF                                             | 4294967295                              | 0xFFFFFFFF000000000000000000000000 |
+      | 0x100000000                                            | 4294967296                              | 0x00000000010000000000000000000000 |
+      | the highest value (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) | 340282366920938463463374607431768211455 | 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF |
+
+  Scenario Outline: It must be able to serialize <label> as an u256
+    Given u256 <value>
+    When I serialize as u256
+    Then the result should be bytes <bytes>
+
+    # TODO Fill in more examples
+    Examples:
+      | label                                                                                  | value                                                                          | bytes                                                              |
+      | zero                                                                                   | 0                                                                              | 0x0000000000000000000000000000000000000000000000000000000000000000 |
+      | one                                                                                    | 1                                                                              | 0x0100000000000000000000000000000000000000000000000000000000000000 |
+      | 0xFF                                                                                   | 255                                                                            | 0xFF00000000000000000000000000000000000000000000000000000000000000 |
+      | 0x1000                                                                                 | 256                                                                            | 0x0001000000000000000000000000000000000000000000000000000000000000 |
+      | the highest value (0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) | 115792089237316195423570985008687907853269984665640564039457584007913129639935 | 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF |
+
+  Scenario Outline: It must be able to serialize <label> as an uleb128
+    Given u32 <value>
+    When I serialize as uleb128
+    Then the result should be bytes <bytes>
+
+    # TODO Fill in more examples
+    Examples:
+      | label                      | value      | bytes        |
+      | zero                       | 0          | 0x00         |
+      | one                        | 1          | 0x01         |
+      | largest single byte (127)  | 127        | 0x7F         |
+      | smallest double byte (128) | 128        | 0x8001       |
+      | other double byte (240)    | 240        | 0xF001       |
+      | 255                        | 255        | 0xFF01       |
+      | three bytes (65535)        | 65535      | 0xFFFF03     |
+      | four bytes (16777215)      | 16777215   | 0xFFFFFF07   |
+      | max u32 (4294966295)       | 4294967295 | 0xFFFFFFFF0F |
+
+
+  Scenario Outline: It must be able to serialize <label> as fixed bytes
+    Given bytes <value>
+    When I serialize as fixed bytes with length <length>
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label            | value  | bytes  | length |
+      | zero single byte | 0x00   | 0x00   | 1      |
+      | single byte      | 0x7F   | 0x7F   | 1      |
+      | two bytes        | 0x0102 | 0x0102 | 2      |
+
+  Scenario Outline: It must be able to serialize <label> as bytes
+    Given bytes <value>
+    When I serialize as bytes
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label                                             | value                                                                                                                                                                                                                                                              | bytes                                                                                                                                                                                                                                                                  |
+      | zero byte                                         | 0x00                                                                                                                                                                                                                                                               | 0x0100                                                                                                                                                                                                                                                                 |
+      | single byte                                       | 0x7F                                                                                                                                                                                                                                                               | 0x017F                                                                                                                                                                                                                                                                 |
+      | two bytes                                         | 0x0102                                                                                                                                                                                                                                                             | 0x020102                                                                                                                                                                                                                                                               |
+      | long bytes with one length byte (127 characters)  | 0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCD   | 0x7F0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCD     |
+      | long bytes with two length bytes (128 characters) | 0x0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF | 0x80010123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF |
+
+  Scenario Outline: It must be able to serialize <label> as a string
+    Given string <value>
+    When I serialize as string
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label                  | value      | bytes                |
+      | empty string           | ""         | 0x00                 |
+      | uppercase A            | "A"        | 0x0141               |
+      | lowercase a            | "a"        | 0x0161               |
+      | three character string | "abc"      | 0x03616263           |
+      | four character string  | "abcd"     | 0x0461626364         |
+      | numbers and letters    | "1234abcd" | 0x083132333461626364 |
+      | emojis                 | "😀🚀"     | 0x08F09F9880F09F9A80 |
+
+
+  Scenario Outline: It must be able to serialize <label> as a sequence of <type>
+    Given sequence of <type> <value>
+    When I serialize as sequence of <type>
+    Then the result should be bytes <bytes>
+
+    Examples:
+      | label          | type    | value        | bytes                                                                                                                                |
+      | no bool        | bool    | []           | 0x00                                                                                                                                 |
+      | single bool    | bool    | [true]       | 0x0101                                                                                                                               |
+      | double bool    | bool    | [false,true] | 0x020001                                                                                                                             |
+      | no u8          | u8      | []           | 0x00                                                                                                                                 |
+      | single u8      | u8      | [0]          | 0x0100                                                                                                                               |
+      | double u8      | u8      | [1,3]        | 0x020103                                                                                                                             |
+      | no u16         | u16     | []           | 0x00                                                                                                                                 |
+      | single u16     | u16     | [0]          | 0x010000                                                                                                                             |
+      | double u16     | u16     | [1,3]        | 0x0201000300                                                                                                                         |
+      | no u32         | u32     | []           | 0x00                                                                                                                                 |
+      | single u32     | u32     | [0]          | 0x0100000000                                                                                                                         |
+      | double u32     | u32     | [1,3]        | 0x020100000003000000                                                                                                                 |
+      | no u64         | u64     | []           | 0x00                                                                                                                                 |
+      | single u64     | u64     | [0]          | 0x010000000000000000                                                                                                                 |
+      | double u64     | u64     | [1,3]        | 0x0201000000000000000300000000000000                                                                                                 |
+      | no u128        | u128    | []           | 0x00                                                                                                                                 |
+      | single u128    | u128    | [0]          | 0x0100000000000000000000000000000000                                                                                                 |
+      | double u128    | u128    | [1,3]        | 0x020100000000000000000000000000000003000000000000000000000000000000                                                                 |
+      | no u256        | u256    | []           | 0x00                                                                                                                                 |
+      | single u256    | u256    | [0]          | 0x010000000000000000000000000000000000000000000000000000000000000000                                                                 |
+      | double u256    | u256    | [1,3]        | 0x0201000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000 |
+      | no uleb128     | uleb128 | []           | 0x00                                                                                                                                 |
+      | single uleb128 | uleb128 | [0]          | 0x0100                                                                                                                               |
+      | double uleb128 | uleb128 | [128,127]    | 0x0280017F                                                                                                                           |
+      | no address     | address | []           | 0x00                                                                                                                                 |
+      | single address | address | [0x1]        | 0x010000000000000000000000000000000000000000000000000000000000000001                                                                 |
+      | double address | address | [0x2,0x0]    | 0x0200000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000 |
+      | no string      | string  | []           | 0x00                                                                                                                                 |
+      | single string  | string  | ["😀🚀"]     | 0x0108F09F9880F09F9A80                                                                                                               |
+      | double string  | string  | ["a","b"]    | 0x0201610162                                                                                                                         |

--- a/tests/step-definitions/bcs.steps.mts
+++ b/tests/step-definitions/bcs.steps.mts
@@ -1,0 +1,302 @@
+import {
+  AccountAddress,
+  Bool,
+  Hex,
+  U8,
+  U16,
+  U32,
+  U64,
+  U128,
+  U256,
+  Deserializer,
+  Serializer,
+  MoveVector,
+  MoveString,
+} from "../../dist/esm/index.mjs"; // TODO: See if we can import directly from src
+import { Given, Then, When } from "@cucumber/cucumber";
+import assert from "assert";
+
+Given("bytes {}", function(input: string) {
+  this.input = fromByteString(input);
+});
+
+Given("address {}", function(input: string) {
+  this.input = AccountAddress.from(input);
+});
+
+Given("bool {}", function(input: string) {
+  this.input = new Bool(input === "true");
+});
+
+Given("u8 {}", function(input: string) {
+  this.input = new U8(parseInt(input, 10));
+});
+
+Given("u16 {}", function(input: string) {
+  this.input = new U16(parseInt(input, 10));
+});
+
+Given("u32 {}", function(input: string) {
+  this.input = new U32(parseInt(input, 10));
+});
+
+Given("u64 {}", function(input: string) {
+  this.input = new U64(BigInt(input));
+});
+
+Given("u128 {}", function(input: string) {
+  this.input = new U128(BigInt(input));
+});
+
+Given("u256 {}", function(input: string) {
+  this.input = new U256(BigInt(input));
+});
+
+Given("string \"{}\"", function(input: string) {
+  this.input = new MoveString(input);
+});
+
+Given("sequence of {} [{}]", function(type: string, input: string) {
+  this.input = sequenceOf(type, input);
+});
+
+When("I serialize as {}", function(inputType: string) {
+  const serializer = new Serializer();
+
+  switch (inputType) {
+    case "sequence of uleb128":
+      const input = this.input! as MoveVector<U32>;
+
+      // TODO: this is not really supported natively in the TS SDK, it's questionable about if we care about sequences of Uleb128
+      // This shows it "is possible"
+      serializer.serializeU32AsUleb128(input.values.length);
+      input.values.forEach((item: U32) => serializer.serializeU32AsUleb128(item.value));
+      break;
+    case "uleb128":
+      // TODO: Uleb doesn't have the same kind of top level support
+      serializer.serializeU32AsUleb128(this.input!.value);
+      break;
+    case "bytes":
+      // TODO: Bytes and fixed bytes have to be converted here, rather than as input, consider changing name of inputs for spec
+      serializer.serializeBytes(this.input!.toUint8Array());
+      break;
+    case "fixed bytes with length 1":
+    case "fixed bytes with length 2":
+      serializer.serializeFixedBytes(this.input!.toUint8Array());
+      break;
+    default:
+      this.input!.serialize(serializer);
+  }
+  this.result = serializer.toUint8Array();
+});
+
+When("I deserialize as {}", function(inputType: string) {
+  const deserializer = new Deserializer((this.input! as Hex).toUint8Array());
+  this.resultError = false;
+  this.result = null;
+
+  try {
+    switch (inputType) {
+      case "bool":
+        this.result = Bool.deserialize(deserializer).value;
+        break;
+      case "u8":
+        this.result = U8.deserialize(deserializer).value;
+        break;
+      case "u16":
+        this.result = U16.deserialize(deserializer).value;
+        break;
+      case "u32":
+        this.result = U32.deserialize(deserializer).value;
+        break;
+      case "u64":
+        this.result = U64.deserialize(deserializer).value;
+        break;
+      case "u128":
+        this.result = U128.deserialize(deserializer).value;
+        break;
+      case "u256":
+        this.result = U256.deserialize(deserializer).value;
+        break;
+      case "string":
+        this.result = MoveString.deserialize(deserializer).value;
+        break;
+      case "address":
+        this.result = AccountAddress.deserialize(deserializer).toString();
+        break;
+      case "uleb128":
+        // We have to type it back into a U32 for test purposes
+        this.result = deserializer.deserializeUleb128AsU32();
+        break;
+      case "bytes":
+        this.result = deserializer.deserializeBytes();
+        break;
+      case "fixed bytes with length 0":
+        this.result = deserializer.deserializeFixedBytes(0);
+        break;
+      case "fixed bytes with length 1":
+        this.result = deserializer.deserializeFixedBytes(1);
+        break;
+      case "fixed bytes with length 2":
+        this.result = deserializer.deserializeFixedBytes(2);
+        break;
+      case "sequence of bool":
+        this.result = MoveVector.deserialize(deserializer, Bool);
+        break;
+      case "sequence of u8":
+        this.result = MoveVector.deserialize(deserializer, U8);
+        break;
+      case "sequence of u16":
+        this.result = MoveVector.deserialize(deserializer, U16);
+        break;
+      case "sequence of u32":
+        this.result = MoveVector.deserialize(deserializer, U32);
+        break;
+      case "sequence of u64":
+        this.result = MoveVector.deserialize(deserializer, U64);
+        break;
+      case "sequence of u128":
+        this.result = MoveVector.deserialize(deserializer, U128);
+        break;
+      case "sequence of u256":
+        this.result = MoveVector.deserialize(deserializer, U256);
+        break;
+      case "sequence of address":
+        this.result = MoveVector.deserialize(deserializer, AccountAddress);
+        break;
+      case "sequence of string":
+        this.result = MoveVector.deserialize(deserializer, MoveString);
+        break;
+      case "sequence of uleb128":
+        // TODO: Check if we want this supported in the spec
+        const length = deserializer.deserializeUleb128AsU32();
+        const list: number[] = [];
+
+        for (let i = 0; i < length; i++) {
+          list.push(deserializer.deserializeUleb128AsU32());
+        }
+
+        this.result = MoveVector.U32(list);
+        break;
+      default:
+        throw new Error(`Unsupported type: ${inputType}`);
+    }
+  } catch (error: any) {
+    // We have to make this to handle error handling
+    this.resultError = true;
+    this.error = error;
+  }
+
+  // Assert none remaining
+  // TODO: Spec maybe shouldn't have this specific check?
+  if (deserializer.remaining() !== 0) {
+    this.dataRemaining = true;
+  }
+});
+
+Then("the result should be bytes {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.deepEqual(this.result, fromByteString(expected).toUint8Array());
+});
+
+Then("the result should be address {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, AccountAddress.from(expected).toString());
+});
+
+Then("the result should be bool {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, expected === "true");
+});
+
+// TODO: None of the types are comparable, we probably want to fix that
+Then("the result should be u8 {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, parseInt(expected, 10));
+});
+
+Then("the result should be u16 {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, parseInt(expected, 10));
+});
+
+Then("the result should be u32 {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, parseInt(expected, 10));
+});
+
+Then("the result should be u64 {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, BigInt(expected));
+});
+
+Then("the result should be u128 {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, BigInt(expected));
+});
+
+Then("the result should be u256 {}", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, BigInt(expected));
+});
+Then("the result should be string \"{}\"", function(expected: string) {
+  checkDeserializationError(this);
+  assert.equal(this.result, expected);
+});
+
+Then("the result should be sequence of {} [{}]", function(typeName: string, expectedList: string) {
+  checkDeserializationError(this);
+  const expected = sequenceOf(typeName, expectedList);
+  assert.deepEqual(this.result, expected);
+});
+
+Then("the deserialization should fail", function() {
+  assert(this.resultError || this.dataRemaining);
+});
+
+function fromByteString(input: string) {
+  if (input === "0x") {
+    return new Hex(new Uint8Array());
+  } else {
+    return Hex.fromHexString(input);
+  }
+}
+
+function parseArray(input: string) {
+  if (input === "") {
+    return [];
+  }
+  return input.split(",");
+}
+
+function checkDeserializationError(input: any) {
+  assert(input.resultError === false || input.resultError === undefined, `Deserialization failed with error: ${input.error}`);
+  assert(input.dataRemaining === false || input.dataRemaining === undefined, "Data remaining after deserialization");
+}
+
+function sequenceOf(type: string, input: string) {
+  switch (type) {
+    case "bool":
+      return new MoveVector(parseArray(input).map((item) => new Bool(item === "true")));
+    case "u8":
+      return new MoveVector(parseArray(input).map((item) => new U8(parseInt(item, 10))));
+    case "u16":
+      return new MoveVector(parseArray(input).map((item) => new U16(parseInt(item, 10))));
+    case "u32":
+      return new MoveVector(parseArray(input).map((item) => new U32(parseInt(item, 10))));
+    case "u64":
+      return new MoveVector(parseArray(input).map((item) => new U64(BigInt(item))));
+    case "u128":
+      return new MoveVector(parseArray(input).map((item) => new U128(BigInt(item))));
+    case "u256":
+      return new MoveVector(parseArray(input).map((item) => new U256(BigInt(item))));
+    case "uleb128":
+      return new MoveVector(parseArray(input).map((item) => new U32(parseInt(item, 10))));
+    case "address":
+      return new MoveVector(parseArray(input).map((item) => AccountAddress.from(item)));
+    case "string":
+      return new MoveVector(parseArray(input).map((item) => new MoveString(item.replace(/"/g, ""))));
+    default:
+      throw new Error(`Unsupported type: ${type}`);
+  }
+}


### PR DESCRIPTION
### Description
This is a prototype for cross SDK specifications.  It points out some interesting differences between SDKs even just for BCS.  We'll need to go and sit down and write proper specifications that cover the behavior we want.

This is a mirror of the Go SDK spec PR https://github.com/aptos-labs/aptos-go-sdk/pull/78 with the same exact specification!

### Test Plan
I got everything running with the below command.  We will need to probably run it in CI, but until we settle on actual specs, I do not want to run them in CI for the time being.

```bash
pnpm _spec
> @aptos-labs/ts-sdk@1.26.0 _spec /opt/git/typescript-sdk
> ./node_modules/.bin/cucumber-js -p default

(node:47604) [DEP0180] DeprecationWarning: fs.Stats constructor is deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
223 scenarios (223 passed)
669 steps (669 passed)
0m00.037s (executing steps: 0m00.011s)
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->