### PR TITLE
[simulations] Add MultiKey simulations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - Add the `isPrimitive` function to `TypeTag`.
 - Add `showStdout` optional property to `Move` and `LocalNode` classes to control the output of the CLI commands
+- Add support for MultiKey's in transaction simulations
 
 # 1.29.1 (2024-10-09)
 

--- a/src/core/crypto/multiKey.ts
+++ b/src/core/crypto/multiKey.ts
@@ -155,6 +155,10 @@ export class MultiKey extends AccountPublicKey {
     }
     throw new Error("Public key not found in MultiKey");
   }
+
+  public static isInstance(value: PublicKey): value is MultiKey {
+    return "publicKeys" in value && "signaturesRequired" in value;
+  }
 }
 
 export class MultiKeySignature extends Signature {


### PR DESCRIPTION
### Description
Provide support for MultiKey public keys in simulations.

### Test Plan
Added a single signer, multi agenet, and fee payer test that tests different public key types (Ed25519, AnyEd25519, AnySecp256k1, and Keyless)

### Related Links
N/A

### Checklist
  - [x] Have you ran `pnpm fmt`?
  