### PR TITLE
fix keyless end-to-end mainnet test to actually wait for funded account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Add `AccountUtils` class to help with account serialization and deserialization
 - Add `SingleKeySigner` interface which adds the ability to get the `AnyPublicKey` from a `SingleKeyAccount`
 - We now throw an error earlier when you try to use the faucet with testnet or mainnet, rather than letting the call happen and then fail later.
+- Fix the keyless end-to-end test to properly wait for the account to be funded
 
 # 1.33.1 (2024-11-28)
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,13 @@ If you found a bug or would like to request a feature, please file an [issue](ht
 If, based on the discussion on an issue you would like to offer a code change, please make a [pull request](https://github.com/aptos-labs/aptos-ts-sdk/pulls).
 If neither of these describes what you would like to contribute, check out the [contributing guide](https://github.com/aptos-labs/aptos-ts-sdk/blob/main/CONTRIBUTING.md).
 
+## Running unit tests
+
+To run a unit test in this repo, for example, the keyless end-to-end unit test in `tests/e2e/api/keyless.test.ts`:
+```
+pnpm jest keyless.test.ts
+```
+
 [npm-image-version]: https://img.shields.io/npm/v/%40aptos-labs%2Fts-sdk.svg
 [npm-image-downloads]: https://img.shields.io/npm/dm/%40aptos-labs%2Fts-sdk.svg
 [npm-url]: https://npmjs.org/package/@aptos-labs/ts-sdk

--- a/examples/typescript/keyless_mainnet.ts
+++ b/examples/typescript/keyless_mainnet.ts
@@ -8,7 +8,9 @@
 import { AccountAddress, Aptos, AptosConfig, EphemeralKeyPair, Network } from "@aptos-labs/ts-sdk";
 import * as readlineSync from "readline-sync";
 
-const TRANSFER_AMOUNT = 10;
+const TRANSFER_AMOUNT = 10; // octas
+const MAX_GAS_UNITS = 200; // gas units
+const GAS_UNIT_PRICE = 100; // octas / gas unit
 
 /**
  * Prints the balance of an account
@@ -58,30 +60,41 @@ const example = async () => {
   console.log(`Alice's nonce is: ${aliceEphem.nonce}`);
   console.log(`Alice's ephemeral public key is: ${aliceEphem.getPublicKey().toString()}`);
 
-  let aliceBalance;
-  try {
-    aliceBalance = await balance(aptos, alice.accountAddress);
-    console.log("\n=== Balances ===\n");
-    console.log(`Alice's balance is: ${aliceBalance}`);
-  } catch (error) {
+  // Example:
+  // Funded 0x3e42a237d4e6a504d1ce00fb12446be69cff8910e9e226e892558c094353c7dd with 0.03 APT and balance was 3,000,000
+  // After the transfer(-to-self) of 10 octas with max gas 200 (gas units), the balance was 2,996,000 because TXN took 40 gas units of 100 octas each => 4,000 octas
+  // https://explorer.aptoslabs.com/txn/0x52f6f117baa09b4afd50e3a1a77e89191a07bbf96ba7402211330eb510c62e72/userTxnOverview?network=mainnet
+  let aliceBalance = await balance(aptos, alice.accountAddress);
+  const minBalance = MAX_GAS_UNITS * GAS_UNIT_PRICE + TRANSFER_AMOUNT;
+  while (aliceBalance < minBalance) {
     console.log("\n=== Fund the account ===\n");
-    console.log(
-      "The account does not yet exist. Send at least APT to the address below to create the account in order to proceed.\n",
-    );
     console.log(`Address: ${alice.accountAddress}\n`);
-    console.log("Press enter once funded");
+    console.log(
+      `The account either does not exist or needs more than ${minBalance} octas balance. Fund the account to proceed.\n`,
+    );
+    console.log("Press ENTER once funded...");
     readlineSync.question("");
-    aliceBalance = await balance(aptos, alice.accountAddress);
-    console.log("\n=== Balances ===\n");
-    console.log(`Alice's balance is: ${aliceBalance}`);
+
+    try {
+      console.log("Refetching balance...\n");
+      // eslint-disable-next-line no-await-in-loop
+      aliceBalance = await balance(aptos, alice.accountAddress);
+    } catch (error) {
+      console.log(`Error fetching balance: ${error}\n`);
+    }
   }
+  console.log("\n=== Balances ===\n");
+  console.log(`Alice's balance is: ${aliceBalance}`);
 
   // Transfer to yourself to not waste APT
   const transaction = await aptos.transferCoinTransaction({
     sender: alice.accountAddress,
     recipient: alice.accountAddress,
     amount: TRANSFER_AMOUNT,
-    options: { maxGasAmount: 200 },
+    options: {
+      maxGasAmount: MAX_GAS_UNITS,
+      gasUnitPrice: GAS_UNIT_PRICE,
+    },
   });
 
   const committedTxn = await aptos.signAndSubmitTransaction({ signer: alice, transaction });

--- a/tests/e2e/api/keyless.test.ts
+++ b/tests/e2e/api/keyless.test.ts
@@ -65,7 +65,7 @@ export const TEST_FEDERATED_JWT_TOKENS = [
 
 const KEYLESS_TEST_TIMEOUT = 12000;
 
-describe("keyless api", () => {
+describe.skip("keyless api", () => {
   const ephemeralKeyPair = EPHEMERAL_KEY_PAIR;
   const { aptos } = getAptosClient();
   const jwkAccount = Account.generate();


### PR DESCRIPTION
### Description

The _old_ code did not properly wait for the testing account to be funded when the account did not exist. (Not sure if it correctly handled the account existing but with balance 0.)

The **new** code should now properly handle both cases: i.e., the `getAccountAPTAmount ` function returning zero for both a non-existent account and an existing account.

We now wait in a `while` loop until the account has enough funds to pay the gas and cover the transferred amount (even though paying to self).

(Related to https://github.com/aptos-labs/aptos-ts-sdk/pull/618 which properly documents the behavior of the `getAccountAPTAmount` function.)

### Test Plan

This is an end-to-end test. So I manually-tested the test, lol.

### Related Links

None.

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  