### PR TITLE
Add support for continually adding more txns to TransactionWorker, make it more extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Unreleased
 
+- [**Breaking Change**] Adds support to `TransactionWorker` for adding new transactions while the worker is running. Marked as breaking because the semantics of the worker are different, since before it would only submit the original batch of transactions and then do nothing with additional transactions pushed to the worker.
+
 # 1.38.0 (2025-04-02)
 
 - Adds and default implementation of `verifySignatureAsync` to `PublicKey`.

--- a/src/api/transaction.ts
+++ b/src/api/transaction.ts
@@ -623,11 +623,16 @@ export class Transaction {
   // TRANSACTION SUBMISSION //
 
   /**
-   * @deprecated Prefer to use `aptos.transaction.batch.forSingleAccount()`
+   * @deprecated For a safer, more ergonomic API, consider using `TransactionWorker` directly.
+   * You can also use `aptos.transaction.batch.forSingleAccount()`.
    *
-   * Batch transactions for a single account by submitting multiple transaction payloads.
-   * This function is useful for efficiently processing and submitting transactions that do not depend on each other, such as
-   * batch funding or batch token minting.
+   * Batch transactions for a single account by submitting multiple transaction
+   * payloads. This function is useful for efficiently processing and submitting
+   * transactions that do not depend on each other, such as batch funding or batch token
+   * minting.
+   *
+   * **Warning**: This does not actually use the batch submission API at
+   * /v1/transactions/batch，it still submits transactions sequentially.
    *
    * @param args - The arguments for batching transactions.
    * @param args.sender - The sender account to sign and submit the transactions.

--- a/src/api/transactionSubmission/management.ts
+++ b/src/api/transactionSubmission/management.ts
@@ -4,6 +4,9 @@ import { InputGenerateTransactionPayloadData, InputGenerateTransactionOptions } 
 import { AptosConfig } from "../aptosConfig";
 import { Account } from "../../account";
 
+/**
+ * For a safer, more ergonomic API, consider using {@link TransactionWorker} directly.
+ */
 export class TransactionManagement extends EventEmitter<TransactionWorkerEvents> {
   account!: Account;
 
@@ -178,6 +181,8 @@ export class TransactionManagement extends EventEmitter<TransactionWorkerEvents>
   }
 
   /**
+   * For a safer, more ergonomic API, consider using {@link TransactionWorker} directly.
+   *
    * Send batch transactions for a single account.
    *
    * This function uses a transaction worker that receives payloads to be processed

--- a/src/transactions/management/accountSequenceNumber.ts
+++ b/src/transactions/management/accountSequenceNumber.ts
@@ -110,7 +110,7 @@ export class AccountSequenceNumber {
    * @group Implementation
    * @category Transactions
    */
-  async nextSequenceNumber(): Promise<bigint | null> {
+  async nextSequenceNumber(): Promise<bigint> {
     /* eslint-disable no-await-in-loop */
     while (this.lock) {
       await sleep(this.sleepTime);

--- a/src/transactions/management/index.ts
+++ b/src/transactions/management/index.ts
@@ -1,2 +1,3 @@
 export * from "./accountSequenceNumber";
 export * from "./transactionWorker";
+export { AsyncQueueCancelledError } from "./asyncQueue";

--- a/tests/e2e/transactionManagement/asyncQueue.test.ts
+++ b/tests/e2e/transactionManagement/asyncQueue.test.ts
@@ -19,6 +19,79 @@ describe("asyncQueue", () => {
     expect(item3).toBe(3);
   });
 
+  it("should enqueue multiple items at once with enqueueMany", async () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    asyncQueue.enqueueMany([1, 2, 3]);
+
+    const item1 = await asyncQueue.dequeue();
+    const item2 = await asyncQueue.dequeue();
+    const item3 = await asyncQueue.dequeue();
+
+    expect(item1).toBe(1);
+    expect(item2).toBe(2);
+    expect(item3).toBe(3);
+  });
+
+  it("should handle enqueueMany with pending dequeues", async () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    const itemPromise1 = asyncQueue.dequeue();
+    const itemPromise2 = asyncQueue.dequeue();
+    const itemPromise3 = asyncQueue.dequeue();
+
+    expect(asyncQueue.pendingDequeueLength()).toBe(3);
+
+    asyncQueue.enqueueMany([10, 20, 30, 40]);
+
+    const item1 = await itemPromise1;
+    const item2 = await itemPromise2;
+    const item3 = await itemPromise3;
+    const item4 = await asyncQueue.dequeue();
+
+    expect(item1).toBe(10);
+    expect(item2).toBe(20);
+    expect(item3).toBe(30);
+    expect(item4).toBe(40);
+    expect(asyncQueue.isEmpty()).toBe(true);
+  });
+
+  it("should dequeue all items with dequeueAll when queue has items", async () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    asyncQueue.enqueueMany([1, 2, 3]);
+
+    const items = await asyncQueue.dequeueAll();
+
+    expect(items).toEqual([1, 2, 3]);
+    expect(asyncQueue.isEmpty()).toBe(true);
+  });
+
+  it("should handle dequeueAll before enqueue", async () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    const itemsPromise = asyncQueue.dequeueAll();
+    expect(asyncQueue.pendingDequeueLength()).toBe(1);
+
+    asyncQueue.enqueue(42);
+
+    const items = await itemsPromise;
+    expect(items).toEqual([42]);
+    expect(asyncQueue.isEmpty()).toBe(true);
+  });
+
+  it("should handle cancellation with dequeueAll", async () => {
+    const asyncQueue = new AsyncQueue<number>();
+
+    const itemsPromise = asyncQueue.dequeueAll();
+    expect(asyncQueue.pendingDequeueLength()).toBe(1);
+
+    asyncQueue.cancel();
+
+    await expect(itemsPromise).rejects.toThrow(AsyncQueueCancelledError);
+    expect(asyncQueue.pendingDequeueLength()).toBe(0);
+  });
+
   it("should handle dequeue before queue", async () => {
     const asyncQueue = new AsyncQueue<number>();
 


### PR DESCRIPTION
### Description
The existing behavior of the TransactionWorker is after it runs out of txns to submit, it no longer processes any further txns. This makes the class less useful, and given the existing API design, is quite unexpected, since the `push` method would still work, the worker wouldn't exit, etc.

This PR makes the worker continually accept new transactions and submit them as they come in.

I also make some other improvements:
1. Certain methods were needlessly async, making the code a bit confusing, particularly for methods that return promises but don't need to be async.
2. Deficiencies in other parts of the code have been fixed at the source, e.g. adding a `dequeueAll` method to `AsyncQueue` so we don't have to replicate the functionality in `processTransactions` with a for-loop.
3. My original goal was to make a version of this that uses the gas station to submit txns instead. With that in mind, there is now a `buildSignAndSubmitTransactionPromise` method that can be overridden.

### Test Plan
See updated tests for the TransactionWorker and AsyncQueue. See also this run of the batch funds example:
```
pnpm install
pnpm build
cd examples/typescript
pnpm install
pnpm ts-node batch_funds.ts
```
```
...
Account sequence number is 20, it should be 20
Account sequence number is 20, it should be 20
```

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  