### PR TITLE
Fix: Add default FeePayer address for sponsored transactions in Script Composer

### DIFF
--- a/src/api/transactionSubmission/build.ts
+++ b/src/api/transactionSubmission/build.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { AccountAddressInput } from "../../core";
+import { AccountAddress, AccountAddressInput } from "../../core";
 import { generateTransaction } from "../../internal/transactionSubmission";
 import {
   InputGenerateTransactionPayloadData,
@@ -171,7 +171,7 @@ export class Build {
       payload: TransactionPayloadScript.load(new Deserializer(bytes)),
       ...args,
     });
-    return new SimpleTransaction(rawTxn);
+    return new SimpleTransaction(rawTxn, args.withFeePayer === true ? AccountAddress.ZERO : undefined);
   }
 
   /**


### PR DESCRIPTION
### Description
- Added the default FeePayer address (`AccountAddress.ZERO`) when the `withFeePayer` parameter is `true` to resolve the `not a FeePayer transaction` issue while executing FeePayer transactions with Script Composer.

### Test Plan
- Added tests to verify that FeePayer transactions are correctly processed and handled in the updated logic.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  