### PR TITLE
Define the return type for `toUint8Array()` in the `SingleKey.ts` file to not break `tsc` build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Unreleased
 
+- Define the return type for `toUint8Array()` in the `SingleKey.ts` file to not break `tsc` build
+
 # 1.38.0 (2025-04-02)
 
 - Adds and default implementation of `verifySignatureAsync` to `PublicKey`.

--- a/src/core/crypto/singleKey.ts
+++ b/src/core/crypto/singleKey.ts
@@ -149,7 +149,7 @@ export class AnyPublicKey extends AccountPublicKey {
    * @group Implementation
    * @category Serialization
    */
-  toUint8Array() {
+  toUint8Array(): Uint8Array {
     return this.bcsToBytes();
   }
 
@@ -289,7 +289,7 @@ export class AnySignature extends Signature {
 
   // region AccountSignature
 
-  toUint8Array() {
+  toUint8Array(): Uint8Array {
     // TODO: keep this warning around for a bit, and eventually change this to return `this.signature.toUint8Array()`.
     // eslint-disable-next-line no-console
     console.warn(


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  