### PR TITLE
Fix federated keyless constructor's address derivation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Fix the `FederatedKeylessAccount` constructor to derive the correct address.
 
 # 1.29.0 (2024-10-04)
 

--- a/src/account/AbstractKeylessAccount.ts
+++ b/src/account/AbstractKeylessAccount.ts
@@ -96,6 +96,7 @@ export abstract class AbstractKeylessAccount extends Serializable implements Acc
   // Use the static constructor 'create' instead.
   protected constructor(args: {
     address?: AccountAddress;
+    publicKey: KeylessPublicKey | FederatedKeylessPublicKey;
     ephemeralKeyPair: EphemeralKeyPair;
     iss: string;
     uidKey: string;
@@ -107,9 +108,9 @@ export abstract class AbstractKeylessAccount extends Serializable implements Acc
     jwt: string;
   }) {
     super();
-    const { address, ephemeralKeyPair, uidKey, uidVal, aud, pepper, proof, proofFetchCallback, jwt } = args;
+    const { address, ephemeralKeyPair, publicKey, uidKey, uidVal, aud, pepper, proof, proofFetchCallback, jwt } = args;
     this.ephemeralKeyPair = ephemeralKeyPair;
-    this.publicKey = KeylessPublicKey.create(args);
+    this.publicKey = publicKey;
     this.accountAddress = address ? AccountAddress.from(address) : this.publicKey.authKey().derivedAddress();
     this.uidKey = uidKey;
     this.uidVal = uidVal;

--- a/src/account/FederatedKeylessAccount.ts
+++ b/src/account/FederatedKeylessAccount.ts
@@ -42,8 +42,9 @@ export class FederatedKeylessAccount extends AbstractKeylessAccount {
     proofFetchCallback?: ProofFetchCallback;
     jwt: string;
   }) {
-    super(args);
-    this.publicKey = FederatedKeylessPublicKey.create(args);
+    const publicKey = FederatedKeylessPublicKey.create(args);
+    super({ publicKey, ...args });
+    this.publicKey = publicKey;
   }
 
   serialize(serializer: Serializer): void {

--- a/src/account/KeylessAccount.ts
+++ b/src/account/KeylessAccount.ts
@@ -4,7 +4,7 @@
 import { JwtPayload, jwtDecode } from "jwt-decode";
 import { HexInput } from "../types";
 import { AccountAddress } from "../core/accountAddress";
-import { ZeroKnowledgeSig } from "../core/crypto";
+import { KeylessPublicKey, ZeroKnowledgeSig } from "../core/crypto";
 
 import { EphemeralKeyPair } from "./EphemeralKeyPair";
 import { Deserializer, Serializer } from "../bcs";
@@ -21,6 +21,12 @@ import { AbstractKeylessAccount, ProofFetchCallback } from "./AbstractKeylessAcc
  * EphemeralKeyPair, and corresponding proof.
  */
 export class KeylessAccount extends AbstractKeylessAccount {
+
+  /**
+   * The KeylessPublicKey associated with the account
+   */
+  readonly publicKey: KeylessPublicKey
+
   // Use the static constructor 'create' instead.
   private constructor(args: {
     address?: AccountAddress;
@@ -34,7 +40,9 @@ export class KeylessAccount extends AbstractKeylessAccount {
     proofFetchCallback?: ProofFetchCallback;
     jwt: string;
   }) {
-    super(args);
+    const publicKey = KeylessPublicKey.create(args);
+    super({ publicKey, ...args });
+    this.publicKey = publicKey;
   }
 
   serialize(serializer: Serializer): void {

--- a/tests/e2e/api/keyless.test.ts
+++ b/tests/e2e/api/keyless.test.ts
@@ -5,9 +5,7 @@
 import {
   Account,
   FederatedKeylessAccount,
-  FederatedKeylessPublicKey,
   KeylessAccount,
-  KeylessPublicKey,
   ProofFetchStatus,
 } from "../../../src";
 import { FUND_AMOUNT, TRANSFER_AMOUNT } from "../../unit/helper";
@@ -127,19 +125,12 @@ describe("keyless api", () => {
       "creates the keyless account via the static constructor and submits a transaction",
       async () => {
         const pepper = await aptos.getPepper({ jwt, ephemeralKeyPair });
-        const publicKey =
-          jwkAddress === undefined
-            ? KeylessPublicKey.fromJwtAndPepper({ jwt, pepper })
-            : FederatedKeylessPublicKey.fromJwtAndPepper({ jwt, pepper, jwkAddress });
-        const address = await aptos.lookupOriginalAccountAddress({
-          authenticationKey: publicKey.authKey().derivedAddress(),
-        });
         const proof = await aptos.getProof({ jwt, ephemeralKeyPair, pepper });
 
         const account =
           jwkAddress === undefined
-            ? KeylessAccount.create({ address, proof, jwt, ephemeralKeyPair, pepper })
-            : FederatedKeylessAccount.create({ address, proof, jwt, ephemeralKeyPair, pepper, jwkAddress });
+            ? KeylessAccount.create({ proof, jwt, ephemeralKeyPair, pepper })
+            : FederatedKeylessAccount.create({ proof, jwt, ephemeralKeyPair, pepper, jwkAddress });
         const recipient = Account.generate();
         await simpleCoinTransactionHelper(aptos, account, recipient);
       },


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
When using the static constructor directly, FederatedKeyless derives the Keyless address.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
Updated an existing test to catch this.