### PR TITLE
Update aptos-client to v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+
 - Remove `scriptComposer` api due to increase in the sdk bundle size, If you wish to continue using it, please use version 1.39.0: [https://www.npmjs.com/package/@aptos-labs/ts-sdk/v/1.39.0](https://www.npmjs.com/package/@aptos-labs/ts-sdk/v/1.39.0)
 - [`Breaking`] Ed25519 and Secp256k1 private keys will now default to the AIP-80 format when calling `toString()`.
 - [`Breaking`] Custom networks now need to set the `network` field in the client config to the correct network type. This is needed to reduce network calls.
 - Add info message if using `CUSTOM` network
+- Update `@aptos-labs/aptos-client` to version `2.0.0`
 
 # 1.39.0 (2025-04-02)
 

--- a/examples/typescript/custom_client.ts
+++ b/examples/typescript/custom_client.ts
@@ -3,7 +3,7 @@
 /**
  * Example to demonstrate how one can config the SDK to use a custom client.
  *
- * The SDK by default supports axios client on web environment and go client on node environment
+ * The SDK by default supports fetch client on web environment and got client on node environment
  * with http2 support.
  *
  * Need to provide a function with the signature
@@ -18,37 +18,6 @@ const superagent = require("superagent");
 
 // Default to devnet, but allow for overriding
 const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
-
-export async function fetchCustomClient<Req, Res>(requestOptions: ClientRequest<Req>): Promise<ClientResponse<Res>> {
-  const { params, method, url, headers, body } = requestOptions;
-
-  const customHeaders: any = {
-    ...headers,
-    customClient: true,
-  };
-
-  const request = {
-    headers: customHeaders,
-    body: JSON.stringify(body),
-    method,
-  };
-
-  let path = url;
-  if (params) {
-    path = `${url}?${params}`;
-  }
-
-  const response = await fetch(path, request);
-  const data = await response.json();
-  return {
-    status: response.status,
-    statusText: response.statusText,
-    data,
-    headers: response.headers,
-    config: response,
-    request,
-  };
-}
 
 export async function superagentCustomClient<Req, Res>(
   requestOptions: ClientRequest<Req>,
@@ -95,22 +64,8 @@ const example = async () => {
     console.log(`${chainInfo}`);
   }
 
-  async function withFetchClient() {
-    const config = new AptosConfig({ network: APTOS_NETWORK, client: { provider: fetchCustomClient } });
-    const aptos = new Aptos(config);
-
-    console.log(`\nclient being used ${config.client.provider.name}`);
-
-    const chainInfo = await aptos.getLedgerInfo();
-    console.log(`${JSON.stringify(chainInfo)}`);
-
-    const latestVersion = await aptos.getIndexerLastSuccessVersion();
-    console.log(`Latest indexer version: ${latestVersion}`);
-  }
-
-  // Call the inner functions
+  // Call the inner function
   await withSuperagentClient();
-  await withFetchClient();
 };
 
 example();

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@aptos-labs/aptos-cli": "^1.0.2",
-    "@aptos-labs/aptos-client": "^1.2.0",
+    "@aptos-labs/aptos-client": "^2.0.0",
     "@noble/curves": "^1.6.0",
     "@noble/hashes": "^1.5.0",
     "@scure/bip32": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^1.0.2
     version: 1.0.2
   '@aptos-labs/aptos-client':
-    specifier: ^1.2.0
-    version: 1.2.0(axios@1.9.0)(got@11.8.6)
+    specifier: ^2.0.0
+    version: 2.0.0(got@11.8.6)
   '@noble/curves':
     specifier: ^1.6.0
     version: 1.9.0
@@ -157,14 +157,12 @@ packages:
       commander: 12.1.0
     dev: false
 
-  /@aptos-labs/aptos-client@1.2.0(axios@1.9.0)(got@11.8.6):
-    resolution: {integrity: sha512-pBlIAT/W+Qa0TOr/318U8r0Gxw/jfyRLcvDGMEXgcVrPqO9Qhwsmozw6LPPIZ963FB7smwIaMeexWFDs3zijcg==}
-    engines: {node: '>=15.10.0'}
+  /@aptos-labs/aptos-client@2.0.0(got@11.8.6):
+    resolution: {integrity: sha512-A23T3zTCRXEKURodp00dkadVtIrhWjC9uo08dRDBkh69OhCnBAxkENmUy/rcBarfLoFr60nRWt7cBkc8wxr1mg==}
+    engines: {node: '>=20.0.0'}
     peerDependencies:
-      axios: ^1.8.4
       got: ^11.8.6
     dependencies:
-      axios: 1.9.0
       got: 11.8.6
     dev: false
 
@@ -3475,16 +3473,6 @@ packages:
       possible-typed-array-names: 1.1.0
     dev: true
 
-  /axios@1.9.0:
-    resolution: {integrity: sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==}
-    dependencies:
-      follow-redirects: 1.15.9
-      form-data: 4.0.2
-      proxy-from-env: 1.1.0
-    transitivePeerDependencies:
-      - debug
-    dev: false
-
   /babel-jest@29.7.0(@babel/core@7.27.1):
     resolution: {integrity: sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4891,16 +4879,6 @@ packages:
   /flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
     dev: true
-
-  /follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-    dev: false
 
   /for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
@@ -7161,10 +7139,6 @@ packages:
   /property-expr@2.0.6:
     resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
     dev: true
-
-  /proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
-    dev: false
 
   /pump@3.0.2:
     resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}


### PR DESCRIPTION
### Description

This PR updates `@aptos-labs/aptos-client` to version `2.0.0` which removes the dependency on `axios` in favor of the native `fetch` in the browser.

### Test Plan

Ran tests locally
Tested locally in wallet adapter demo, Aptos Build, and Explorer

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  