### PR TITLE
Add isPrimitive function to TypeTag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Add the `isPrimitive` function to `TypeTag`.
 
 # 1.29.1 (2024-10-09)
 - Fix the `FederatedKeylessAccount` constructor to derive the correct address.

--- a/src/transactions/typeTag/index.ts
+++ b/src/transactions/typeTag/index.ts
@@ -95,6 +95,20 @@ export abstract class TypeTag extends Serializable {
   isU256(): this is TypeTagU256 {
     return this instanceof TypeTagU256;
   }
+
+  isPrimitive(): boolean {
+    return (
+      this instanceof TypeTagSigner ||
+      this instanceof TypeTagAddress ||
+      this instanceof TypeTagBool ||
+      this instanceof TypeTagU8 ||
+      this instanceof TypeTagU16 ||
+      this instanceof TypeTagU32 ||
+      this instanceof TypeTagU64 ||
+      this instanceof TypeTagU128 ||
+      this instanceof TypeTagU256
+    );
+  }
 }
 
 export class TypeTagBool extends TypeTag {

--- a/tests/unit/typeTag.test.ts
+++ b/tests/unit/typeTag.test.ts
@@ -31,6 +31,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagBool correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagBool();
+    expect(tag.isPrimitive()).toBe(true);
 
     tag.serialize(serializer);
 
@@ -40,6 +41,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagU8 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU8();
+    expect(tag.isPrimitive()).toBe(true);
 
     tag.serialize(serializer);
 
@@ -49,6 +51,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagU16 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU16();
+    expect(tag.isPrimitive()).toBe(true);
 
     tag.serialize(serializer);
 
@@ -58,6 +61,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagU32 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU32();
+    expect(tag.isPrimitive()).toBe(true);
 
     tag.serialize(serializer);
 
@@ -67,6 +71,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagU64 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU64();
+    expect(tag.isPrimitive()).toBe(true);
 
     tag.serialize(serializer);
 
@@ -76,6 +81,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagU128 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU128();
+    expect(tag.isPrimitive()).toBe(true);
 
     tag.serialize(serializer);
 
@@ -85,6 +91,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagU256 correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagU256();
+    expect(tag.isPrimitive()).toBe(true);
 
     tag.serialize(serializer);
 
@@ -94,6 +101,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagAddress correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagAddress();
+    expect(tag.isPrimitive()).toBe(true);
 
     tag.serialize(serializer);
 
@@ -112,6 +120,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagVector correctly", () => {
     const serializer = new Serializer();
     const tag = new TypeTagVector(new TypeTagU32());
+    expect(tag.isPrimitive()).toBe(false);
 
     tag.serialize(serializer);
     const deserialized = TypeTag.deserialize(new Deserializer(serializer.toUint8Array()));
@@ -124,6 +133,7 @@ describe("Deserialize TypeTags", () => {
   test("deserializes a TypeTagStruct correctly", () => {
     const serializer = new Serializer();
     const tag = parseTypeTag(expectedTypeTag.string);
+    expect(tag.isPrimitive()).toBe(false);
 
     tag.serialize(serializer);
     const deserialized = TypeTag.deserialize(new Deserializer(serializer.toUint8Array()));


### PR DESCRIPTION
### Description
We have an isPrimitive function in `parser.ts` but it is not exported and only operates on strings. It'd be nicer to have the function on `TypeTag` directly.

Note that we can't do `this.isSigner() | this.isAddress()` etc because the typechecker (perhaps erroneously) makes the type more specific due to the first check, so the rest of the checks fail typechecking.

### Test Plan
See updated unit tests.

### Related Links
N/A

### Checklist
  - [x] Have you ran `pnpm fmt`?