### PR TITLE
[account] Fix derive account from private key on chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 ## Unreleased
 
 - Define the return type for `toUint8Array()` in the `SingleKey.ts` file to not break `tsc` build
+- Fix `deriveAccountFromPrivateKey` to use the "legacy" derivation path for Ed25519 keys first.
+- Deprecate `deriveAccountFromPrivateKey` as more inspection is needed from the user to determine the correct address.
 
 # 1.38.0 (2025-04-02)
 

--- a/src/api/account.ts
+++ b/src/api/account.ts
@@ -975,6 +975,7 @@ export class Account {
    * runExample().catch(console.error);
    * ```
    * @group Account
+   * @deprecated Note that more inspection is needed by the user to determine which account exists on-chain
    */
   async deriveAccountFromPrivateKey(args: { privateKey: PrivateKey }): Promise<AccountModule> {
     return deriveAccountFromPrivateKey({ aptosConfig: this.config, ...args });

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -386,7 +386,8 @@ describe("account api", () => {
         await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100 });
 
         const derivedAccount = await aptos.deriveAccountFromPrivateKey({ privateKey: account.privateKey });
-        expect(derivedAccount).toStrictEqual(account);
+        // Note, this will now always return the legacy account
+        expect(derivedAccount.accountAddress.equals(account.accountAddress)).toEqual(false);
       });
       test("single sender secp256k1", async () => {
         const config = new AptosConfig({ network: Network.LOCAL });


### PR DESCRIPTION
### Description
Note that most wallets supported the legacy key, so we are putting that as the default.  But, this needs to be deprecated as it is no longer useful when all accounts are listed as "created"

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  