### PR TITLE
[docs] Fix docs tags that don't match tags supported in TSDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The [TypeScript SDK](https://www.npmjs.com/package/@aptos-labs/ts-sdk) allows yo
 ## Learn How To Use The TypeScript SDK
 ### [Quickstart](https://aptos.dev/en/build/sdks/ts-sdk/quickstart)
 ### [Tutorials](https://aptos.dev/en/build/sdks/ts-sdk)
-### [Examples](./examples)
+### [Examples](./examples/README.md)
 ### [Reference Docs (For looking up specific functions)](https://aptos-labs.github.io/aptos-ts-sdk/)
 
 

--- a/src/account/KeylessAccount.ts
+++ b/src/account/KeylessAccount.ts
@@ -19,9 +19,6 @@ import { AbstractKeylessAccount, ProofFetchCallback } from "./AbstractKeylessAcc
  *
  * When the proof expires or the JWT becomes invalid, the KeylessAccount must be instantiated again with a new JWT,
  * EphemeralKeyPair, and corresponding proof.
- *
- * @static
- * @readonly PEPPER_LENGTH - The length of the pepper used for privacy preservation.
  */
 export class KeylessAccount extends AbstractKeylessAccount {
   /**

--- a/src/bcs/serializable/moveStructs.ts
+++ b/src/bcs/serializable/moveStructs.ts
@@ -42,8 +42,7 @@ import { EntryFunctionArgument, TransactionArgument } from "../../transactions/i
  * const vecOfStrings = new MoveVector([new MoveString("hello"), new MoveString("world")]);
  * const vecOfStrings2 = MoveVector.MoveString(["hello", "world"]);
  *
- * @params
- * values: an Array<T> of values where T is a class that implements Serializable
+ * @param values an Array<T> of values where T is a class that implements Serializable
  * @returns a `MoveVector<T>` with the values `values`
  */
 export class MoveVector<T extends Serializable & EntryFunctionArgument>
@@ -132,9 +131,9 @@ export class MoveVector<T extends Serializable & EntryFunctionArgument>
 
   /**
    * Factory method to generate a MoveOption<U16> from a `number` or `null`.
-   * 
-   * This method allows you to create a MoveVector that can either hold a U16 value or be empty. 
-   * 
+   *
+   * This method allows you to create a MoveVector that can either hold a U16 value or be empty.
+   *
    * @param values - The value used to fill the MoveVector. If `value` is null or undefined, the resulting MoveVector's
    * `.isSome()` method will return false.
    * @returns A MoveVector<U16> with an inner value `value`.
@@ -150,13 +149,13 @@ export class MoveVector<T extends Serializable & EntryFunctionArgument>
 
   /**
    * Factory method to generate a MoveVector<U32> from a `number` or `null`.
-   * 
-   * This method allows you to create a MoveVector that can either hold a U32 value or be empty. 
-   * 
+   *
+   * This method allows you to create a MoveVector that can either hold a U32 value or be empty.
+   *
    * @param values - The value used to fill the MoveVector. If `value` is null or undefined,
    * the resulting MoveVector's .isSome() method will return false.
    * @returns A MoveVector<U32> with an inner value `value`.
-   * 
+   *
    * @example
    * ```
    * const v = MoveVector.U32([1, 2, 3, 4]);
@@ -442,7 +441,7 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    * MoveOption.U8(1).isSome() === true;
    * MoveOption.U8().isSome() === false;
    * MoveOption.U8(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
+   * @param value the value used to fill the MoveOption. If `value` is undefined
    * the resulting MoveOption's .isSome() method will return false.
    * @returns a MoveOption<U8> with an inner value `value`
    */
@@ -457,7 +456,7 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    * MoveOption.U16(1).isSome() === true;
    * MoveOption.U16().isSome() === false;
    * MoveOption.U16(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
+   * @param value the value used to fill the MoveOption. If `value` is undefined
    * the resulting MoveOption's .isSome() method will return false.
    * @returns a MoveOption<U16> with an inner value `value`
    */
@@ -472,7 +471,7 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    * MoveOption.U32(1).isSome() === true;
    * MoveOption.U32().isSome() === false;
    * MoveOption.U32(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
+   * @param value the value used to fill the MoveOption. If `value` is undefined
    * the resulting MoveOption's .isSome() method will return false.
    * @returns a MoveOption<U32> with an inner value `value`
    */
@@ -487,7 +486,7 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    * MoveOption.U64(1).isSome() === true;
    * MoveOption.U64().isSome() === false;
    * MoveOption.U64(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
+   * @param value the value used to fill the MoveOption. If `value` is undefined
    * the resulting MoveOption's .isSome() method will return false.
    * @returns a MoveOption<U64> with an inner value `value`
    */
@@ -502,7 +501,7 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    * MoveOption.U128(1).isSome() === true;
    * MoveOption.U128().isSome() === false;
    * MoveOption.U128(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
+   * @param value the value used to fill the MoveOption. If `value` is undefined
    * the resulting MoveOption's .isSome() method will return false.
    * @returns a MoveOption<U128> with an inner value `value`
    */
@@ -517,7 +516,7 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    * MoveOption.U256(1).isSome() === true;
    * MoveOption.U256().isSome() === false;
    * MoveOption.U256(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
+   * @param value the value used to fill the MoveOption. If `value` is undefined
    * the resulting MoveOption's .isSome() method will return false.
    * @returns a MoveOption<U256> with an inner value `value`
    */
@@ -532,7 +531,7 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    * MoveOption.Bool(true).isSome() === true;
    * MoveOption.Bool().isSome() === false;
    * MoveOption.Bool(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
+   * @param value the value used to fill the MoveOption. If `value` is undefined
    * the resulting MoveOption's .isSome() method will return false.
    * @returns a MoveOption<Bool> with an inner value `value`
    */
@@ -548,7 +547,7 @@ export class MoveOption<T extends Serializable & EntryFunctionArgument>
    * MoveOption.MoveString("").isSome() === true;
    * MoveOption.MoveString().isSome() === false;
    * MoveOption.MoveString(undefined).isSome() === false;
-   * @params value: the value used to fill the MoveOption. If `value` is undefined
+   * @param value the value used to fill the MoveOption. If `value` is undefined
    * the resulting MoveOption's .isSome() method will return false.
    * @returns a MoveOption<MoveString> with an inner value `value`
    */

--- a/src/core/accountAddress.ts
+++ b/src/core/accountAddress.ts
@@ -250,7 +250,9 @@ export class AccountAddress extends Serializable implements TransactionArgument 
    *
    * @throws {ParsingError} If the hex string does not start with 0x or is not in a valid format.
    *
-   * @note This function has strict parsing behavior. For relaxed behavior, please use the `fromString` function.
+   * @remarks
+   *
+   * This function has strict parsing behavior. For relaxed behavior, please use the `fromString` function.
    *
    * @see AIP-40 documentation for more details on address formats:
    * https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md.

--- a/src/core/crypto/ed25519.ts
+++ b/src/core/crypto/ed25519.ts
@@ -181,21 +181,18 @@ export class Ed25519PublicKey extends AccountPublicKey {
 
 /**
  * Represents the private key of an Ed25519 key pair.
- *
- * @static
- * @readonly LENGTH - Length of an Ed25519 private key.
- * @static
- * @readonly SLIP_0010_SEED - The Ed25519 key seed to use for BIP-32 compatibility.
  */
 export class Ed25519PrivateKey extends Serializable implements PrivateKey {
   /**
    * Length of an Ed25519 private key
+   * @readonly
    */
   static readonly LENGTH: number = 32;
 
   /**
    * The Ed25519 key seed to use for BIP-32 compatibility
    * See more {@link https://github.com/satoshilabs/slips/blob/master/slip-0010.md}
+   * @readonly
    */
   static readonly SLIP_0010_SEED = "ed25519 seed";
 
@@ -350,12 +347,12 @@ export class Ed25519PrivateKey extends Serializable implements PrivateKey {
 
 /**
  * Represents a signature of a message signed using an Ed25519 private key.
- *
- * @static LENGTH - Length of an Ed25519 signature, which is 64 bytes.
  */
 export class Ed25519Signature extends Signature {
   /**
-   * Length of an Ed25519 signature
+   * Length of an Ed25519 signature, which is 64 bytes.
+   *
+   * @readonly
    */
   static readonly LENGTH = 64;
 

--- a/src/core/crypto/hdKey.ts
+++ b/src/core/crypto/hdKey.ts
@@ -75,7 +75,6 @@ export const deriveKey = (hashSeed: Uint8Array | string, data: Uint8Array | stri
  * @param key
  * @param chainCode
  * @param index
- * @constructor
  */
 export const CKDPriv = ({ key, chainCode }: DerivedKeys, index: number): DerivedKeys => {
   const buffer = new ArrayBuffer(4);

--- a/src/core/crypto/privateKey.ts
+++ b/src/core/crypto/privateKey.ts
@@ -4,10 +4,6 @@ import { Signature } from "./signature";
 
 /**
  * Represents a private key used for signing messages and deriving the associated public key.
- *
- * @method sign - Signs the given message with the private key.
- * @method publicKey - Derives the public key associated with the private key.
- * @method toUint8Array - Retrieves the private key in bytes.
  */
 export interface PrivateKey {
   /**

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -17,7 +17,6 @@ import { convertSigningMessage } from "./utils";
  * Represents a Secp256k1 ECDSA public key.
  *
  * @extends PublicKey
- * @static
  * @property LENGTH - The length of the Secp256k1 public key in bytes.
  */
 export class Secp256k1PublicKey extends PublicKey {
@@ -284,13 +283,11 @@ export class Secp256k1PrivateKey extends Serializable implements PrivateKey {
 /**
  * Represents a signature of a message signed using a Secp256k1 ECDSA private key.
  *
- * @static
- * @readonly
- * @length The length of Secp256k1 ECDSA signatures, which is 64 bytes.
  */
 export class Secp256k1Signature extends Signature {
   /**
-   * Secp256k1 ecdsa signatures are 256-bit.
+   * Secp256k1 ecdsa signatures are 256-bit or 64 bytes
+   * @readonly
    */
   static readonly LENGTH = 64;
 


### PR DESCRIPTION
### Description
These docs updates remove things that don't apply to TSDoc, are duplicated, or just don't match existing information.

Running the generate docs command spits out most of these warnings, so I've gotten rid of a good amount of them.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  