### PR TITLE
Add additional key rotation APIs 

### DIFF
--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -25,6 +25,8 @@ import {
   getSigningMessage,
   publicPackageTransaction,
   rotateAuthKey,
+  rotateAuthKeyUnverified,
+  rotateAuthKeyWithVerificationTransaction,
   signAndSubmitAsFeePayer,
   signAndSubmitTransaction,
   signAsFeePayer,
@@ -36,7 +38,7 @@ import {
   InputGenerateTransactionOptions,
   InputGenerateTransactionPayloadData,
 } from "../transactions";
-import { AccountAddressInput, PrivateKeyInput } from "../core";
+import { AccountAddressInput, AuthenticationKey, PrivateKeyInput } from "../core";
 import { Account } from "../account";
 import { Build } from "./transactionSubmission/build";
 import { Simulate } from "./transactionSubmission/simulate";
@@ -508,6 +510,46 @@ export class Transaction {
    */
   async rotateAuthKey(args: { fromAccount: Account; toNewPrivateKey: PrivateKeyInput }): Promise<TransactionResponse> {
     return rotateAuthKey({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Rotates the authentication key for a given account without a proof of ownership challenge. After
+   * rotation, the account will sign a no-op transaction with the new key to publish the public key on chain.
+   *
+   * @param args - The arguments for rotating the authentication key.
+   * @param args.fromAccount - The account for which the authentication key will be rotated.
+   * @param args.toAccount - The account whose authentication key will be used as the new authentication key for fromAccount.
+   *
+   * @remarks
+   * The authentication key of toAccount will be used, NOT the address of toAccount, though in most cases they will be the same.
+   *
+   * @returns PendingTransactionResponse
+   */
+  async rotateAuthKeyUnverified(args: {
+    fromAccount: Account;
+    newAuthKey: AuthenticationKey;
+  }): Promise<PendingTransactionResponse> {
+    return rotateAuthKeyUnverified({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Rotates the authentication key for a given account without a proof of ownership challenge. After
+   * rotation, the account will sign a no-op transaction with the new key to publish the public key on chain.
+   *
+   * @param args - The arguments for rotating the authentication key.
+   * @param args.fromAccount - The account for which the authentication key will be rotated.
+   * @param args.toAccount - The account whose authentication key will be used as the new authentication key for fromAccount.
+   *
+   * @remarks
+   * The authentication key of toAccount will be used, NOT the address of toAccount, though in most cases they will be the same.
+   *
+   * @returns PendingTransactionResponse
+   */
+  async rotateAuthKeyWithVerificationTransaction(args: {
+    fromAccount: Account;
+    toAccount: Account;
+  }): Promise<PendingTransactionResponse> {
+    return rotateAuthKeyWithVerificationTransaction({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/internal/transactionSubmission.ts
+++ b/src/internal/transactionSubmission.ts
@@ -33,13 +33,7 @@ import {
   EntryFunctionABI,
 } from "../transactions/types";
 import { getInfo } from "./account";
-import {
-  UserTransactionResponse,
-  PendingTransactionResponse,
-  MimeType,
-  HexInput,
-  TransactionResponse,
-} from "../types";
+import { UserTransactionResponse, PendingTransactionResponse, MimeType, HexInput, TransactionResponse } from "../types";
 import { SignedTransaction, TypeTagU8, TypeTagVector, generateSigningMessageForTransaction } from "../transactions";
 import { SimpleTransaction } from "../transactions/instances/simpleTransaction";
 import { MultiAgentTransaction } from "../transactions/instances/multiAgentTransaction";


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
Allows for unverified key rotations and key rotation chained with a transaction submission.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
e2e tests

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  