### PR TITLE
Improve fee payer txn submission APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - [`Fix`] `getModuleEventsByEventType` will also account for EventHandle events.
 - [`Hot Fix`] change regex to find object address when using `createObjectAndPublishPackage` move function
 - Add support for federated keyless accounts as defined in AIP-96
+- Add a `signAndSubmitAsFeePayer` function to the API.
+- Add an optional `feePayerAuthenticator` parameter to `signAndSubmitTransaction`.
 
 # 1.27.1 (2024-08-23)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - [`Fix`] `getModuleEventsByEventType` will also account for EventHandle events.
 - [`Hot Fix`] change regex to find object address when using `createObjectAndPublishPackage` move function
 - Add support for federated keyless accounts as defined in AIP-96
-- Add a `signAndSubmitAsFeePayer` function to the API.
-- Add an optional `feePayerAuthenticator` parameter to `signAndSubmitTransaction`.
+- Add a `signAndSubmitAsFeePayer` function to the API to allow for submission by the fee payer.
+- Add an optional `feePayerAuthenticator` and `feePayer` parameter to `signAndSubmitTransaction` to support signing and submitting in one line.
 
 # 1.27.1 (2024-08-23)
 

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -74,7 +74,11 @@ const example = async () => {
   const sponsorSignature = aptos.transaction.signAsFeePayer({ signer: sponsor, transaction });
 
   // Submit the transaction to chain
-  const committedTxn = await aptos.signAndSubmitTransaction({ signer: alice, feePayerAuthenticator: sponsorSignature, transaction });
+  const committedTxn = await aptos.signAndSubmitTransaction({
+    signer: alice,
+    feePayerAuthenticator: sponsorSignature,
+    transaction,
+  });
 
   console.log(`Submitted transaction: ${committedTxn.hash}`);
   const response = await aptos.waitForTransaction({ transactionHash: committedTxn.hash });

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -71,7 +71,7 @@ const example = async () => {
   });
 
   // Submit the transaction to chain
-  const committedTxn = await aptos.signAndSubmitFeePayerTransaction({signer: alice, feePayer: sponsor, transaction});
+  const committedTxn = await aptos.signAndSubmitAsFeePayer({signer: alice, feePayer: sponsor, transaction});
 
   console.log(`Submitted transaction: ${committedTxn.hash}`);
   const response = await aptos.waitForTransaction({ transactionHash: committedTxn.hash });

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -71,7 +71,7 @@ const example = async () => {
   });
 
   // Submit the transaction to chain
-  const committedTxn = await aptos.signAndSubmitTransaction({signer: alice, feePayer: sponsor, transaction});
+  const committedTxn = await aptos.signAndSubmitTransaction({ signer: alice, feePayer: sponsor, transaction });
 
   console.log(`Submitted transaction: ${committedTxn.hash}`);
   const response = await aptos.waitForTransaction({ transactionHash: committedTxn.hash });

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -70,8 +70,11 @@ const example = async () => {
     },
   });
 
+  // Sponsor signs
+  const sponsorSignature = aptos.transaction.signAsFeePayer({ signer: sponsor, transaction });
+
   // Submit the transaction to chain
-  const committedTxn = await aptos.signAndSubmitTransaction({ signer: alice, feePayer: sponsor, transaction });
+  const committedTxn = await aptos.signAndSubmitTransaction({ signer: alice, feePayerAuthenticator: sponsorSignature, transaction });
 
   console.log(`Submitted transaction: ${committedTxn.hash}`);
   const response = await aptos.waitForTransaction({ transactionHash: committedTxn.hash });

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -71,7 +71,7 @@ const example = async () => {
   });
 
   // Submit the transaction to chain
-  const committedTxn = await aptos.signAndSubmitAsFeePayer({signer: alice, feePayer: sponsor, transaction});
+  const committedTxn = await aptos.signAndSubmitTransaction({signer: alice, feePayer: sponsor, transaction});
 
   console.log(`Submitted transaction: ${committedTxn.hash}`);
   const response = await aptos.waitForTransaction({ transactionHash: committedTxn.hash });

--- a/examples/typescript/simple_sponsored_transaction.ts
+++ b/examples/typescript/simple_sponsored_transaction.ts
@@ -70,18 +70,8 @@ const example = async () => {
     },
   });
 
-  // Alice signs
-  const senderSignature = aptos.transaction.sign({ signer: alice, transaction });
-
-  // Sponsor signs
-  const sponsorSignature = aptos.transaction.signAsFeePayer({ signer: sponsor, transaction });
-
   // Submit the transaction to chain
-  const committedTxn = await aptos.transaction.submit.simple({
-    transaction,
-    senderAuthenticator: senderSignature,
-    feePayerAuthenticator: sponsorSignature,
-  });
+  const committedTxn = await aptos.signAndSubmitFeePayerTransaction({signer: alice, feePayer: sponsor, transaction});
 
   console.log(`Submitted transaction: ${committedTxn.hash}`);
   const response = await aptos.waitForTransaction({ transactionHash: committedTxn.hash });

--- a/src/account/AbstractKeylessAccount.ts
+++ b/src/account/AbstractKeylessAccount.ts
@@ -28,7 +28,7 @@ import { FederatedKeylessPublicKey } from "../core/crypto/federatedKeyless";
  * Account implementation for the Keyless authentication scheme.  This abstract class is used for standard Keyless Accounts
  * and Federated Keyless Accounts.
  */
-export abstract class KeylessAccountCommon extends Serializable implements Account {
+export abstract class AbstractKeylessAccount extends Serializable implements Account {
   static readonly PEPPER_LENGTH: number = 31;
 
   /**
@@ -131,8 +131,8 @@ export abstract class KeylessAccountCommon extends Serializable implements Accou
     }
     this.signingScheme = SigningScheme.SingleKey;
     const pepperBytes = Hex.fromHexInput(pepper).toUint8Array();
-    if (pepperBytes.length !== KeylessAccountCommon.PEPPER_LENGTH) {
-      throw new Error(`Pepper length in bytes should be ${KeylessAccountCommon.PEPPER_LENGTH}`);
+    if (pepperBytes.length !== AbstractKeylessAccount.PEPPER_LENGTH) {
+      throw new Error(`Pepper length in bytes should be ${AbstractKeylessAccount.PEPPER_LENGTH}`);
     }
     this.pepper = pepperBytes;
   }

--- a/src/account/FederatedKeylessAccount.ts
+++ b/src/account/FederatedKeylessAccount.ts
@@ -9,7 +9,7 @@ import { ZeroKnowledgeSig } from "../core/crypto";
 import { EphemeralKeyPair } from "./EphemeralKeyPair";
 import { Deserializer, Serializer } from "../bcs";
 import { FederatedKeylessPublicKey } from "../core/crypto/federatedKeyless";
-import { KeylessAccountCommon, ProofFetchCallback } from "./KeylessAccountCommon";
+import { AbstractKeylessAccount, ProofFetchCallback } from "./AbstractKeylessAccount";
 
 /**
  * Account implementation for the FederatedKeyless authentication scheme.
@@ -22,7 +22,7 @@ import { KeylessAccountCommon, ProofFetchCallback } from "./KeylessAccountCommon
  * When the proof expires or the JWT becomes invalid, the KeylessAccount must be instantiated again with a new JWT,
  * EphemeralKeyPair, and corresponding proof.
  */
-export class FederatedKeylessAccount extends KeylessAccountCommon {
+export class FederatedKeylessAccount extends AbstractKeylessAccount {
   /**
    * The FederatedKeylessPublicKey associated with the account
    */

--- a/src/account/KeylessAccount.ts
+++ b/src/account/KeylessAccount.ts
@@ -8,7 +8,7 @@ import { ZeroKnowledgeSig } from "../core/crypto";
 
 import { EphemeralKeyPair } from "./EphemeralKeyPair";
 import { Deserializer, Serializer } from "../bcs";
-import { KeylessAccountCommon, ProofFetchCallback } from "./KeylessAccountCommon";
+import { AbstractKeylessAccount, ProofFetchCallback } from "./AbstractKeylessAccount";
 
 /**
  * Account implementation for the Keyless authentication scheme.
@@ -20,7 +20,7 @@ import { KeylessAccountCommon, ProofFetchCallback } from "./KeylessAccountCommon
  * When the proof expires or the JWT becomes invalid, the KeylessAccount must be instantiated again with a new JWT,
  * EphemeralKeyPair, and corresponding proof.
  */
-export class KeylessAccount extends KeylessAccountCommon {
+export class KeylessAccount extends AbstractKeylessAccount {
   // Use the static constructor 'create' instead.
   private constructor(args: {
     address?: AccountAddress;

--- a/src/account/MultiKeyAccount.ts
+++ b/src/account/MultiKeyAccount.ts
@@ -7,7 +7,7 @@ import { AccountAddress, AccountAddressInput } from "../core/accountAddress";
 import { HexInput, SigningScheme } from "../types";
 import { AccountAuthenticatorMultiKey } from "../transactions/authenticator/account";
 import { AnyRawTransaction } from "../transactions/types";
-import { KeylessAccount } from "./KeylessAccount";
+import { KeylessAccountCommon } from "./KeylessAccountCommon";
 
 export interface VerifyMultiKeySignatureArgs {
   message: HexInput;
@@ -130,7 +130,7 @@ export class MultiKeyAccount implements Account {
    * @return
    */
   async waitForProofFetch() {
-    const keylessSigners = this.signers.filter((signer) => signer instanceof KeylessAccount) as KeylessAccount[];
+    const keylessSigners = this.signers.filter((signer) => signer instanceof KeylessAccountCommon) as KeylessAccountCommon[];
     const promises = keylessSigners.map(async (signer) => signer.waitForProofFetch());
     await Promise.all(promises);
   }

--- a/src/account/MultiKeyAccount.ts
+++ b/src/account/MultiKeyAccount.ts
@@ -7,7 +7,7 @@ import { AccountAddress, AccountAddressInput } from "../core/accountAddress";
 import { HexInput, SigningScheme } from "../types";
 import { AccountAuthenticatorMultiKey } from "../transactions/authenticator/account";
 import { AnyRawTransaction } from "../transactions/types";
-import { KeylessAccountCommon } from "./KeylessAccountCommon";
+import { AbstractKeylessAccount } from "./AbstractKeylessAccount";
 
 export interface VerifyMultiKeySignatureArgs {
   message: HexInput;
@@ -131,8 +131,8 @@ export class MultiKeyAccount implements Account {
    */
   async waitForProofFetch() {
     const keylessSigners = this.signers.filter(
-      (signer) => signer instanceof KeylessAccountCommon,
-    ) as KeylessAccountCommon[];
+      (signer) => signer instanceof AbstractKeylessAccount,
+    ) as AbstractKeylessAccount[];
     const promises = keylessSigners.map(async (signer) => signer.waitForProofFetch());
     await Promise.all(promises);
   }

--- a/src/account/MultiKeyAccount.ts
+++ b/src/account/MultiKeyAccount.ts
@@ -130,7 +130,9 @@ export class MultiKeyAccount implements Account {
    * @return
    */
   async waitForProofFetch() {
-    const keylessSigners = this.signers.filter((signer) => signer instanceof KeylessAccountCommon) as KeylessAccountCommon[];
+    const keylessSigners = this.signers.filter(
+      (signer) => signer instanceof KeylessAccountCommon,
+    ) as KeylessAccountCommon[];
     const promises = keylessSigners.map(async (signer) => signer.waitForProofFetch());
     await Promise.all(promises);
   }

--- a/src/account/index.ts
+++ b/src/account/index.ts
@@ -3,6 +3,6 @@ export * from "./Account";
 export * from "./SingleKeyAccount";
 export * from "./EphemeralKeyPair";
 export * from "./KeylessAccount";
-export * from "./KeylessAccountCommon";
+export * from "./AbstractKeylessAccount";
 export * from "./FederatedKeylessAccount";
 export * from "./MultiKeyAccount";

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -21,6 +21,7 @@ import {
   WaitForTransactionOptions,
 } from "../types";
 import {
+  FeePayerOrFeePayerAuthenticatorOrNeither,
   getSigningMessage,
   publicPackageTransaction,
   rotateAuthKey,
@@ -346,9 +347,8 @@ export class Transaction {
    *
    * @return PendingTransactionResponse
    */
-  async signAndSubmitTransaction(args: {
+  async signAndSubmitTransaction(args: FeePayerOrFeePayerAuthenticatorOrNeither & {
     signer: Account;
-    feePayerAuthenticator: AccountAuthenticator;
     transaction: AnyRawTransaction;
   }): Promise<PendingTransactionResponse> {
     return signAndSubmitTransaction({

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -346,13 +346,15 @@ export class Transaction {
    *
    * @return PendingTransactionResponse
    */
-  async signAndSubmitTransaction(args: FeePayerOrFeePayerAuthenticatorOrNeither & {
-    signer: Account;
-    transaction: AnyRawTransaction;
-  }): Promise<PendingTransactionResponse> {
+  async signAndSubmitTransaction(
+    args: FeePayerOrFeePayerAuthenticatorOrNeither & {
+      signer: Account;
+      transaction: AnyRawTransaction;
+    },
+  ): Promise<PendingTransactionResponse> {
     return signAndSubmitTransaction({
       aptosConfig: this.config,
-      ...args
+      ...args,
     });
   }
 
@@ -374,13 +376,11 @@ export class Transaction {
    *
    * @return PendingTransactionResponse
    */
-  async signAndSubmitAsFeePayer(
-    args: {
-      feePayer: Account;
-      senderAuthenticator: AccountAuthenticator;
-      transaction: AnyRawTransaction;
-    },
-  ): Promise<PendingTransactionResponse> {
+  async signAndSubmitAsFeePayer(args: {
+    feePayer: Account;
+    senderAuthenticator: AccountAuthenticator;
+    transaction: AnyRawTransaction;
+  }): Promise<PendingTransactionResponse> {
     return signAndSubmitAsFeePayer({
       aptosConfig: this.config,
       ...args,

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -28,7 +28,6 @@ import {
   signAndSubmitAsFeePayer,
   signAndSubmitTransaction,
   signAsFeePayer,
-  SignerOrSignerAuthenticator,
   signTransaction,
 } from "../internal/transactionSubmission";
 import {
@@ -358,39 +357,27 @@ export class Transaction {
   }
 
   /**
-   * Sign and submit a single signer transaction a with fee payer to chain
+   * Sign and submit a single signer transaction as the fee payer to chain given an authenticator by the sender of the transaction.
    *
-   * Note: Exactly one signer or signerAuthenticator must be set. If you have don't have access to the
-   * singing account (the account that created the transaction), the signerAuthenticator parameter may be
-   * set instead with an authenticator provided by the signer.
-   *
-   * @param args.signer The signer account to sign the transaction
-   * @param args.signerAuthenticator The AccountAuthenticator signed by the sender of the transaction
    * @param args.feePayer The fee payer account to sign the transaction
+   * @param args.senderAuthenticator The AccountAuthenticator signed by the sender of the transaction
    * @param args.transaction An instance of a RawTransaction, plus optional secondary/fee payer addresses
    *
    * @example
-   * const transaction = await aptos.transaction.build.simple({feePayer: true ...})
-   * const transaction = await aptos.signAndSubmitAsFeePayer({
-   *  signer: alice,
+   * const transaction = await aptos.transaction.build.simple({sender: alice.accountAddress, feePayer: true ...})
+   * const senderAuthenticator = alice.signTransactionWithAuthenticator(transaction)
+   * const pendingTransaction = await aptos.signAndSubmitAsFeePayer({
+   *  senderAuthenticator,
    *  feePayer: bob,
-   *  transaction
-   * })
-   *
-   * @example
-   * const transaction = await aptos.transaction.build.simple({feePayer: true ...})
-   * const authenticator = alice.signTransactionWithAuthenticator(transaction)
-   * const transaction = await aptos.signAndSubmitAsFeePayer({
-   *  signerAuthenticator: authenticator,
-   *  feePayer: alice,
-   *  transaction
+   *  transaction,
    * })
    *
    * @return PendingTransactionResponse
    */
   async signAndSubmitAsFeePayer(
-    args: SignerOrSignerAuthenticator & {
+    args: {
       feePayer: Account;
+      senderAuthenticator: AccountAuthenticator;
       transaction: AnyRawTransaction;
     },
   ): Promise<PendingTransactionResponse> {

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -24,7 +24,10 @@ import {
   getSigningMessage,
   publicPackageTransaction,
   rotateAuthKey,
+  signAndSubmitAsFeePayer,
   signAndSubmitTransaction,
+  signAsFeePayer,
+  SignerOrSignerAuthenticator,
   signTransaction,
 } from "../internal/transactionSubmission";
 import {
@@ -290,20 +293,8 @@ export class Transaction {
    */
   // eslint-disable-next-line class-methods-use-this
   signAsFeePayer(args: { signer: Account; transaction: AnyRawTransaction }): AccountAuthenticator {
-    const { signer, transaction } = args;
-
-    // if transaction doesnt hold a "feePayerAddress" prop it means
-    // this is not a fee payer transaction
-    if (!transaction.feePayerAddress) {
-      throw new Error(`Transaction ${transaction} is not a Fee Payer transaction`);
-    }
-
-    // Set the feePayerAddress to the signer account address
-    transaction.feePayerAddress = signer.accountAddress;
-
-    return signTransaction({
-      signer,
-      transaction,
+    return signAsFeePayer({
+      ...args,
     });
   }
 
@@ -357,13 +348,55 @@ export class Transaction {
    */
   async signAndSubmitTransaction(args: {
     signer: Account;
+    feePayerAuthenticator: AccountAuthenticator;
     transaction: AnyRawTransaction;
   }): Promise<PendingTransactionResponse> {
-    const { signer, transaction } = args;
     return signAndSubmitTransaction({
       aptosConfig: this.config,
-      signer,
-      transaction,
+      ...args
+    });
+  }
+
+  /**
+   * Sign and submit a single signer transaction a with fee payer to chain
+   *
+   * Note: Exactly one signer or signerAuthenticator must be set. If you have don't have access to the
+   * singing account (the account that created the transaction), the signerAuthenticator parameter may be
+   * set instead with an authenticator provided by the signer.
+   *
+   * @param args.signer The signer account to sign the transaction
+   * @param args.signerAuthenticator The AccountAuthenticator signed by the sender of the transaction
+   * @param args.feePayer The fee payer account to sign the transaction
+   * @param args.transaction An instance of a RawTransaction, plus optional secondary/fee payer addresses
+   *
+   * @example
+   * const transaction = await aptos.transaction.build.simple({feePayer: true ...})
+   * const transaction = await aptos.signAndSubmitAsFeePayer({
+   *  signer: alice,
+   *  feePayer: bob,
+   *  transaction
+   * })
+   *
+   * @example
+   * const transaction = await aptos.transaction.build.simple({feePayer: true ...})
+   * const authenticator = alice.signTransactionWithAuthenticator(transaction)
+   * const transaction = await aptos.signAndSubmitAsFeePayer({
+   *  signerAuthenticator: authenticator,
+   *  feePayer: alice,
+   *  transaction
+   * })
+   *
+   * @return PendingTransactionResponse
+   */
+  async signAndSubmitAsFeePayer(
+    args: SignerOrSignerAuthenticator & {
+      feePayer: Account;
+      transaction: AnyRawTransaction;
+    },
+  ): Promise<PendingTransactionResponse> {
+    return signAndSubmitAsFeePayer({
+      aptosConfig: this.config,
+      ...args,
     });
   }
 }

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -8,7 +8,7 @@
 import { AptosConfig } from "../api/aptosConfig";
 import { MoveVector, U8 } from "../bcs";
 import { postAptosFullNode } from "../client";
-import { Account, KeylessAccountCommon, MultiKeyAccount } from "../account";
+import { Account, AbstractKeylessAccount, MultiKeyAccount } from "../account";
 import { AccountAddress, AccountAddressInput } from "../core/accountAddress";
 import { PrivateKey } from "../core/crypto";
 import { AccountAuthenticator } from "../transactions/authenticator/account";
@@ -301,10 +301,10 @@ export async function signAndSubmitTransaction(
   const { aptosConfig, signer, feePayer, transaction } = args;
   // If the signer contains a KeylessAccount, await proof fetching in case the proof
   // was fetched asyncronously.
-  if (signer instanceof KeylessAccountCommon || signer instanceof MultiKeyAccount) {
+  if (signer instanceof AbstractKeylessAccount || signer instanceof MultiKeyAccount) {
     await signer.waitForProofFetch();
   }
-  if (feePayer instanceof KeylessAccountCommon || feePayer instanceof MultiKeyAccount) {
+  if (feePayer instanceof AbstractKeylessAccount || feePayer instanceof MultiKeyAccount) {
     await feePayer.waitForProofFetch();
   }
   const feePayerAuthenticator =
@@ -327,7 +327,7 @@ export async function signAndSubmitAsFeePayer(args: {
 }): Promise<PendingTransactionResponse> {
   const { aptosConfig, senderAuthenticator, feePayer, transaction } = args;
 
-  if (feePayer instanceof KeylessAccountCommon || feePayer instanceof MultiKeyAccount) {
+  if (feePayer instanceof AbstractKeylessAccount || feePayer instanceof MultiKeyAccount) {
     await feePayer.waitForProofFetch();
   }
 

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -286,16 +286,18 @@ export async function submitTransaction(
   });
   return data;
 }
-export type FeePayerOrFeePayerAuthenticatorOrNeither = 
-| { feePayer: Account; feePayerAuthenticator?: never }
-| { feePayer?: never; feePayerAuthenticator: AccountAuthenticator }
-| { feePayer?: never; feePayerAuthenticator?: never }
+export type FeePayerOrFeePayerAuthenticatorOrNeither =
+  | { feePayer: Account; feePayerAuthenticator?: never }
+  | { feePayer?: never; feePayerAuthenticator: AccountAuthenticator }
+  | { feePayer?: never; feePayerAuthenticator?: never };
 
-export async function signAndSubmitTransaction(args: FeePayerOrFeePayerAuthenticatorOrNeither & {
-  aptosConfig: AptosConfig;
-  signer: Account;
-  transaction: AnyRawTransaction;
-}): Promise<PendingTransactionResponse> {
+export async function signAndSubmitTransaction(
+  args: FeePayerOrFeePayerAuthenticatorOrNeither & {
+    aptosConfig: AptosConfig;
+    signer: Account;
+    transaction: AnyRawTransaction;
+  },
+): Promise<PendingTransactionResponse> {
   const { aptosConfig, signer, feePayer, transaction } = args;
   // If the signer contains a KeylessAccount, await proof fetching in case the proof
   // was fetched asyncronously.
@@ -305,7 +307,8 @@ export async function signAndSubmitTransaction(args: FeePayerOrFeePayerAuthentic
   if (feePayer instanceof KeylessAccountCommon || feePayer instanceof MultiKeyAccount) {
     await feePayer.waitForProofFetch();
   }
-  const feePayerAuthenticator = args.feePayerAuthenticator || (feePayer && signAsFeePayer({ signer: feePayer, transaction }));
+  const feePayerAuthenticator =
+    args.feePayerAuthenticator || (feePayer && signAsFeePayer({ signer: feePayer, transaction }));
 
   const senderAuthenticator = signTransaction({ signer, transaction });
   return submitTransaction({

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -315,28 +315,19 @@ export async function signAndSubmitTransaction(args: FeePayerOrFeePayerAuthentic
     feePayerAuthenticator,
   });
 }
-export type SignerOrSignerAuthenticator = 
-| { signer: Account; signerAuthenticator?: never }
-| { signer?: never; signerAuthenticator: AccountAuthenticator }
 
-export async function signAndSubmitAsFeePayer(args: SignerOrSignerAuthenticator & {
+export async function signAndSubmitAsFeePayer(args: {
   aptosConfig: AptosConfig;
   feePayer: Account;
+  senderAuthenticator: AccountAuthenticator;
   transaction: AnyRawTransaction;
 }): Promise<PendingTransactionResponse> {
-  const { aptosConfig, signer, signerAuthenticator, feePayer, transaction } = args;
-
-  // If the signer contains a KeylessAccount, await proof fetching in case the proof
-  // was fetched asyncronously.
-  if (signer instanceof KeylessAccountCommon || signer instanceof MultiKeyAccount) {
-    await signer.waitForProofFetch();
-  }
+  const { aptosConfig, senderAuthenticator, feePayer, transaction } = args;
 
   if (feePayer instanceof KeylessAccountCommon || feePayer instanceof MultiKeyAccount) {
     await feePayer.waitForProofFetch();
   }
 
-  const senderAuthenticator = signerAuthenticator || signTransaction({ signer, transaction });
   const feePayerAuthenticator = signAsFeePayer({ signer: feePayer, transaction });
 
   return submitTransaction({

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -827,9 +827,6 @@ describe("transaction submission", () => {
       // expect transaction is a sponsored transaction
       expect(response.signature?.type).toBe("fee_payer_signature");
 
-      // expect transaction is a sponsored transaction
-      expect(response.signature?.type).toBe("fee_payer_signature");
-
       const uncreatedAccountInfo = await aptos.account.getAccountInfo({
         accountAddress: uncreatedAccount.accountAddress,
       });
@@ -859,9 +856,6 @@ describe("transaction submission", () => {
       await aptos.waitForTransaction({
         transactionHash: response.hash,
       });
-      // expect transaction is a sponsored transaction
-      expect(response.signature?.type).toBe("fee_payer_signature");
-
       // expect transaction is a sponsored transaction
       expect(response.signature?.type).toBe("fee_payer_signature");
 


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
This simplifies the fee payer APIs by reducing the steps needed to submit such a transaction while still maintaining support for remote signing.

Now the txn may be submitted either on the fee payer side or the sender side.

This also improves the keyless experience as proofs may be fetched asynchronously, in those cases since submission is an async function where we can await the proof fetch.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Tested via sponsored txn example.

More tests in progress



### Related Links
<!-- Please link to any relevant issues or pull requests! -->