### PR TITLE
Add secp256k1 verify and pubKey recovery function

### DIFF
--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { Account as AccountModule } from "../account";
-import { AccountAddress, PrivateKey, AccountAddressInput, createObjectAddress } from "../core";
+import {
+  AccountAddress,
+  PrivateKey,
+  AccountAddressInput,
+  createObjectAddress,
+  Secp256k1Signature,
+  AnyPublicKey,
+  AnySignature,
+} from "../core";
 import {
   AccountData,
   AnyNumber,
@@ -11,6 +19,7 @@ import {
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
   GetObjectDataQueryResponse,
+  HexInput,
   LedgerVersionArg,
   MoveModuleBytecode,
   MoveResource,
@@ -39,6 +48,7 @@ import {
   getResources,
   getTransactions,
   lookupOriginalAccountAddress,
+  verifySecp256k1Account,
 } from "../internal/account";
 import { APTOS_COIN, APTOS_FA, ProcessorType } from "../utils/const";
 import { AptosConfig } from "./aptosConfig";
@@ -873,5 +883,45 @@ export class Account {
    */
   async deriveAccountFromPrivateKey(args: { privateKey: PrivateKey }): Promise<AccountModule> {
     return deriveAccountFromPrivateKey({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Verifies a Secp256k1 account by checking the signature against the message and account's authentication key.
+   *
+   * This function takes a message and signature, and attempts to recover the public key that created the signature.
+   * It then verifies that the recovered public key matches the authentication key stored on-chain for the provided account address.
+   *
+   * If a recovery bit is provided, it will only attempt verification with that specific recovery bit.
+   * Otherwise, it will try all possible recovery bits (0-3) until it finds a match.
+   *
+   * @param args - The arguments for verifying the Secp256k1 account
+   * @param args.message - The message that was signed
+   * @param args.signature - The signature to verify (either raw hex or Secp256k1Signature object)
+   * @param args.recoveryBit - Optional specific recovery bit to use for verification
+   * @param args.accountAddress - The address of the account to verify
+   * @returns The recovered public key if verification succeeds
+   * @throws Error if verification fails or no matching public key is found
+   *
+   * @example
+   * ```typescript
+   * import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+   *
+   * const config = new AptosConfig({ network: Network.DEVNET });
+   * const aptos = new Aptos(config);
+   *
+   * const publicKey = await aptos.verifySecp256k1Account({
+   *   message: "0x1234...",
+   *   signature: "0x5678...",
+   *   accountAddress: "0x1"
+   * });
+   * ```
+   */
+  async verifySecp256k1Account(args: {
+    message: HexInput;
+    signature: HexInput | Secp256k1Signature | AnySignature;
+    recoveryBit?: number;
+    accountAddress: AccountAddressInput;
+  }): Promise<AnyPublicKey> {
+    return verifySecp256k1Account({ aptosConfig: this.config, ...args });
   }
 }

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -4,14 +4,18 @@
 import { sha3_256 } from "@noble/hashes/sha3";
 import { secp256k1 } from "@noble/curves/secp256k1";
 import { HDKey } from "@scure/bip32";
+import { bytesToNumberBE, inRange } from "@noble/curves/abstract/utils";
 import { Serializable, Deserializer, Serializer } from "../../bcs";
 import { Hex } from "../hex";
 import { HexInput, PrivateKeyVariants } from "../../types";
 import { isValidBIP44Path, mnemonicToSeed } from "./hdKey";
 import { PrivateKey } from "./privateKey";
-import { PublicKey, VerifySignatureArgs } from "./publicKey";
+import { PublicKey } from "./publicKey";
 import { Signature } from "./signature";
 import { convertSigningMessage } from "./utils";
+
+const secp256k1P = BigInt("0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f");
+const secp256k1N = BigInt("0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141");
 
 /**
  * Represents a Secp256k1 ECDSA public key.
@@ -53,7 +57,7 @@ export class Secp256k1PublicKey extends PublicKey {
    * @param args.message - The message that was signed.
    * @param args.signature - The signature to verify against the public key.
    */
-  verifySignature(args: VerifySignatureArgs): boolean {
+  verifySignature(args: { message: HexInput; signature: Secp256k1Signature }): boolean {
     const { message, signature } = args;
     const messageToVerify = convertSigningMessage(message);
     const messageBytes = Hex.fromHexInput(messageToVerify).toUint8Array();
@@ -123,6 +127,33 @@ export class Secp256k1PublicKey extends PublicKey {
    */
   static isInstance(publicKey: PublicKey): publicKey is Secp256k1PublicKey {
     return "key" in publicKey && (publicKey.key as any)?.data?.length === Secp256k1PublicKey.LENGTH;
+  }
+
+  static fromSignatureAndMessage(args: {
+    signature: HexInput | Secp256k1Signature;
+    message: HexInput;
+    recoveryBit: number;
+  }): Secp256k1PublicKey {
+    const { signature, message, recoveryBit } = args;
+    let signatureBytes: Uint8Array;
+    if (signature instanceof Secp256k1Signature) {
+      signatureBytes = signature.toUint8Array();
+    } else {
+      signatureBytes = Hex.fromHexInput(signature).toUint8Array();
+      if (signatureBytes.length !== Secp256k1Signature.LENGTH) {
+        throw new Error(`Signature length should be ${Secp256k1Signature.LENGTH}`);
+      }
+    }
+    const r = bytesToNumberBE(signatureBytes.subarray(0, 32)); // Let r = int(sig[0:32]); fail if r ≥ p.
+    if (!inRange(r, BigInt(1), secp256k1P)) throw new Error("Invalid secp256k1 signature - r ≥ p");
+    const s = bytesToNumberBE(signatureBytes.subarray(32, 64)); // Let s = int(sig[32:64]); fail if s ≥ n.
+    if (!inRange(s, BigInt(1), secp256k1N)) throw new Error("Invalid secp256k1 signature - s ≥ n");
+    const sig = new secp256k1.Signature(r, s);
+    const messageToVerify = convertSigningMessage(message);
+    const messageBytes = Hex.fromHexInput(messageToVerify).toUint8Array();
+    const messageSha3Bytes = sha3_256(messageBytes);
+    const publicKeyBytes = sig.addRecoveryBit(recoveryBit).recoverPublicKey(messageSha3Bytes).toRawBytes(false);
+    return new Secp256k1PublicKey(publicKeyBytes);
   }
 }
 

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -16,6 +16,7 @@ import {
   GetAccountOwnedTokensFromCollectionResponse,
   GetAccountOwnedTokensQueryResponse,
   GetObjectDataQueryResponse,
+  HexInput,
   LedgerVersionArg,
   MoveModuleBytecode,
   MoveResource,
@@ -28,7 +29,14 @@ import {
 } from "../types";
 import { AccountAddress, AccountAddressInput } from "../core/accountAddress";
 import { Account } from "../account";
-import { AnyPublicKey, Ed25519PublicKey, PrivateKey } from "../core/crypto";
+import {
+  AnyPublicKey,
+  AnySignature,
+  Ed25519PublicKey,
+  PrivateKey,
+  Secp256k1PublicKey,
+  Secp256k1Signature,
+} from "../core/crypto";
 import { queryIndexer } from "./general";
 import {
   GetAccountCoinsCountQuery,
@@ -794,4 +802,73 @@ export async function isAccountExist(args: { aptosConfig: AptosConfig; authKey: 
     }
     throw new Error(`Error while looking for an account info ${accountAddress.toString()}`);
   }
+}
+
+export async function verifySecp256k1Account(args: {
+  aptosConfig: AptosConfig;
+  message: HexInput;
+  signature: HexInput | Secp256k1Signature | AnySignature;
+  recoveryBit?: number;
+  accountAddress: AccountAddressInput;
+}): Promise<AnyPublicKey> {
+  const { aptosConfig, message, recoveryBit, accountAddress } = args;
+  let signature: HexInput | Secp256k1Signature;
+  if (args.signature instanceof AnySignature) {
+    if (args.signature.signature instanceof Secp256k1Signature) {
+      signature = args.signature.signature;
+    } else {
+      throw new Error("Invalid signature type");
+    }
+  } else {
+    signature = args.signature;
+  }
+  const { authentication_key: authKeyString } = await getInfo({
+    aptosConfig,
+    accountAddress,
+  });
+  const authKey = new AuthenticationKey({ data: authKeyString });
+
+  if (recoveryBit !== undefined) {
+    const publicKey = new AnyPublicKey(
+      Secp256k1PublicKey.fromSignatureAndMessage({
+        signature,
+        message,
+        recoveryBit,
+      }),
+    );
+    const derivedAuthKey = publicKey.authKey();
+    if (authKey.toStringWithoutPrefix() === derivedAuthKey.toStringWithoutPrefix()) {
+      return publicKey;
+    }
+    throw new Error(
+      // eslint-disable-next-line max-len
+      `Derived authentication key ${derivedAuthKey.toString()} does not match the authentication key ${authKey.toString()} for account ${accountAddress.toString()}`,
+    );
+  }
+
+  for (let i = 0; i < 4; i += 1) {
+    try {
+      const publicKey = new AnyPublicKey(
+        Secp256k1PublicKey.fromSignatureAndMessage({
+          signature,
+          message,
+          recoveryBit: i,
+        }),
+      );
+      const derivedAuthKey = publicKey.authKey();
+      if (authKey.toStringWithoutPrefix() === derivedAuthKey.toStringWithoutPrefix()) {
+        return publicKey;
+      }
+    } catch (e) {
+      if (e instanceof Error && e.message.includes("recovery id")) {
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  throw new Error(
+    `Failed to recover the public key matching authentication key ${authKey.toString()} for account ${accountAddress.toString()}`,
+  );
 }

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -11,6 +11,8 @@ import {
   SigningSchemeInput,
   U64,
   AccountAddress,
+  SingleKeyAccount,
+  Secp256k1PrivateKey,
 } from "../../../src";
 import { getAptosClient } from "../helper";
 
@@ -299,6 +301,52 @@ describe("account api", () => {
 
       expect(tokens.length).toBe(1);
       expect(tokens[0].current_token_data?.token_name).toBe("Test Token");
+    });
+
+    test("it verifies a secp256k1 signature", async () => {
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const account = new SingleKeyAccount({
+        privateKey: new Secp256k1PrivateKey(
+          "secp256k1-priv-0x1111111111111111111111111111111111111111111111111111111111111111",
+        ),
+      });
+      await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100 });
+      const message = new TextEncoder().encode("hello");
+      const signature = account.sign(message);
+
+      const pubKey = await aptos.verifySecp256k1Account({
+        message,
+        signature,
+        accountAddress: account.accountAddress,
+      });
+      expect(pubKey.toString()).toBe(account.publicKey.toString());
+
+      await expect(
+        aptos.verifySecp256k1Account({
+          message: new TextEncoder().encode("hi"),
+          signature,
+          accountAddress: account.accountAddress,
+        }),
+      ).rejects.toThrow("Failed to recover the public key");
+
+      await expect(
+        aptos.verifySecp256k1Account({
+          message,
+          signature,
+          accountAddress: account.accountAddress,
+          recoveryBit: 0,
+        }),
+      ).rejects.toThrow("does not match the authentication key");
+
+      await expect(
+        aptos.verifySecp256k1Account({
+          message,
+          signature,
+          accountAddress: account.accountAddress,
+          recoveryBit: 3,
+        }),
+      ).rejects.toThrow("recovery id 2 or 3 invalid");
     });
 
     describe("it derives an account from a private key", () => {


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
With secp256k1 you can recover the publicKey from the signature and message.  This is common in EVM world.  This will ease migrations as it allows users to use familiar APIs, which may be missing the publicKey.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
e2e test added

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  