### PR TITLE
Add is_event to MoveStruct

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1014,6 +1014,12 @@ export type MoveStruct = {
    */
   is_native: boolean;
   /**
+   * Whether the struct is a module event (aka v2 event). This will be false for v1
+   * events because the value is derived from the #[event] attribute on the struct in
+   * the Move source code. This attribute is only relevant for v2 events.
+   */
+  is_event: boolean;
+  /**
    * Abilities associated with the struct
    */
   abilities: Array<MoveAbility>;


### PR DESCRIPTION
### Description
TS SDK counterpart to https://github.com/aptos-labs/aptos-core/pull/14246.

We can't release this yet, the `is_event` field has only been released to devnet and testnet so far.

### Test Plan
I see there are no tests for `is_native` so idk if we normally test these fields, given they're really just served verbatim from the API. Happy to add tests if requested.

### Related Links
- https://github.com/aptos-labs/aptos-core/pull/14246