### PR TITLE
[ts-sdk] add a helper function to return the paired FA address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Override @babel/runtime and @babel/helpers to use an updated version
 - Fix pagination of AccountResources and AccountModules
 - Add API for `getResourcesPage` and `getModulesPage` to support manual pagination
+- Added `pairedFaMetadataAddress` function to calculate the paired fungible asset metadata address for a given coin type, with enhanced support for various address formats (short form, long form, with leading zeros)
 
 # 1.36.0 (2025-03-14)
 

--- a/src/core/accountAddress.ts
+++ b/src/core/accountAddress.ts
@@ -184,6 +184,31 @@ export class AccountAddress extends Serializable implements TransactionArgument 
   }
 
   /**
+   * Convert the account address to a string in SHORT format, which is 0x followed by the shortest
+   * possible representation (no leading zeros).
+   *
+   * @returns AccountAddress as a string in SHORT form.
+   * @group Implementation
+   * @category Serialization
+   */
+  toStringShort(): `0x${string}` {
+    return `0x${this.toStringShortWithoutPrefix()}`;
+  }
+
+  /**
+   * Returns a lossless short string representation of the address by trimming leading zeros.
+   * If the address consists of all zeros, returns "0".
+   *
+   * @returns A string representation of the address without leading zeros
+   * @group Implementation
+   * @category Serialization
+   */
+  toStringShortWithoutPrefix(): string {
+    const hex = bytesToHex(this.data).replace(/^0+/, "");
+    return hex === "" ? "0" : hex;
+  }
+
+  /**
    * Get the inner data as a Uint8Array.
    * The inner data is already a Uint8Array, so no conversion takes place.
    *

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -4,6 +4,7 @@
 import { decode } from "js-base64";
 import { MoveFunctionId, MoveStructId } from "../types";
 import { AccountAddress } from "../core/accountAddress";
+import { createObjectAddress } from "../core/account/utils/address";
 
 /**
  * Sleep for the specified amount of time in milliseconds.
@@ -234,4 +235,53 @@ export function isValidFunctionInfo(functionInfo: string): boolean {
  */
 export function truncateAddress(address: string, start: number = 6, end: number = 5) {
   return `${address.slice(0, start)}...${address.slice(-end)}`;
+}
+
+/**
+ * Constants for metadata address calculation
+ */
+const APTOS_COIN_TYPE_STR = "0x1::aptos_coin::AptosCoin";
+const APT_METADATA_ADDRESS_HEX = AccountAddress.A.toStringLong();
+
+/**
+ * Helper function to standardize Move type string by converting all addresses to short form,
+ * including addresses within nested type parameters
+ */
+function standardizeMoveTypeString(input: string): string {
+  // Regular expression to match addresses in the type string, including those within type parameters
+  // This regex matches "0x" followed by hex digits, handling both standalone addresses and those within <>
+  const addressRegex = /0x[0-9a-fA-F]+/g;
+
+  return input.replace(addressRegex, (match) => {
+    // Use AccountAddress to handle the address
+    return AccountAddress.from(match, { maxMissingChars: 63 }).toStringShort();
+  });
+}
+
+/**
+ * Calculates the paired FA metadata address for a given coin type.
+ * This function is tolerant of various address formats in the coin type string,
+ * including complex nested types.
+ *
+ * @example
+ * // All these formats are valid and will produce the same result:
+ * pairedFaMetadataAddress("0x1::aptos_coin::AptosCoin")  // simple form
+ * pairedFaMetadataAddress("0x0000000000000000000000000000000000000000000000000000000000000001::aptos_coin::AptosCoin")  // long form
+ * pairedFaMetadataAddress("0x00001::aptos_coin::AptosCoin")  // with leading zeros
+ * pairedFaMetadataAddress("0x1::coin::Coin<0x1412::a::struct<0x0001::aptos_coin::AptosCoin>>")  // nested type parameters
+ *
+ * @param coinType - The coin type string in any of these formats:
+ *   - Short form address: "0x1::aptos_coin::AptosCoin"
+ *   - Long form address: "0x0000000000000000000000000000000000000000000000000000000000000001::aptos_coin::AptosCoin"
+ *   - With leading zeros: "0x00001::aptos_coin::AptosCoin"
+ *   - With nested types: "0x1::coin::Coin<0x1412::a::struct<0x0001::aptos_coin::AptosCoin>>"
+ * @returns The calculated metadata address as an AccountAddress instance
+ */
+export function pairedFaMetadataAddress(coinType: `0x${string}::${string}::${string}`): AccountAddress {
+  // Standardize the coin type string to handle any address format
+  const standardizedMoveTypeName = standardizeMoveTypeString(coinType);
+
+  return standardizedMoveTypeName === APTOS_COIN_TYPE_STR
+    ? AccountAddress.A
+    : createObjectAddress(AccountAddress.A, standardizedMoveTypeName);
 }

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,0 +1,86 @@
+import { pairedFaMetadataAddress } from "../../src/utils/helpers";
+import { AccountAddress } from "../../src/core/accountAddress";
+
+describe("pairedFaMetadataAddress", () => {
+  test("matches the ground truth cases on chain", () => {
+    // Test case 1: Aptos Coin should return APT_METADATA_ADDRESS_HEX
+    expect(pairedFaMetadataAddress("0x1::aptos_coin::AptosCoin")).toEqual(AccountAddress.A);
+
+    // Test case 2: Moon Coin should match the specific hash
+    expect(
+      pairedFaMetadataAddress(
+        "0x66c34778730acbb120cefa57a3d98fd21e0c8b3a51e9baee530088b2e444e94c::moon_coin::MoonCoin",
+      ),
+    ).toEqual(AccountAddress.from("0xf772c28c069aa7e4417d85d771957eb3c5c11b5bf90b1965cda23b899ebc0384"));
+
+    // Test case 3: THL Coin should match the specific hash
+    expect(
+      pairedFaMetadataAddress("0x7fd500c11216f0fe3095d0c4b8aa4d64a4e2e04f83758462f2b127255643615::thl_coin::THL"),
+    ).toEqual(AccountAddress.from("0x377adc4848552eb2ea17259be928001923efe12271fef1667e2b784f04a7cf3a"));
+
+    // Test case 4: LP Coin with USDC and AptosCoin should match the specific hash
+    expect(
+      pairedFaMetadataAddress(
+        "0x5a97986a9d031c4567e15b797be516910cfcb4156312482efc6a19c0a30c948::lp_coin::LP<0xf22bede237a07e121b56d91a491eb7bcdfd1f5907926a9e58338f964a01b17fa::asset::USDC, 0x1::aptos_coin::AptosCoin, 0x190d44266241744264b964a37b8f09863167a12d3e70cda39376cfb4e3561e12::curves::Uncorrelated>",
+      ),
+    ).toEqual(AccountAddress.from("0xb7cc2781865ac4b29da6e0660f4cd00c0625cb47b37152405fc8ba2708867e54"));
+  });
+
+  test("handles standardization of input types", () => {
+    // Test that leading zeros in addresses are handled correctly
+    expect(pairedFaMetadataAddress("0x01::aptos_coin::AptosCoin")).toEqual(AccountAddress.A);
+    expect(pairedFaMetadataAddress("0x001::aptos_coin::AptosCoin")).toEqual(AccountAddress.A);
+  });
+
+  test("handles various address formats", () => {
+    const testCases = [
+      // Simple forms
+      {
+        input: "0x1::aptos_coin::AptosCoin",
+        expected: AccountAddress.A, // Special case for Aptos Coin
+      },
+      {
+        input: "0x0000000000000000000000000000000000000000000000000000000000000001::aptos_coin::AptosCoin", // long form
+        expected: AccountAddress.A,
+      },
+      {
+        input: "0x00001::aptos_coin::AptosCoin", // with leading zeros
+        expected: AccountAddress.A,
+      },
+      // Complex nested types
+      {
+        input: "0x1::coin::Coin<0x1412::a::struct<0x0001::aptos_coin::AptosCoin>>",
+        expected: pairedFaMetadataAddress(
+          "0x1::coin::Coin<0x1412::a::struct<0x1::aptos_coin::AptosCoin>>" as `0x${string}::${string}::${string}`,
+        ),
+      },
+      {
+        input: "0x1::coin::Coin<0x0001412::a::struct<0x1::aptos_coin::AptosCoin>>",
+        expected: pairedFaMetadataAddress(
+          "0x1::coin::Coin<0x1412::a::struct<0x1::aptos_coin::AptosCoin>>" as `0x${string}::${string}::${string}`,
+        ),
+      },
+    ];
+
+    for (const { input, expected } of testCases) {
+      const result = pairedFaMetadataAddress(input as `0x${string}::${string}::${string}`);
+      expect(result).toEqual(expected);
+    }
+  });
+
+  test("normalizes addresses consistently in nested types", () => {
+    const variations = [
+      "0x1::coin::Coin<0x1412::a::struct<0x0001::aptos_coin::AptosCoin>>",
+      "0x01::coin::Coin<0x001412::a::struct<0x1::aptos_coin::AptosCoin>>",
+      "0x0001::coin::Coin<0x1412::a::struct<0x00001::aptos_coin::AptosCoin>>",
+    ];
+
+    // All variations should produce the same metadata address
+    const results = variations.map((input) => pairedFaMetadataAddress(input as `0x${string}::${string}::${string}`));
+    const firstResult = results[0];
+
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i]).toEqual(firstResult);
+    }
+  });
+});


### PR DESCRIPTION
### Description
add a helper function `pairedFaMetadataAddress` to return the paired fa address for even non-standard coin type string.

### Test Plan
unit test.

### Related Links


### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  