### PR TITLE
[coin] Populate the `coinType` when only `faMetadataAddress` is provided in `getAccountCoinAmount`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 # Unreleased
 
 - Support `Serialized Type` to Script txn.  Now can use vector<String> for example.
+- Populate `coinType` for `getAccountCoinAmount` if only `faMetadataAddress` is provided.
 
 # 1.27.1 (2024-08-23)
 

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -44,6 +44,7 @@ export const DEFAULT_TXN_TIMEOUT_SEC = 20;
  * The default gas currency for the network.
  */
 export const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
+export const APTOS_FA = "0x000000000000000000000000000000000000000000000000000000000000000a";
 
 export const RAW_TRANSACTION_SALT = "APTOS::RawTransaction";
 export const RAW_TRANSACTION_WITH_DATA_SALT = "APTOS::RawTransactionWithData";


### PR DESCRIPTION
### Description
Add a view function to retrieve the `coinType` if it is paired with the `faMetadataAddress`

### Test Plan
```ts
import { Aptos, AptosConfig, Network, NetworkToNetworkName } from "@aptos-labs/ts-sdk";

const APTOS_NETWORK: Network = NetworkToNetworkName[Network.MAINNET];
const aptos = new Aptos(new AptosConfig({ network: APTOS_NETWORK }));

async function main() {
  const balance1 = await aptos.getAccountCoinAmount({
    accountAddress: "0xa35066a9238fc9d2f4f53e2ec6a0aba4ff949ba7eaa43b748ad9f0fb60add3c2",
    coinType: "0x1::aptos_coin::AptosCoin",
  });
  const balance2 = await aptos.getAccountCoinAmount({
    accountAddress: "0xa35066a9238fc9d2f4f53e2ec6a0aba4ff949ba7eaa43b748ad9f0fb60add3c2",
    faMetadataAddress: "0x000000000000000000000000000000000000000000000000000000000000000a",
  });
  const balance3 = await aptos.getAccountCoinAmount({
    accountAddress: "0x66cb05df2d855fbae92cdb2dfac9a0b29c969a03998fa817735d27391b52b189",
    faMetadataAddress: "0x000000000000000000000000000000000000000000000000000000000000000a",
  });
  const balance4 = await aptos.getAccountCoinAmount({
    accountAddress: "0x66cb05df2d855fbae92cdb2dfac9a0b29c969a03998fa817735d27391b52b189",
    coinType: "0x1::aptos_coin::AptosCoin",
  });
  const badFaBalance = await aptos.getAccountCoinAmount({
    accountAddress: "0x66cb05df2d855fbae92cdb2dfac9a0b29c969a03998fa817735d27391b52b189",
    faMetadataAddress: "0x000000000000000000000000000000000000000001230000000000000000000a",
  });

  if (balance1 === 0) throw new Error("Balance1 is 0");
  if (balance2 === 0) throw new Error("Balance2 is 0");
  if (balance3 === 0) throw new Error("Balance3 is 0");
  if (balance4 === 0) throw new Error("Balance4 is 0");
  if (badFaBalance !== 0) throw new Error("Bad FA balance is not 0");

  console.log("Balances are: ", balance1, balance2, balance3, balance4, badFaBalance);
}

main();
```