### PR TITLE
[confidential-assets] Use provided module address truly everywhere

### DIFF
--- a/confidential-assets/package.json
+++ b/confidential-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aptos-labs/confidential-assets",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "author": "",
   "license": "ISC",
   "description": "",


### PR DESCRIPTION
### Description
The module address provided in the constructor wasn't being passed through properly. To prevent issues like this in the future, the static methods now take the module address as a required argument. This way the dev knows for sure that they're passing in the default if they want.

### Test Plan
Tested manually as part of https://github.com/aptos-labs/confidential-payments-example.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  