### PR TITLE
[client] Add warning if setting a custom network without a chain id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Unreleased
 - Remove `scriptComposer` api due to increase in the sdk bundle size, If you wish to continue using it, please use version 1.39.0: [https://www.npmjs.com/package/@aptos-labs/ts-sdk/v/1.39.0](https://www.npmjs.com/package/@aptos-labs/ts-sdk/v/1.39.0)
-
 - [`Breaking`] Ed25519 and Secp256k1 private keys will now default to the AIP-80 format when calling `toString()`.
+- [`Breaking`] Custom networks now need to set the `network` field in the client config to the correct network type. This is needed to reduce network calls.
+- Add info message if using `CUSTOM` network
 
 # 1.39.0 (2025-04-02)
 

--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -134,6 +134,15 @@ export class AptosConfig {
    * @group Client
    */
   constructor(settings?: AptosSettings) {
+    // If there are any endpoint overrides, they are custom networks, keep that in mind
+    if (settings?.fullnode || settings?.indexer || settings?.faucet || settings?.pepper || settings?.prover) {
+      if (settings?.network === Network.CUSTOM) {
+        console.info("Note: using CUSTOM network will require queries to lookup ChainId");
+      } else if (!settings?.network) {
+        throw new Error("Custom endpoints require a network to be specified");
+      }
+    }
+
     this.network = settings?.network ?? Network.DEVNET;
     this.fullnode = settings?.fullnode;
     this.faucet = settings?.faucet;


### PR DESCRIPTION
### Description
Adds a warning if users don't set their network appropriately as it adds extra network calls.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  