### PR TITLE
[scriptComposer]fix object detected in rust

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Upgrade rotateAuthKey API to support Account types other than Ed25519.
 - Update simulation for MultiKeyAccount to use signatures of the same type as the corresponding public key.
 - Add `truncateAddress` helper function to truncate an address at the middle with an ellipsis.
+- Fix scriptComposer addBatchedCalls more typeArguments error
 
 # 1.35.0 (2025-02-11)
 

--- a/src/transactions/scriptComposer/index.ts
+++ b/src/transactions/scriptComposer/index.ts
@@ -58,7 +58,7 @@ export class AptosScriptComposer {
 
     // Load the calling type arguments into the loader.
     if (input.typeArguments !== undefined) {
-      for(const ty of input.typeArguments) {
+      for (const ty of input.typeArguments) {
         await this.builder.load_type_tag(nodeUrl, ty.toString());
       }
     }

--- a/src/transactions/scriptComposer/index.ts
+++ b/src/transactions/scriptComposer/index.ts
@@ -58,8 +58,8 @@ export class AptosScriptComposer {
 
     // Load the calling type arguments into the loader.
     if (input.typeArguments !== undefined) {
-      for (const ty of input.typeArguments) {
-        await this.builder.load_type_tag(nodeUrl, ty.toString());
+      for (const typeArgument of input.typeArguments) {
+        await this.builder.load_type_tag(nodeUrl, typeArgument.toString());
       }
     }
     const typeArguments = standardizeTypeTags(input.typeArguments);

--- a/src/transactions/scriptComposer/index.ts
+++ b/src/transactions/scriptComposer/index.ts
@@ -58,7 +58,9 @@ export class AptosScriptComposer {
 
     // Load the calling type arguments into the loader.
     if (input.typeArguments !== undefined) {
-      await Promise.all(input.typeArguments.map((typeTag) => this.builder.load_type_tag(nodeUrl, typeTag.toString())));
+      for(const ty of input.typeArguments) {
+        await this.builder.load_type_tag(nodeUrl, ty.toString());
+      }
     }
     const typeArguments = standardizeTypeTags(input.typeArguments);
     const functionAbi = await fetchMoveFunctionAbi(moduleAddress, moduleName, functionName, this.config);


### PR DESCRIPTION
### Description
Fix scriptComposer addBatchedCalls more typeArguments error

<recursive use of an object detected which would lead to unsafe aliasing in rust>

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  