### PR TITLE
[paginaton] Fix cursor pagination, add by page APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Adds support for keyless signature verification.
 - Implements signature verification for MultiKey.
 - Override @babel/runtime and @babel/helpers to use an updated version
+- Fix pagination of AccountResources and AccountModules
+- Add API for `getResourcesPage` and `getModulesPage` to support manual pagination
 
 # 1.36.0 (2025-03-14)
 

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -6,6 +6,7 @@ import { AccountAddress, PrivateKey, AccountAddressInput, createObjectAddress } 
 import {
   AccountData,
   AnyNumber,
+  CursorPaginationArgs,
   GetAccountCoinsDataResponse,
   GetAccountCollectionsWithOwnedTokenResponse,
   GetAccountOwnedTokensFromCollectionResponse,
@@ -35,8 +36,10 @@ import {
   getInfo,
   getModule,
   getModules,
+  getModulesPage,
   getResource,
   getResources,
+  getResourcesPage,
   getTransactions,
   lookupOriginalAccountAddress,
 } from "../internal/account";
@@ -112,7 +115,6 @@ export class Account {
    * This function may call the API multiple times to auto paginate through results.
    *
    * @param args.accountAddress - The Aptos account address to query modules for.
-   * @param args.options.offset - The cursor to start returning results from.  Note, this is obfuscated and is not an index.
    * @param args.options.limit - The maximum number of results to return.
    * @param args.options.ledgerVersion - The ledger version to query; if not provided, it retrieves the latest version.
    *
@@ -130,7 +132,6 @@ export class Account {
    *   const accountModules = await aptos.getAccountModules({
    *     accountAddress: "0x1", // replace with a real account address
    *     options: {
-   *       offset: 0, // starting from the first module
    *       limit: 10, // limiting to 10 modules
    *     },
    *   });
@@ -143,9 +144,50 @@ export class Account {
    */
   async getAccountModules(args: {
     accountAddress: AccountAddressInput;
-    options?: PaginationArgs & LedgerVersionArg;
+    options?: { limit?: number } & LedgerVersionArg;
   }): Promise<MoveModuleBytecode[]> {
     return getModules({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Queries for a page of modules in an account given an account address.
+   *
+   * @param args.accountAddress - The Aptos account address to query modules for.
+   * @param args.options.cursor - The cursor to start returning results from.  Note, this is obfuscated and is not an index.
+   * @param args.options.limit - The maximum number of results to return.
+   * @param args.options.ledgerVersion - The ledger version to query; if not provided, it retrieves the latest version.
+   *
+   * @returns - The account modules associated with the specified address. Along with a cursor for future pagination. If the cursor is undefined, it means there are no more modules to fetch.
+   *
+   * @example
+   * ```typescript
+   * import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+   *
+   * const config = new AptosConfig({ network: Network.TESTNET });
+   * const aptos = new Aptos(config);
+   *
+   * async function runExample() {
+   *   // Fetching account modules for a specific account
+   *   const {modules, cursor} = await aptos.getAccountModulesPage({
+   *     accountAddress: "0x1", // replace with a real account address
+   *     options: {
+   *       cursor: undefined, // starting from the first module
+   *       limit: 10, // limiting to 10 modules
+   *     },
+   *   });
+   *
+   *   console.log(modules);
+   *   console.log(`More to fetch: ${cursor !== undefined}`);
+   * }
+   * runExample().catch(console.error);
+   * ```
+   * @group Account
+   */
+  async getAccountModulesPage(args: {
+    accountAddress: AccountAddressInput;
+    options?: CursorPaginationArgs & LedgerVersionArg;
+  }): Promise<{ modules: MoveModuleBytecode[]; cursor: string | undefined }> {
+    return getModulesPage({ aptosConfig: this.config, ...args });
   }
 
   /**
@@ -234,7 +276,6 @@ export class Account {
    * This function may call the API multiple times to auto paginate through results.
    *
    * @param args.accountAddress - The Aptos account address to query resources for.
-   * @param args.options.offset - The cursor to start returning results from.  Note, this is obfuscated and is not an index.
    * @param args.options.limit - The maximum number of results to return.
    * @param args.options.ledgerVersion - The ledger version to query; if not provided, it will get the latest version.
    * @returns Account resources.
@@ -260,6 +301,45 @@ export class Account {
     options?: PaginationArgs & LedgerVersionArg;
   }): Promise<MoveResource[]> {
     return getResources({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Queries a page of account resources given an account address.
+   *
+   * @param args.accountAddress - The Aptos account address to query resources for.
+   * @param args.options.cursor - The cursor to start returning results from.  Note, this is obfuscated and is not an index.
+   * @param args.options.limit - The maximum number of results to return.
+   * @param args.options.ledgerVersion - The ledger version to query; if not provided, it will get the latest version.
+   * @returns Account resources.
+   *
+   * @example
+   * ```typescript
+   * import { Aptos, AptosConfig, Network } from "@aptos-labs/ts-sdk";
+   *
+   * const config = new AptosConfig({ network: Network.TESTNET });
+   * const aptos = new Aptos(config);
+   *
+   * async function runExample() {
+   *   // Fetching account resources for a specific account address
+   *   const resources = await aptos.getAccountResourcesPage({
+   *     accountAddress: "0x1", // replace with a real account address
+   *     options: {
+   *       cursor: undefined, // starting from the first resource
+   *       limit: 10, // limiting to 10 resources
+   *     },
+   *   });
+   *   console.log(resources);
+   *   console.log(`More to fetch: ${resources.cursor !== undefined}`);
+   * }
+   * runExample().catch(console.error);
+   * ```
+   * @group Account
+   */
+  async getAccountResourcesPage(args: {
+    accountAddress: AccountAddressInput;
+    options?: CursorPaginationArgs & LedgerVersionArg;
+  }): Promise<{ resources: MoveResource[]; cursor: string | undefined }> {
+    return getResourcesPage({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/client/get.ts
+++ b/src/client/get.ts
@@ -234,7 +234,7 @@ export async function getAptosPepperService<Req extends {}, Res extends {}>(
 export async function paginateWithCursor<Req extends Record<string, any>, Res extends Array<{}>>(
   options: GetAptosRequestOptions,
 ): Promise<Res> {
-  const out: any[] = [];
+  const out: Res = new Array(0) as Res;
   let cursor: string | undefined;
   const requestParams = options.params as { start?: string; limit?: number };
   do {
@@ -261,14 +261,14 @@ export async function paginateWithCursor<Req extends Record<string, any>, Res ex
     out.push(...response.data);
     requestParams.start = cursor;
   } while (cursor !== null && cursor !== undefined);
-  return out as Res;
+  return out;
 }
 
 /// This function is a helper for paginating using a function wrapping an API using offset instead of start
 export async function paginateWithObfuscatedCursor<Req extends Record<string, any>, Res extends Array<{}>>(
   options: GetAptosRequestOptions,
 ): Promise<Res> {
-  const out: any[] = [];
+  const out: Res = new Array(0) as Res;
   let cursor: string | undefined;
   const requestParams = options.params as { start?: string; limit?: number };
   const totalLimit = requestParams.limit;
@@ -296,7 +296,7 @@ export async function paginateWithObfuscatedCursor<Req extends Record<string, an
       requestParams.limit = newLimit;
     }
   } while (cursor !== null && cursor !== undefined);
-  return out as Res;
+  return out;
 }
 
 export async function getPageWithObfuscatedCursor<Req extends Record<string, any>, Res extends Array<{}>>(
@@ -307,10 +307,10 @@ export async function getPageWithObfuscatedCursor<Req extends Record<string, any
 
   // Drop any other values
   // TODO: Throw error if cursor is not a string
-  if ("string" == typeof options.params?.cursor) {
+  if (typeof options.params?.cursor === "string") {
     requestParams.start = options.params.cursor;
   }
-  if ("number" == typeof options.params?.limit) {
+  if (typeof options.params?.limit === "number") {
     requestParams.limit = options.params.limit;
   }
 

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -200,7 +200,7 @@ export async function getTransactions(args: {
  * @param args.aptosConfig - The configuration settings for Aptos.
  * @param args.accountAddress - The address of the account to fetch resources for.
  * @param args.options - Optional pagination and ledger version parameters.
- * @param args.options.limit - The maximum number of resources to retrieve (default is 1000).
+ * @param args.options.limit - The maximum number of resources to retrieve (default is 999).
  * @param args.options.ledgerVersion - The specific ledger version to query.
  * @group Implementation
  */
@@ -216,7 +216,7 @@ export async function getResources(args: {
     path: `accounts/${AccountAddress.from(accountAddress).toString()}/resources`,
     params: {
       ledger_version: options?.ledgerVersion,
-      limit: options?.limit ?? 1000,
+      limit: options?.limit ?? 999,
     },
   });
 }

--- a/src/internal/utils/utils.ts
+++ b/src/internal/utils/utils.ts
@@ -1,38 +1,8 @@
 import { AccountAddress, AccountAddressInput } from "../../core/accountAddress";
-import { MoveModuleBytecode, LedgerVersionArg, PaginationArgs, AccountData } from "../../types/types";
+import { MoveModuleBytecode, LedgerVersionArg, AccountData } from "../../types/types";
 import { AptosConfig } from "../../api/aptosConfig";
-import { getAptosFullNode, paginateWithObfuscatedCursor } from "../../client";
+import { getAptosFullNode } from "../../client";
 import { memoizeAsync } from "../../utils/memoize";
-
-/**
- * Retrieves the modules associated with a specified account address.
- *
- * @param args - The arguments for retrieving modules.
- * @param args.aptosConfig - The configuration for connecting to the Aptos blockchain.
- * @param args.accountAddress - The address of the account whose modules are to be retrieved.
- * @param args.options - Optional parameters for pagination and ledger version.
- * @param args.options.limit - The maximum number of modules to retrieve (default is 1000).
- * @param args.options.offset - The starting point for pagination.  Note, this is obfuscated and is not an index.
- * @param args.options.ledgerVersion - The specific ledger version to query.
- * @group Implementation
- */
-export async function getModules(args: {
-  aptosConfig: AptosConfig;
-  accountAddress: AccountAddressInput;
-  options?: PaginationArgs & LedgerVersionArg;
-}): Promise<MoveModuleBytecode[]> {
-  const { aptosConfig, accountAddress, options } = args;
-  return paginateWithObfuscatedCursor<{}, MoveModuleBytecode[]>({
-    aptosConfig,
-    originMethod: "getModules",
-    path: `accounts/${AccountAddress.from(accountAddress).toString()}/modules`,
-    params: {
-      ledger_version: options?.ledgerVersion,
-      offset: options?.offset,
-      limit: options?.limit ?? 1000,
-    },
-  });
-}
 
 /**
  * Retrieves account information for a specified account address.

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -238,6 +238,16 @@ export interface PaginationArgs {
 }
 
 /**
+ * Defines the parameters for paginating query results, including the starting position and maximum number of items to return.
+ * @param cursor Specifies the starting position of the query result. Default is at the beginning if undefined.  This is not a number and must come from the API.
+ * @param limit Specifies the maximum number of items to return. Default is 25.
+ */
+export interface CursorPaginationArgs {
+  cursor?: string;
+  limit?: number;
+}
+
+/**
  * Represents the arguments for specifying a token standard.
  *
  * @param tokenStandard - Optional standard of the token.

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -41,17 +41,43 @@ describe("account api", () => {
       expect(data.length).toBeGreaterThan(0);
     });
 
-    test("it fetches account modules with pagination", async () => {
+    test("it fetches account modules with a limit", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
       const data = await aptos.getAccountModules({
         accountAddress: "0x1",
         options: {
-          offset: 1,
           limit: 1,
         },
       });
       expect(data.length).toEqual(1);
+    });
+
+    test("it fetches account modules with pagination", async () => {
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      let { modules, cursor } = await aptos.getAccountModulesPage({
+        accountAddress: "0x1",
+        options: {
+          limit: 1,
+        },
+      });
+      expect(modules.length).toEqual(1);
+      expect(cursor).toBeDefined();
+      while (true) {
+        const { modules: modules2, cursor: cursor2 } = await aptos.getAccountModulesPage({
+          accountAddress: "0x1",
+          options: {
+            cursor,
+          },
+        });
+        expect(modules2.length).toBeGreaterThan(0);
+        expect(modules2).not.toContain(modules[0]);
+        if (cursor2 === undefined) {
+          break;
+        }
+        cursor = cursor2;
+      }
     });
 
     test("it fetches an account module", async () => {
@@ -73,17 +99,39 @@ describe("account api", () => {
       expect(data.length).toBeGreaterThan(0);
     });
 
-    test("it fetches account resources with pagination", async () => {
+    test("it fetches account resources with a limit", async () => {
       const config = new AptosConfig({ network: Network.LOCAL });
       const aptos = new Aptos(config);
       const data = await aptos.getAccountResources({
         accountAddress: "0x1",
         options: {
-          offset: 1,
           limit: 1,
         },
       });
       expect(data.length).toEqual(1);
+    });
+
+    test("it fetches account resources with pagination", async () => {
+      const config = new AptosConfig({ network: Network.LOCAL });
+      const aptos = new Aptos(config);
+      const { resources, cursor } = await aptos.getAccountResourcesPage({
+        accountAddress: "0x1",
+        options: {
+          limit: 1,
+        },
+      });
+      expect(resources.length).toEqual(1);
+      expect(cursor).toBeDefined();
+
+      const { resources: resources2, cursor: cursor2 } = await aptos.getAccountResourcesPage({
+        accountAddress: "0x1",
+        options: {
+          cursor,
+        },
+      });
+      expect(resources2.length).toBeGreaterThan(0);
+      expect(cursor2).toBeUndefined();
+      expect(resources2).not.toContain(resources[0]);
     });
 
     test("it fetches an account resource without a type", async () => {


### PR DESCRIPTION
### Description
Right now, you can just request a very long page, but that's really not useful for explorers and other things.  Ideally, it should get all, and not just query up to some amount.  May consider removing default page sizes of default APIs in the future.

Resolves https://github.com/aptos-labs/aptos-ts-sdk/issues/665

### Test Plan
See new unit tests around pagination testing.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  