### PR TITLE
Fix code scanning alert no. 2: Incomplete string escaping or encoding

### DIFF
--- a/src/core/crypto/hdKey.ts
+++ b/src/core/crypto/hdKey.ts
@@ -83,7 +83,7 @@ export const CKDPriv = ({ key, chainCode }: DerivedKeys, index: number): Derived
   return deriveKey(chainCode, data);
 };
 
-const removeApostrophes = (val: string): string => val.replace("'", "");
+const removeApostrophes = (val: string): string => val.replace(/'/g, "");
 
 /**
  * Splits derive path into segments


### PR DESCRIPTION
Fixes [https://github.com/aptos-labs/aptos-ts-sdk/security/code-scanning/2](https://github.com/aptos-labs/aptos-ts-sdk/security/code-scanning/2)

To fix the problem, we need to ensure that all occurrences of the apostrophe character are removed from the input string. The best way to achieve this is by using a regular expression with the global flag (`g`). This will ensure that every instance of the apostrophe character is replaced, not just the first one.

- Modify the `removeApostrophes` function to use a regular expression with the global flag.
- No additional imports or dependencies are required for this change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
