### PR TITLE
Add support for vector arguments passing in as strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+
 - Add new `scriptComposer` api in transactionSubmission api to allow SDK callers to invoke multiple Move functions inside a same transaction and compose the calls dynamically.
+- Add support for vectors as string as a valid argument
 
 # 1.33.2 (2025-01-22)
 

--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -423,6 +423,13 @@ function parseArg(
       }
     }
 
+    if (isString(arg)) {
+      // In a web env, arguments are passing as strings
+      if (arg.startsWith("[")) {
+        return checkOrConvertArgument(JSON.parse(arg), param, position, genericTypeParams);
+      }
+    }
+
     // TODO: Support Uint16Array, Uint32Array, BigUint64Array?
 
     if (Array.isArray(arg)) {

--- a/tests/unit/remoteAbi.test.ts
+++ b/tests/unit/remoteAbi.test.ts
@@ -94,6 +94,9 @@ describe("Remote ABI", () => {
       expect(checkOrConvertArgument(new Uint8Array([0, 255]).buffer, parseTypeTag("vector<u8>"), 0, [])).toEqual(
         MoveVector.U8([0, 255]),
       );
+      expect(checkOrConvertArgument("[1, 2]", parseTypeTag("vector<u128>"), 0, [])).toEqual(
+        new MoveVector<U128>([new U128(1), new U128(2)]),
+      );
       // When using strings, it should be exactly the same as a Move String, but it should be a MoveVector
       const convertedString = checkOrConvertArgument("0xFF", parseTypeTag("vector<u8>"), 0, []);
       expect(convertedString).toBeInstanceOf(MoveVector<U8>);


### PR DESCRIPTION
### Description
In a Web env, arguments passing into the sdk are strings, so if we pass arguments as `[1,2,3]`, the web will convert it into `"[1,2,3]"`.

This PR adds support to convert the array as string argument to an array, so then we can convert it to a BSC argument.

This is already semi-supported by the Explorer, adding it to the SDK for a more general solution

### Test Plan
- Added a new test

### Related Links
[Simulation](http://localhost:3000/manage/transactions/simulation?network=testnet&data=%7B%22version%22%3A%226613599144%22%2C%22hash%22%3A%220x0c824b50ca003ba147d4da5626b77167c71440f7e1b52fb0807f59060ec5c139%22%2C%22state_change_hash%22%3A%220xdefb59588f3c4b798236f295d33da4f9d8dfad7063917205feaa36650734bf5f%22%2C%22event_root_hash%22%3A%220x6c3b14438f35843f65a29efca454375bd623e4e8bf8ca4007803f7cc8fab251e%22%2C%22state_checkpoint_hash%22%3Anull%2C%22gas_used%22%3A%2289%22%2C%22success%22%3Afalse%2C%22vm_status%22%3A%22Execution%20failed%20in%200x3dc96a17bfdcda9f19c3c1f3621abd576b5c84980c4d22cedeb272b498f35565%3A%3Aperpetual_core%3A%3Acalculate_rate%20at%20code%20offset%20214%22%2C%22accumulator_root_hash%22%3A%220xff887380ddba74f8b8b93205be697eb4267eb60b9460878e527e98ffdcc5400d%22%2C%22changes%22%3A%5B%7B%22address%22%3A%220xa7f9629945aec12835f5d06bd8f3bdc0c02ea5a71f5edd9711a32d7c61da40b5%22%2C%22state_key_hash%22%3A%220xfc20f6f67ab7584fdbc403395e6e9b985526f3642c5dff0cd0070618576a6be7%22%2C%22data%22%3A%7B%22type%22%3A%220x1%3A%3Acoin%3A%3ACoinStore%3C0x1%3A%3Aaptos_coin%3A%3AAptosCoin%3E%22%2C%22data%22%3A%7B%22coin%22%3A%7B%22value%22%3A%221167936760%22%7D%2C%22deposit_events%22%3A%7B%22counter%22%3A%2264%22%2C%22guid%22%3A%7B%22id%22%3A%7B%22addr%22%3A%220xa7f9629945aec12835f5d06bd8f3bdc0c02ea5a71f5edd9711a32d7c61da40b5%22%2C%22creation_num%22%3A%222%22%7D%7D%7D%2C%22frozen%22%3Afalse%2C%22withdraw_events%22%3A%7B%22counter%22%3A%220%22%2C%22guid%22%3A%7B%22id%22%3A%7B%22addr%22%3A%220xa7f9629945aec12835f5d06bd8f3bdc0c02ea5a71f5edd9711a32d7c61da40b5%22%2C%22creation_num%22%3A%223%22%7D%7D%7D%7D%7D%2C%22type%22%3A%22write_resource%22%7D%2C%7B%22address%22%3A%220xa7f9629945aec12835f5d06bd8f3bdc0c02ea5a71f5edd9711a32d7c61da40b5%22%2C%22state_key_hash%22%3A%220xa0e3ca0bdf785848654895ee5288affa13c9775820b84fd93e2e465ec617fb56%22%2C%22data%22%3A%7B%22type%22%3A%220x1%3A%3Aaccount%3A%3AAccount%22%2C%22data%22%3A%7B%22authentication_key%22%3A%220xa7f9629945aec12835f5d06bd8f3bdc0c02ea5a71f5edd9711a32d7c61da40b5%22%2C%22coin_register_events%22%3A%7B%22counter%22%3A%222%22%2C%22guid%22%3A%7B%22id%22%3A%7B%22addr%22%3A%220xa7f9629945aec12835f5d06bd8f3bdc0c02ea5a71f5edd9711a32d7c61da40b5%22%2C%22creation_num%22%3A%220%22%7D%7D%7D%2C%22guid_creation_num%22%3A%2246%22%2C%22key_rotation_events%22%3A%7B%22counter%22%3A%220%22%2C%22guid%22%3A%7B%22id%22%3A%7B%22addr%22%3A%220xa7f9629945aec12835f5d06bd8f3bdc0c02ea5a71f5edd9711a32d7c61da40b5%22%2C%22creation_num%22%3A%221%22%7D%7D%7D%2C%22rotation_capability_offer%22%3A%7B%22for%22%3A%7B%22vec%22%3A%5B%5D%7D%7D%2C%22sequence_number%22%3A%22420320%22%2C%22signer_capability_offer%22%3A%7B%22for%22%3A%7B%22vec%22%3A%5B%5D%7D%7D%7D%7D%2C%22type%22%3A%22write_resource%22%7D%2C%7B%22state_key_hash%22%3A%220x6e4b28d40f98a106a65163530924c0dcb40c1349d3aa915d108b4d6cfc1ddb19%22%2C%22handle%22%3A%220x1b854694ae746cdbd8d44186ca4929b2b337df21d1c74633be19b2710552fdca%22%2C%22key%22%3A%220x0619dc29a0aac8fa146714058e8dd6d2d0f3bdf5f6331907bf91f3acd81e6935%22%2C%22value%22%3A%220x4b485a3b90f85f950100000000000000%22%2C%22data%22%3Anull%2C%22type%22%3A%22write_table_item%22%7D%5D%2C%22sender%22%3A%220xa7f9629945aec12835f5d06bd8f3bdc0c02ea5a71f5edd9711a32d7c61da40b5%22%2C%22sequence_number%22%3A%22420319%22%2C%22max_gas_amount%22%3A%22100000%22%2C%22gas_unit_price%22%3A%22100%22%2C%22expiration_timestamp_secs%22%3A%221738666982%22%2C%22payload%22%3A%7B%22function%22%3A%220x3dc96a17bfdcda9f19c3c1f3621abd576b5c84980c4d22cedeb272b498f35565%3A%3Aperpetual_scripts%3A%3Acancel_multiple_orders_external%22%2C%22type_arguments%22%3A%5B%5D%2C%22arguments%22%3A%5B%22397%22%2C%5B%22914774039741178046416127%22%2C%22914626465366384494871468%22%2C%22914368210386445557400456%22%5D%2C%5Bfalse%2Cfalse%2Cfalse%5D%5D%2C%22type%22%3A%22entry_function_payload%22%7D%2C%22signature%22%3A%7B%22public_key%22%3A%220xb6f15767cb752c099576dabcc63a417666e4f1165f85443846a2d2a1a1d4f0b9%22%2C%22signature%22%3A%220xc39eb6f4654f96e39e516c2f9255fbbc1f3358d39ed879f4c4d8baf94e8237935648a5d89886a40699fe1b0b6382d3c52c7e238ca3e5bde748c1f24857ba380f%22%2C%22type%22%3A%22ed25519_signature%22%7D%2C%22events%22%3A%5B%7B%22guid%22%3A%7B%22creation_number%22%3A%220%22%2C%22account_address%22%3A%220x0%22%7D%2C%22sequence_number%22%3A%220%22%2C%22type%22%3A%220x1%3A%3Atransaction_fee%3A%3AFeeStatement%22%2C%22data%22%3A%7B%22execution_gas_units%22%3A%2278%22%2C%22io_gas_units%22%3A%2212%22%2C%22storage_fee_octas%22%3A%220%22%2C%22storage_fee_refund_octas%22%3A%220%22%2C%22total_charge_gas_units%22%3A%2289%22%7D%7D%5D%2C%22timestamp%22%3A%221738666382226533%22%2C%22type%22%3A%22user_transaction%22%7D) fails if the argument is `[914774039741178046416127,914626465366384494871468,914368210386445557400456]` but succeed with `914774039741178046416127,914626465366384494871468,914368210386445557400456` - that breaks nested vector tho


### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  