### PR TITLE
Fix potential for unsafe access with amountEncrypted

### DIFF
--- a/confidential-assets/package.json
+++ b/confidential-assets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aptos-labs/confidential-assets",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "author": "",
   "license": "ISC",
   "description": "",

--- a/confidential-assets/src/confidentialAmount.ts
+++ b/confidential-assets/src/confidentialAmount.ts
@@ -20,7 +20,8 @@ export class ConfidentialAmount {
 
   chunkBits = CHUNK_BITS;
 
-  amountEncrypted?: TwistedElGamalCiphertext[];
+  /** We keep this just as an optimization. */
+  private amountEncrypted?: TwistedElGamalCiphertext[];
 
   static CHUNKS_COUNT = CHUNKS_COUNT;
 
@@ -154,11 +155,18 @@ export class ConfidentialAmount {
     });
   }
 
-  encrypt(publicKey: TwistedEd25519PublicKey, randomness?: bigint[]): TwistedElGamalCiphertext[] {
+  private encrypt(publicKey: TwistedEd25519PublicKey, randomness?: bigint[]): TwistedElGamalCiphertext[] {
     this.amountEncrypted = this.amountChunks.map((chunk, i) =>
       TwistedElGamal.encryptWithPK(chunk, publicKey, randomness?.[i]),
     );
 
     return this.amountEncrypted;
+  }
+
+  public getAmountEncrypted(publicKey: TwistedEd25519PublicKey, randomness?: bigint[]): TwistedElGamalCiphertext[] {
+    if (!this.amountEncrypted) {
+      this.encrypt(publicKey, randomness);
+    }
+    return this.amountEncrypted!;
   }
 }

--- a/confidential-assets/src/confidentialAsset.ts
+++ b/confidential-assets/src/confidentialAsset.ts
@@ -186,11 +186,6 @@ export class ConfidentialAsset {
     });
   }
 
-  /**
-   * If you wish to use the default for the module address, just set
-   * `confidentialAssetModuleAddress` to the default:
-   * `DEFAULT_CONFIDENTIAL_COIN_MODULE_ADDRESS`.
-   */
   static buildRolloverPendingBalanceTxPayload(
     args: {
       tokenAddress: string;


### PR DESCRIPTION
### Description
Right now user code needs to keep track of whether `amountEncrypted` is undefined or not. This field is ultimately intended to be a cache to prevent having to recompute the data, so let's protect it behind a function that will compute the value if needed on demand.

### Test Plan
todo

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  