### PR TITLE
Add support for EventHandle events to getModuleEventsByEventType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - Support `Serialized Type` to Script txn.  Now can use vector<String> for example.
 - Populate `coinType` for `getAccountCoinAmount` if only `faMetadataAddress` is provided.
+- [`Fix`] `getModuleEventsByEventType` will also account for EventHandle events.
 
 # 1.27.1 (2024-08-23)
 

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -31,9 +31,16 @@ export async function getModuleEventsByEventType(args: {
   const { aptosConfig, eventType, options } = args;
 
   const whereCondition: EventsBoolExp = {
-    account_address: { _eq: "0x0000000000000000000000000000000000000000000000000000000000000000" },
-    creation_number: { _eq: "0" },
-    sequence_number: { _eq: "0" },
+    _or: [
+      // EventHandle events
+      { account_address: { _eq: eventType.split("::")[0] } },
+      // Module events
+      {
+        account_address: { _eq: "0x0000000000000000000000000000000000000000000000000000000000000000" },
+        sequence_number: { _eq: 0 },
+        creation_number: { _eq: 0 },
+      },
+    ],
     indexed_type: { _eq: eventType },
   };
 


### PR DESCRIPTION
### Description
Added support for EventHandle events which emit a sequence number, creation number, and are indexed on the module address.

### Test Plan

**EventHandle Event**
<img width="1842" alt="image" src="https://github.com/user-attachments/assets/81ca6592-b6cf-47be-b2f4-608404c0d04c">

**Module Event**
<img width="1837" alt="image" src="https://github.com/user-attachments/assets/19dcff77-b642-426c-92e0-52658b153a4c">

### Related Links
Fixes https://github.com/aptos-labs/aptos-ts-sdk/issues/494