### PR TITLE
For multiKey simulation - use signature of same type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+- Update simulation for MultiKeyAccount to use signatures of the same type as the corresponding public key.
 - Add `truncateAddress` helper function to truncate an address at the middle with an ellipsis.
 
 # 1.35.0 (2025-02-11)

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -638,7 +638,12 @@ export function getAuthenticatorForSimulation(publicKey?: PublicKey) {
     return new AccountAuthenticatorMultiKey(
       accountPublicKey,
       new MultiKeySignature({
-        signatures: accountPublicKey.publicKeys.map(() => new AnySignature(invalidSignature)),
+        signatures: accountPublicKey.publicKeys.map((pubKey) => {
+          if (KeylessPublicKey.isInstance(pubKey.publicKey) || FederatedKeylessPublicKey.isInstance(pubKey.publicKey)) {
+            return new AnySignature(KeylessSignature.getSimulationSignature());
+          }
+          return new AnySignature(invalidSignature);
+        }),
         bitmap: accountPublicKey.createBitmap({
           bits: Array(accountPublicKey.publicKeys.length)
             .fill(0)


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
Previously multikey just used null ed25519 signatures.  This gave too optimistic gasEstimates which would lead to MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS error.  It is better to be pessimistic within reason.

TODO - only include N signatures where N = signaturesRequired.  Right now we have N = num of pub keys

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  