### PR TITLE
Correct typo in variable name

### DIFF
--- a/tests/e2e/transaction/transactionSimulation.test.ts
+++ b/tests/e2e/transaction/transactionSimulation.test.ts
@@ -16,13 +16,13 @@ describe("transaction simulation", () => {
   const singleSignerED25519SenderAccount = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: false });
   const legacyED25519SenderAccount = Account.generate();
   const singleSignerSecp256k1Account = Account.generate({ scheme: SigningSchemeInput.Secp256k1Ecdsa });
-  const recieverAccounts = [Account.generate(), Account.generate()];
+  const receiverAccounts = [Account.generate(), Account.generate()];
   const secondarySignerAccount = Account.generate();
   const feePayerAccount = Account.generate();
   let multisigAddress: string;
   const multisigEntryFunction: InputEntryFunctionData = {
     function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-    functionArguments: [1, recieverAccounts[0].accountAddress],
+    functionArguments: [1, receiverAccounts[0].accountAddress],
   };
   beforeAll(async () => {
     await fundAccounts(aptos, [
@@ -30,7 +30,7 @@ describe("transaction simulation", () => {
       singleSignerED25519SenderAccount,
       singleSignerSecp256k1Account,
       legacyED25519SenderAccount,
-      ...recieverAccounts,
+      ...receiverAccounts,
       secondarySignerAccount,
       feePayerAccount,
     ]);
@@ -47,7 +47,7 @@ describe("transaction simulation", () => {
           sender: singleSignerED25519SenderAccount.accountAddress,
           data: {
             bytecode: singleSignerScriptBytecode,
-            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -61,7 +61,7 @@ describe("transaction simulation", () => {
           sender: singleSignerED25519SenderAccount.accountAddress,
           data: {
             function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            functionArguments: [1, receiverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -96,8 +96,8 @@ describe("transaction simulation", () => {
             functionArguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
-              recieverAccounts[0].accountAddress,
-              recieverAccounts[1].accountAddress,
+              receiverAccounts[0].accountAddress,
+              receiverAccounts[1].accountAddress,
               new U64(BigInt(50)),
             ],
           },
@@ -122,8 +122,8 @@ describe("transaction simulation", () => {
               functionArguments: [
                 new U64(100),
                 new U64(200),
-                recieverAccounts[0].accountAddress,
-                recieverAccounts[1].accountAddress,
+                receiverAccounts[0].accountAddress,
+                receiverAccounts[1].accountAddress,
                 new U64(50),
               ],
             },
@@ -145,7 +145,7 @@ describe("transaction simulation", () => {
           sender: singleSignerED25519SenderAccount.accountAddress,
           data: {
             bytecode: singleSignerScriptBytecode,
-            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
           withFeePayer: true,
         });
@@ -163,7 +163,7 @@ describe("transaction simulation", () => {
           sender: singleSignerED25519SenderAccount.accountAddress,
           data: {
             function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            functionArguments: [1, receiverAccounts[0].accountAddress],
           },
           withFeePayer: true,
         });
@@ -204,8 +204,8 @@ describe("transaction simulation", () => {
             functionArguments: [
               new U64(100),
               new U64(200),
-              recieverAccounts[0].accountAddress,
-              recieverAccounts[1].accountAddress,
+              receiverAccounts[0].accountAddress,
+              receiverAccounts[1].accountAddress,
               new U64(50),
             ],
           },
@@ -234,7 +234,7 @@ describe("transaction simulation", () => {
           sender: singleSignerSecp256k1Account.accountAddress,
           data: {
             bytecode: singleSignerScriptBytecode,
-            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -248,7 +248,7 @@ describe("transaction simulation", () => {
           sender: singleSignerSecp256k1Account.accountAddress,
           data: {
             function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            functionArguments: [1, receiverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -283,8 +283,8 @@ describe("transaction simulation", () => {
             functionArguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
-              recieverAccounts[0].accountAddress,
-              recieverAccounts[1].accountAddress,
+              receiverAccounts[0].accountAddress,
+              receiverAccounts[1].accountAddress,
               new U64(BigInt(50)),
             ],
           },
@@ -309,8 +309,8 @@ describe("transaction simulation", () => {
               functionArguments: [
                 new U64(100),
                 new U64(200),
-                recieverAccounts[0].accountAddress,
-                recieverAccounts[1].accountAddress,
+                receiverAccounts[0].accountAddress,
+                receiverAccounts[1].accountAddress,
                 new U64(50),
               ],
             },
@@ -332,7 +332,7 @@ describe("transaction simulation", () => {
           sender: singleSignerSecp256k1Account.accountAddress,
           data: {
             bytecode: singleSignerScriptBytecode,
-            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
           withFeePayer: true,
         });
@@ -350,7 +350,7 @@ describe("transaction simulation", () => {
           sender: singleSignerSecp256k1Account.accountAddress,
           data: {
             function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            functionArguments: [1, receiverAccounts[0].accountAddress],
           },
           withFeePayer: true,
         });
@@ -391,8 +391,8 @@ describe("transaction simulation", () => {
             functionArguments: [
               new U64(100),
               new U64(200),
-              recieverAccounts[0].accountAddress,
-              recieverAccounts[1].accountAddress,
+              receiverAccounts[0].accountAddress,
+              receiverAccounts[1].accountAddress,
               new U64(50),
             ],
           },
@@ -421,7 +421,7 @@ describe("transaction simulation", () => {
           sender: legacyED25519SenderAccount.accountAddress,
           data: {
             bytecode: singleSignerScriptBytecode,
-            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -435,7 +435,7 @@ describe("transaction simulation", () => {
           sender: legacyED25519SenderAccount.accountAddress,
           data: {
             function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            functionArguments: [1, receiverAccounts[0].accountAddress],
           },
         });
         const [response] = await aptos.transaction.simulate.simple({
@@ -470,8 +470,8 @@ describe("transaction simulation", () => {
             functionArguments: [
               new U64(BigInt(100)),
               new U64(BigInt(200)),
-              recieverAccounts[0].accountAddress,
-              recieverAccounts[1].accountAddress,
+              receiverAccounts[0].accountAddress,
+              receiverAccounts[1].accountAddress,
               new U64(BigInt(50)),
             ],
           },
@@ -493,7 +493,7 @@ describe("transaction simulation", () => {
             secondarySignerAddresses: [secondarySignerAccount.accountAddress],
             data: {
               function: `${contractPublisherAccount.accountAddress}::transfer::two_by_two`,
-              functionArguments: [100, 200, recieverAccounts[0].accountAddress, recieverAccounts[1].accountAddress, 50],
+              functionArguments: [100, 200, receiverAccounts[0].accountAddress, receiverAccounts[1].accountAddress, 50],
             },
           });
 
@@ -513,7 +513,7 @@ describe("transaction simulation", () => {
           sender: legacyED25519SenderAccount.accountAddress,
           data: {
             bytecode: singleSignerScriptBytecode,
-            functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+            functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
           },
           withFeePayer: true,
         });
@@ -531,7 +531,7 @@ describe("transaction simulation", () => {
           sender: legacyED25519SenderAccount.accountAddress,
           data: {
             function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
-            functionArguments: [1, recieverAccounts[0].accountAddress],
+            functionArguments: [1, receiverAccounts[0].accountAddress],
           },
           withFeePayer: true,
         });
@@ -569,7 +569,7 @@ describe("transaction simulation", () => {
           secondarySignerAddresses: [secondarySignerAccount.accountAddress],
           data: {
             function: `${contractPublisherAccount.accountAddress}::transfer::two_by_two`,
-            functionArguments: [100, 200, recieverAccounts[0].accountAddress, recieverAccounts[1].accountAddress, 50],
+            functionArguments: [100, 200, receiverAccounts[0].accountAddress, receiverAccounts[1].accountAddress, 50],
           },
           withFeePayer: true,
         });
@@ -591,7 +591,7 @@ describe("transaction simulation", () => {
         sender: singleSignerSecp256k1Account.accountAddress,
         data: {
           bytecode: singleSignerScriptBytecode,
-          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
         },
         withFeePayer: true,
       });
@@ -611,7 +611,7 @@ describe("transaction simulation", () => {
         secondarySignerAddresses: [secondarySignerAccount.accountAddress],
         data: {
           bytecode: singleSignerScriptBytecode,
-          functionArguments: [new U64(1), recieverAccounts[0].accountAddress],
+          functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
         },
         withFeePayer: true,
       });


### PR DESCRIPTION
### Description
This PR fixes a typo by correcting "recieverAccounts" to "receiverAccounts" in `transactionSimulation.test.ts`.

### Test Plan
CI test

### Related Links
N.A.