### PR TITLE
Fixed the multisig simulation test failure

### DIFF
--- a/tests/e2e/transaction/helper.ts
+++ b/tests/e2e/transaction/helper.ts
@@ -9,14 +9,18 @@ import {
   EntryFunctionArgumentTypes,
   HexInput,
   InputGenerateTransactionData,
+  InputViewFunctionData,
   SimpleEntryFunctionArgumentTypes,
   MoveVector,
   AnyRawTransaction,
   isUserTransactionResponse,
   Ed25519PrivateKey,
   EphemeralKeyPair,
+  generateTransactionPayload,
+  InputEntryFunctionData,
 } from "../../../src";
 import { FUND_AMOUNT, TRANSFER_AMOUNT } from "../../unit/helper";
+import { getAptosClient } from "../helper";
 
 export const EPHEMERAL_KEY_PAIR = new EphemeralKeyPair({
   privateKey: new Ed25519PrivateKey("0x1111111111111111111111111111111111111111111111111111111111111111"),
@@ -93,6 +97,59 @@ export async function fundAccounts(aptos: Aptos, accounts: Array<Account>) {
     throw new Error("Expected user transaction response");
   }
   return response;
+}
+
+export async function createAndFundMultisigAccount(owner: Account) {
+  const { aptos } = getAptosClient();
+  const payload: InputViewFunctionData = {
+    function: "0x1::multisig_account::get_next_multisig_account_address",
+    functionArguments: [owner.accountAddress.toString()],
+  };
+  const [multisigAddress] = await aptos.view<[string]>({ payload });
+  const createMultisig = await aptos.transaction.build.simple({
+    sender: owner.accountAddress,
+    data: {
+      function: "0x1::multisig_account::create",
+      functionArguments: [1, [], []],
+    },
+  });
+  const ownerAuthenticator = aptos.transaction.sign({ signer: owner, transaction: createMultisig });
+  const res = await aptos.transaction.submit.simple({
+    senderAuthenticator: ownerAuthenticator,
+    transaction: createMultisig,
+  });
+  await aptos.waitForTransaction({ transactionHash: res.hash });
+  await aptos.fundAccount({ accountAddress: multisigAddress, amount: FUND_AMOUNT });
+  return multisigAddress;
+}
+
+export async function createMultisigTransaction(
+  owner: Account,
+  multisigAddress: string,
+  multisigEntryFunction: InputEntryFunctionData,
+) {
+  const { aptos, config } = getAptosClient();
+  const transactionPayload = await generateTransactionPayload({
+    multisigAddress,
+    function: multisigEntryFunction.function,
+    functionArguments: multisigEntryFunction.functionArguments,
+    aptosConfig: config,
+  });
+  const createMultisigTx = await aptos.transaction.build.simple({
+    sender: owner.accountAddress,
+    data: {
+      function: "0x1::multisig_account::create_transaction",
+      functionArguments: [multisigAddress, transactionPayload.multiSig.transaction_payload!.bcsToBytes()],
+    },
+  });
+
+  const createMultisigTxAuthenticator = aptos.transaction.sign({ signer: owner, transaction: createMultisigTx });
+
+  const createMultisigTxResponse = await aptos.transaction.submit.simple({
+    senderAuthenticator: createMultisigTxAuthenticator,
+    transaction: createMultisigTx,
+  });
+  await aptos.waitForTransaction({ transactionHash: createMultisigTxResponse.hash });
 }
 
 export async function simpleCoinTransactionHeler(aptos: Aptos, sender: Account, recipient: Account) {

--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -1,7 +1,14 @@
-import { Account, U64, SigningSchemeInput } from "../../../src";
+import { Account, U64, SigningSchemeInput, InputEntryFunctionData } from "../../../src";
 import { longTestTimeout } from "../../unit/helper";
 import { getAptosClient } from "../helper";
-import { fundAccounts, multiSignerScriptBytecode, publishTransferPackage, singleSignerScriptBytecode } from "./helper";
+import {
+  createAndFundMultisigAccount,
+  createMultisigTransaction,
+  fundAccounts,
+  multiSignerScriptBytecode,
+  publishTransferPackage,
+  singleSignerScriptBytecode,
+} from "./helper";
 
 describe("transaction simulation", () => {
   const { aptos } = getAptosClient();
@@ -12,6 +19,11 @@ describe("transaction simulation", () => {
   const recieverAccounts = [Account.generate(), Account.generate()];
   const secondarySignerAccount = Account.generate();
   const feePayerAccount = Account.generate();
+  let multisigAddress: string;
+  const multisigEntryFunction: InputEntryFunctionData = {
+    function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+    functionArguments: [1, recieverAccounts[0].accountAddress],
+  };
   beforeAll(async () => {
     await fundAccounts(aptos, [
       contractPublisherAccount,
@@ -25,6 +37,10 @@ describe("transaction simulation", () => {
     await publishTransferPackage(aptos, contractPublisherAccount);
   }, longTestTimeout);
   describe("Single Sender ED25519", () => {
+    beforeAll(async () => {
+      multisigAddress = await createAndFundMultisigAccount(singleSignerED25519SenderAccount);
+      await createMultisigTransaction(singleSignerED25519SenderAccount, multisigAddress, multisigEntryFunction);
+    }, longTestTimeout);
     describe("single signer", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
@@ -54,13 +70,13 @@ describe("transaction simulation", () => {
         });
         expect(response.success).toBeTruthy();
       });
-      test.skip("with multisig payload", async () => {
+      test("with multisig payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
           sender: singleSignerED25519SenderAccount.accountAddress,
           data: {
-            multisigAddress: secondarySignerAccount.accountAddress,
-            function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            multisigAddress,
+            function: multisigEntryFunction.function,
+            functionArguments: multisigEntryFunction.functionArguments,
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -160,13 +176,13 @@ describe("transaction simulation", () => {
         });
         expect(response.success).toBeTruthy();
       });
-      test.skip("with multisig payload", async () => {
+      test("with multisig payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
           sender: singleSignerED25519SenderAccount.accountAddress,
           data: {
-            multisigAddress: secondarySignerAccount.accountAddress,
-            function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            multisigAddress,
+            function: multisigEntryFunction.function,
+            functionArguments: multisigEntryFunction.functionArguments,
           },
           withFeePayer: true,
         });
@@ -208,6 +224,10 @@ describe("transaction simulation", () => {
     });
   });
   describe("Single Sender Secp256k1", () => {
+    beforeAll(async () => {
+      multisigAddress = await createAndFundMultisigAccount(singleSignerSecp256k1Account);
+      await createMultisigTransaction(singleSignerSecp256k1Account, multisigAddress, multisigEntryFunction);
+    }, longTestTimeout);
     describe("single signer", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
@@ -237,13 +257,13 @@ describe("transaction simulation", () => {
         });
         expect(response.success).toBeTruthy();
       });
-      test.skip("with multisig payload", async () => {
+      test("with multisig payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
           sender: singleSignerSecp256k1Account.accountAddress,
           data: {
-            multisigAddress: secondarySignerAccount.accountAddress,
-            function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            multisigAddress,
+            function: multisigEntryFunction.function,
+            functionArguments: multisigEntryFunction.functionArguments,
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -343,13 +363,13 @@ describe("transaction simulation", () => {
         });
         expect(response.success).toBeTruthy();
       });
-      test.skip("with multisig payload", async () => {
+      test("with multisig payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
           sender: singleSignerSecp256k1Account.accountAddress,
           data: {
-            multisigAddress: secondarySignerAccount.accountAddress,
-            function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            multisigAddress,
+            function: multisigEntryFunction.function,
+            functionArguments: multisigEntryFunction.functionArguments,
           },
           withFeePayer: true,
         });
@@ -391,6 +411,10 @@ describe("transaction simulation", () => {
     });
   });
   describe("Legacy ED25519", () => {
+    beforeAll(async () => {
+      multisigAddress = await createAndFundMultisigAccount(legacyED25519SenderAccount);
+      await createMultisigTransaction(legacyED25519SenderAccount, multisigAddress, multisigEntryFunction);
+    }, longTestTimeout);
     describe("single signer", () => {
       test("with script payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
@@ -420,13 +444,13 @@ describe("transaction simulation", () => {
         });
         expect(response.success).toBeTruthy();
       });
-      test.skip("with multisig payload", async () => {
+      test("with multisig payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
           sender: legacyED25519SenderAccount.accountAddress,
           data: {
-            multisigAddress: secondarySignerAccount.accountAddress,
-            function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            multisigAddress,
+            function: multisigEntryFunction.function,
+            functionArguments: multisigEntryFunction.functionArguments,
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -520,13 +544,13 @@ describe("transaction simulation", () => {
         });
         expect(response.success).toBeTruthy();
       });
-      test.skip("with multisig payload", async () => {
+      test("with multisig payload", async () => {
         const rawTxn = await aptos.transaction.build.simple({
           sender: legacyED25519SenderAccount.accountAddress,
           data: {
-            multisigAddress: secondarySignerAccount.accountAddress,
-            function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            multisigAddress,
+            function: multisigEntryFunction.function,
+            functionArguments: multisigEntryFunction.functionArguments,
           },
           withFeePayer: true,
         });


### PR DESCRIPTION
### Description
The multisig simulation test fails with a vm_status: 'ACCOUNT_NOT_MULTISIG' error because the address used in the test is not associated with a multisig account. Additionally, the multisig transaction has not been submitted on-chain.

This update resolves the issue by properly setting up the multisig simulation test environment:
* Creating and using a multisig account.
* Creating a multisig transaction before running the simulation. 

Two helper functions, `createAndFundMultisigAccount` and `createMultisigTransaction`, are introduced. These functions can also be helpful in the future.

### Test Plan
unit tests

### Related Links
This resolves https://github.com/aptos-labs/aptos-ts-sdk/issues/505.