### PR TITLE
Log `minimumLedgerVersion` is not used anymore warning

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -675,7 +675,9 @@ export class Account {
    * is specified.
    * @param args.faMetadataAddress The fungible asset metadata address to query. Note: If not provided, it may be automatically
    * populated if `coinType` is specified.
-   * @param args.minimumLedgerVersion Optional ledger version to sync up to before querying.
+   * @param args.minimumLedgerVersion Not used anymore, here for backward compatibility
+   * see https://github.com/aptos-labs/aptos-ts-sdk/pull/519, will be removed in the near future.
+   * Optional ledger version to sync up to before querying.
    * @returns The current amount of the specified coin held by the account.
    *
    * @example
@@ -703,8 +705,16 @@ export class Account {
     faMetadataAddress?: AccountAddressInput;
     minimumLedgerVersion?: AnyNumber;
   }): Promise<number> {
-    const { accountAddress, coinType, faMetadataAddress } = args;
+    const { accountAddress, coinType, faMetadataAddress, minimumLedgerVersion } = args;
 
+    if (minimumLedgerVersion) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `minimumLedgerVersion is not used anymore, here for backward 
+        compatibility see https://github.com/aptos-labs/aptos-ts-sdk/pull/519, 
+        will be removed in the near future`,
+      );
+    }
     // Attempt to populate the CoinType field if the FA address is provided.
     // We cannot do this internally due to dependency cycles issue.
     let coinAssetType: MoveStructId | undefined = coinType;


### PR DESCRIPTION
### Description
Following https://github.com/aptos-labs/aptos-ts-sdk/pull/519, `getAccountCoinAmount` API function does not use Indexer to fetch the data and therefore `minimumLedgerVersion` is not needed.
We keep it as a function argument to not break projects, but it is a bit confusing as devs think this function still uses Indexer

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  