### PR TITLE
[refactor] Remove remaining exclamations asserting non-null

### DIFF
--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -59,7 +59,7 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
 
   const aptosResponse: AptosResponse<Req, Res> = {
     status: clientResponse.status,
-    statusText: clientResponse.statusText!,
+    statusText: clientResponse.statusText ?? "No status text provided",
     data: clientResponse.data,
     headers: clientResponse.headers,
     config: clientResponse.config,

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -400,7 +400,12 @@ export function generateSignedTransactionForSimulation(args: InputSimulateTransa
         getAuthenticatorForSimulation(publicKey),
       );
     }
-    const feePayerAuthenticator = getAuthenticatorForSimulation(feePayerPublicKey!);
+    if (!feePayerPublicKey) {
+      throw new Error(
+        "Must provide a feePayerPublicKey argument to generate a signed fee payer transaction for simulation",
+      );
+    }
+    const feePayerAuthenticator = getAuthenticatorForSimulation(feePayerPublicKey);
 
     const transactionAuthenticator = new TransactionAuthenticatorFeePayer(
       accountAuthenticator,
@@ -423,7 +428,13 @@ export function generateSignedTransactionForSimulation(args: InputSimulateTransa
 
     let secondaryAccountAuthenticators: Array<AccountAuthenticator> = [];
 
-    secondaryAccountAuthenticators = secondarySignersPublicKeys!.map((publicKey) =>
+    if (!secondarySignersPublicKeys) {
+      throw new Error(
+        "Must provide a secondarySignersPublicKeys argument to generate a signed multi agent transaction for simulation",
+      );
+    }
+
+    secondaryAccountAuthenticators = secondarySignersPublicKeys.map((publicKey) =>
       getAuthenticatorForSimulation(publicKey),
     );
 


### PR DESCRIPTION
### Description
Exclamations can cause unexpected failures, so this just checks for validity of any usages of exclamations, and throws an error (or passes a default value), when not present

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  