### PR TITLE
[fix] Allow signing non-hex messages on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Remove usage of Buffer.from and replace with TextEncoder for greater compatibility
+
 # 1.28.0 (2024-09-19)
 
 - Support `Serialized Type` to Script txn. Now can use vector<String> for example.

--- a/src/core/crypto/utils.ts
+++ b/src/core/crypto/utils.ts
@@ -12,9 +12,9 @@ export const convertSigningMessage = (message: HexInput): HexInput => {
   // if message is of type string, verify it is a valid Hex string
   if (typeof message === "string") {
     const isValid = Hex.isValid(message);
-    // If message is not a valid Hex string, convert it into a Buffer
+    // If message is not a valid Hex string, convert it
     if (!isValid.valid) {
-      return Buffer.from(message, "utf8");
+      return new TextEncoder().encode(message);
     }
     // If message is a valid Hex string, return it
     return message;


### PR DESCRIPTION
### Description
Fixes non-hex message signing on browser platforms
Resolves: https://github.com/aptos-labs/aptos-ts-sdk/issues/520

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->