### PR TITLE
Add a default implementation of verifySignatureAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Unreleased
 
+- Adds and default implementation of `verifySignatureAsync` to `PublicKey`.
+
 # 1.37.1 (2025-03-24)
 
 - Upgrade min versions of @noble/curves and @noble/hashes to 1.6.0 and 1.5.0 respectively as they are required to use keyless signature verification.

--- a/src/core/crypto/publicKey.ts
+++ b/src/core/crypto/publicKey.ts
@@ -61,7 +61,9 @@ export abstract class PublicKey extends Serializable {
    * @group Implementation
    * @category Serialization
    */
-  abstract verifySignatureAsync(args: VerifySignatureAsyncArgs): Promise<boolean>;
+  async verifySignatureAsync(args: VerifySignatureAsyncArgs): Promise<boolean> {
+    return this.verifySignature(args);
+  }
 
   /**
    * Get the raw public key bytes


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

This allows for simpler implementation of publicKeys, for example EIP1193DerivedPublicKey in the wallet adapter

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  