### PR TITLE
[PrivateKey] Default toString for Ed25519 and Secp256k1 private keys to AIP-80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Unreleased
 
+- [`Breaking`] Ed25519 and Secp256k1 private keys will now default to the AIP-80 format when calling `toString()`.
+
 # 1.39.0 (2025-04-02)
 
 - Add a `transferFungibleAssetBetweenStores` function to transfer Fungible Assets between any (primary or secondary) fungible stores.

--- a/src/core/crypto/ed25519.ts
+++ b/src/core/crypto/ed25519.ts
@@ -383,7 +383,7 @@ export class Ed25519PrivateKey extends Serializable implements PrivateKey {
    * @category Serialization
    */
   toString(): string {
-    return this.toHexString();
+    return this.toAIP80String();
   }
 
   /**

--- a/src/core/crypto/secp256k1.ts
+++ b/src/core/crypto/secp256k1.ts
@@ -324,7 +324,7 @@ export class Secp256k1PrivateKey extends Serializable implements PrivateKey {
    * @category Serialization
    */
   toString(): string {
-    return this.toHexString();
+    return this.toAIP80String();
   }
 
   /**

--- a/tests/unit/ed25519.test.ts
+++ b/tests/unit/ed25519.test.ts
@@ -109,17 +109,17 @@ describe("Ed25519PublicKey", () => {
   });
 });
 
-describe("PrivateKey", () => {
+describe("Ed25519PrivateKey", () => {
   it("should create the instance correctly without error with AIP-80 compliant private key", () => {
     const privateKey2 = new Ed25519PrivateKey(ed25519.privateKey, false);
     expect(privateKey2).toBeInstanceOf(Ed25519PrivateKey);
-    expect(privateKey2.toAIP80String()).toEqual(ed25519.privateKey);
+    expect(privateKey2.toString()).toEqual(ed25519.privateKey);
   });
 
   it("should create the instance correctly without error with non-AIP-80 compliant private key", () => {
     const privateKey = new Ed25519PrivateKey(ed25519.privateKey, false);
     expect(privateKey).toBeInstanceOf(Ed25519PrivateKey);
-    expect(privateKey.toAIP80String()).toEqual(ed25519.privateKey);
+    expect(privateKey.toString()).toEqual(ed25519.privateKey);
   });
 
   it("should create the instance correctly without error with Uint8Array private key", () => {
@@ -130,6 +130,11 @@ describe("PrivateKey", () => {
     const privateKey3 = new Ed25519PrivateKey(hexUint8Array, false);
     expect(privateKey3).toBeInstanceOf(Ed25519PrivateKey);
     expect(privateKey3.toHexString()).toEqual(Hex.fromHexInput(hexUint8Array).toString());
+  });
+
+  it("should print in AIP-80 format", () => {
+    const privateKey = new Ed25519PrivateKey(ed25519.privateKeyHex, false);
+    expect(privateKey.toString()).toEqual(ed25519.privateKey);
   });
 
   it("should throw an error with invalid hex input length", () => {
@@ -165,7 +170,7 @@ describe("PrivateKey", () => {
     const deserializer = new Deserializer(serializedPrivateKey);
     const privateKey = Ed25519PrivateKey.deserialize(deserializer);
 
-    expect(privateKey.toAIP80String()).toEqual(ed25519.privateKey);
+    expect(privateKey.toString()).toEqual(ed25519.privateKey);
   });
 
   it("should serialize and deserialize correctly", () => {
@@ -207,7 +212,7 @@ describe("PrivateKey", () => {
     const { mnemonic, path, privateKey } = wallet;
     const key = Ed25519PrivateKey.fromDerivationPath(path, mnemonic);
     expect(key).toBeInstanceOf(Ed25519PrivateKey);
-    expect(privateKey).toEqual(key.toAIP80String());
+    expect(privateKey).toEqual(key.toString());
   });
 });
 

--- a/tests/unit/secp256k1.test.ts
+++ b/tests/unit/secp256k1.test.ts
@@ -105,13 +105,13 @@ describe("Secp256k1PrivateKey", () => {
   it("should create the instance correctly without error with AIP-80 compliant private key", () => {
     const privateKey2 = new Secp256k1PrivateKey(secp256k1TestObject.privateKey, false);
     expect(privateKey2).toBeInstanceOf(Secp256k1PrivateKey);
-    expect(privateKey2.toAIP80String()).toEqual(secp256k1TestObject.privateKey);
+    expect(privateKey2.toString()).toEqual(secp256k1TestObject.privateKey);
   });
 
   it("should create the instance correctly without error with non-AIP-80 compliant private key", () => {
     const privateKey = new Secp256k1PrivateKey(secp256k1TestObject.privateKeyHex, false);
     expect(privateKey).toBeInstanceOf(Secp256k1PrivateKey);
-    expect(privateKey.toAIP80String()).toEqual(secp256k1TestObject.privateKey);
+    expect(privateKey.toString()).toEqual(secp256k1TestObject.privateKey);
   });
 
   it("should create the instance correctly without error with Uint8Array private key", () => {
@@ -124,6 +124,11 @@ describe("Secp256k1PrivateKey", () => {
     const privateKey3 = new Secp256k1PrivateKey(hexUint8Array, false);
     expect(privateKey3).toBeInstanceOf(Secp256k1PrivateKey);
     expect(privateKey3.toHexString()).toEqual(Hex.fromHexInput(hexUint8Array).toString());
+  });
+
+  it("should print in AIP-80 format", () => {
+    const privateKey = new Secp256k1PrivateKey(secp256k1TestObject.privateKeyHex, false);
+    expect(privateKey.toString()).toEqual(secp256k1TestObject.privateKey);
   });
 
   it("should throw an error with invalid hex input length", () => {
@@ -155,7 +160,7 @@ describe("Secp256k1PrivateKey", () => {
     const deserializer = new Deserializer(serializedPrivateKey);
     const privateKey = Secp256k1PrivateKey.deserialize(deserializer);
 
-    expect(privateKey.toAIP80String()).toEqual(secp256k1TestObject.privateKey);
+    expect(privateKey.toString()).toEqual(secp256k1TestObject.privateKey);
   });
 
   it("should serialize and deserialize correctly", () => {
@@ -179,7 +184,7 @@ describe("Secp256k1PrivateKey", () => {
     const { mnemonic, path, privateKey } = secp256k1WalletTestObject;
     const key = Secp256k1PrivateKey.fromDerivationPath(path, mnemonic);
     expect(key).toBeInstanceOf(Secp256k1PrivateKey);
-    expect(key.toAIP80String()).toEqual(privateKey);
+    expect(key.toString()).toEqual(privateKey);
   });
 });
 


### PR DESCRIPTION
### Description
**This should not be released until the next major version is released.**

Added default `toString` formatting to use AIP-80 for `Ed25519PrivateKey` and `Secp256k1PrivateKey`

### Test Plan
- [x] Added tests to Ed25519 and Secp256k1 unit tests

### Related Links
https://github.com/aptos-labs/aptos-ts-sdk/pull/550

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  