### PR TITLE
Correctly use new getAmountEncrypted function

### DIFF
--- a/confidential-assets/src/confidentialAmount.ts
+++ b/confidential-assets/src/confidentialAmount.ts
@@ -110,7 +110,6 @@ export class ConfidentialAmount {
     },
   ): ConfidentialAmount {
     const amountChunks = ConfidentialAmount.amountToChunks(amount, opts?.chunksCount, opts?.chunkBits);
-
     return new ConfidentialAmount({ amount, amountChunks, ...opts });
   }
 
@@ -164,9 +163,9 @@ export class ConfidentialAmount {
   }
 
   public getAmountEncrypted(publicKey: TwistedEd25519PublicKey, randomness?: bigint[]): TwistedElGamalCiphertext[] {
-    if (!this.amountEncrypted) {
-      this.encrypt(publicKey, randomness);
+    if (this.amountEncrypted === undefined) {
+      return this.encrypt(publicKey, randomness);
     }
-    return this.amountEncrypted!;
+    return this.amountEncrypted;
   }
 }

--- a/confidential-assets/src/confidentialAsset.ts
+++ b/confidential-assets/src/confidentialAsset.ts
@@ -309,7 +309,7 @@ export class ConfidentialAsset {
     ] = await confidentialTransfer.authorizeTransfer();
 
     const newBalance = encryptedAmountAfterTransfer.map((el) => el.serialize()).flat();
-    const amountBySender = confidentialTransfer.confidentialAmountToTransfer.amountEncrypted!.map((el) => el.serialize()).flat();
+    const amountBySender = confidentialTransfer.confidentialAmountToTransfer.getAmountEncrypted(args.senderDecryptionKey.publicKey()).map((el) => el.serialize()).flat();
     const amountByRecipient = encryptedAmountByRecipient.map((el) => el.serialize()).flat();
     const auditorEks = confidentialTransfer.auditorsU8EncryptionKeys;
     const auditorBalances = auditorsCBList

--- a/confidential-assets/src/confidentialKeyRotation.ts
+++ b/confidential-assets/src/confidentialKeyRotation.ts
@@ -65,7 +65,6 @@ export class ConfidentialKeyRotation {
     const currentBalance = await ConfidentialAmount.fromEncrypted(args.currEncryptedBalance, args.currDecryptionKey);
 
     const newBalance = ConfidentialAmount.fromAmount(currentBalance.amount);
-    newBalance.encrypt(args.newDecryptionKey.publicKey(), randomness);
 
     return new ConfidentialKeyRotation({
       currDecryptionKey: args.currDecryptionKey,
@@ -192,7 +191,7 @@ export class ConfidentialKeyRotation {
       this.currDecryptionKey.publicKey().toUint8Array(),
       this.newDecryptionKey.publicKey().toUint8Array(),
       ...this.currEncryptedBalance.map((el) => el.serialize()).flat(),
-      ...this.newConfidentialAmount.amountEncrypted!.map((el) => el.serialize()).flat(),
+      ...this.newConfidentialAmount.getAmountEncrypted(this.newDecryptionKey.publicKey()).map((el) => el.serialize()).flat(),
       X1.toRawBytes(),
       X2.toRawBytes(),
       X3.toRawBytes(),
@@ -340,7 +339,7 @@ export class ConfidentialKeyRotation {
         sigmaProof,
         rangeProof,
       },
-      this.newConfidentialAmount.amountEncrypted!,
+      this.newConfidentialAmount.getAmountEncrypted(this.newDecryptionKey.publicKey()),
     ];
   }
 

--- a/confidential-assets/src/confidentialNormalization.ts
+++ b/confidential-assets/src/confidentialNormalization.ts
@@ -56,7 +56,6 @@ export class ConfidentialNormalization {
     const randomness = args.randomness ?? ed25519GenListOfRandom(ConfidentialAmount.CHUNKS_COUNT);
 
     const normalizedConfidentialAmount = ConfidentialAmount.fromAmount(args.balanceAmount);
-    normalizedConfidentialAmount.encrypt(args.decryptionKey.publicKey(), randomness);
 
     return new ConfidentialNormalization({
       decryptionKey: args.decryptionKey,
@@ -174,7 +173,7 @@ export class ConfidentialNormalization {
       H_RISTRETTO.toRawBytes(),
       this.decryptionKey.publicKey().toUint8Array(),
       ...this.unnormalizedEncryptedBalance.map((el) => el.serialize()).flat(),
-      ...this.normalizedConfidentialAmount.amountEncrypted!.map((el) => el.serialize()).flat(),
+      ...this.normalizedConfidentialAmount.getAmountEncrypted(this.decryptionKey.publicKey(), this.randomness).map((el) => el.serialize()).flat(),
       X1.toRawBytes(),
       X2.toRawBytes(),
       ...X3List.map((X3) => X3.toRawBytes()),
@@ -316,6 +315,6 @@ export class ConfidentialNormalization {
     const sigmaProof = await this.genSigmaProof();
     const rangeProof = await this.genRangeProof();
 
-    return [{ sigmaProof, rangeProof }, this.normalizedConfidentialAmount.amountEncrypted!];
+    return [{ sigmaProof, rangeProof }, this.normalizedConfidentialAmount.getAmountEncrypted(this.decryptionKey.publicKey(), this.randomness)];
   }
 }

--- a/confidential-assets/src/confidentialWithdraw.ts
+++ b/confidential-assets/src/confidentialWithdraw.ts
@@ -66,7 +66,6 @@ export class ConfidentialWithdraw {
     const confidentialAmountAfterWithdraw = ConfidentialAmount.fromAmount(
       actualBalance.amount - confidentialAmountToWithdraw.amount,
     );
-    confidentialAmountAfterWithdraw.encrypt(args.decryptionKey.publicKey(), randomness);
 
     return new ConfidentialWithdraw({
       decryptionKey: args.decryptionKey,
@@ -310,7 +309,7 @@ export class ConfidentialWithdraw {
     const sigmaProof = await this.genSigmaProof();
     const rangeProof = await this.genRangeProof();
 
-    return [{ sigmaProof, rangeProof }, this.confidentialAmountAfterWithdraw.amountEncrypted!];
+    return [{ sigmaProof, rangeProof }, this.confidentialAmountAfterWithdraw.getAmountEncrypted(this.decryptionKey.publicKey(), this.randomness)];
   }
 
   static async verifyRangeProof(opts: {

--- a/confidential-assets/tests/e2e/confidentialCoin.test.ts
+++ b/confidential-assets/tests/e2e/confidentialCoin.test.ts
@@ -193,7 +193,7 @@ describe("Confidential balance api", () => {
         sender: alice.accountAddress,
         tokenAddress: TOKEN_ADDRESS,
         decryptionKey: aliceConfidential,
-        encryptedActualBalance: aliceConfidentialAmount.amountEncrypted!,
+        encryptedActualBalance: aliceConfidentialAmount.getAmountEncrypted(aliceConfidential.publicKey()),
         amountToWithdraw: WITHDRAW_AMOUNT,
       });
       const txResp = await sendAndWaitTx(withdrawTx, alice);

--- a/confidential-assets/tests/units/api/checkBalances.test.ts
+++ b/confidential-assets/tests/units/api/checkBalances.test.ts
@@ -14,15 +14,16 @@ describe("Check balance", () => {
   );
   it("should check balance", async () => {
     const balances = await getBalances(aliceConfidential, alice.accountAddress);
+    const alicePublicKey = aliceConfidential.publicKey();
 
     console.log({
       pending: {
-        encrypted: balances.pending.amountEncrypted?.map((el) => el.serialize()),
+        encrypted: balances.pending.getAmountEncrypted(alicePublicKey).map((el) => el.serialize()),
         amount: balances.pending.amount.toString(),
         amountChunks: balances.pending.amountChunks.map((chunk) => chunk.toString()),
       },
       actual: {
-        encrypted: balances.actual.amountEncrypted?.map((el) => el.serialize()),
+        encrypted: balances.actual.getAmountEncrypted(alicePublicKey).map((el) => el.serialize()),
         amount: balances.actual.amount.toString(),
         amountChunks: balances.actual.amountChunks.map((chunk) => chunk.toString()),
       },

--- a/confidential-assets/tests/units/api/negativeNormalize.test.ts
+++ b/confidential-assets/tests/units/api/negativeNormalize.test.ts
@@ -88,7 +88,6 @@ describe("Transfer", () => {
     console.log({ balances })
 
     const fakeBalance = ConfidentialAmount.fromAmount(normalizeAmount)
-    fakeBalance.encrypt(aliceConfidential.publicKey());
 
     const recipientEncKey = await confidentialAsset.getEncryptionByAddr({
       accountAddress: AccountAddress.from(recipientAccAddr),
@@ -100,7 +99,7 @@ describe("Transfer", () => {
     const normalizeTx = await confidentialAsset.normalizeUserBalance({
       tokenAddress,
       decryptionKey: aliceConfidential,
-      unnormalizedEncryptedBalance: fakeBalance.amountEncrypted!,
+      unnormalizedEncryptedBalance: fakeBalance.getAmountEncrypted(aliceConfidential.publicKey()),
       balanceAmount: fakeBalance.amount,
 
       sender: alice.accountAddress,

--- a/confidential-assets/tests/units/api/negativeTransfer.test.ts
+++ b/confidential-assets/tests/units/api/negativeTransfer.test.ts
@@ -80,7 +80,7 @@ describe("Transfer", () => {
     const transferTx = await confidentialAsset.transferCoin({
       senderDecryptionKey: aliceConfidential,
       recipientEncryptionKey: new TwistedEd25519PublicKey(recipientEncKey),
-      encryptedActualBalance: balances.actual.amountEncrypted!,
+      encryptedActualBalance: balances.actual.getAmountEncrypted(aliceConfidential.publicKey()),
       amountToTransfer: transferAmount,
       sender: alice.accountAddress,
       tokenAddress,

--- a/confidential-assets/tests/units/api/negativeWithdraw.test.ts
+++ b/confidential-assets/tests/units/api/negativeWithdraw.test.ts
@@ -82,7 +82,7 @@ describe("Negative withdraw", () => {
       sender: alice.accountAddress,
       tokenAddress,
       decryptionKey: aliceConfidential,
-      encryptedActualBalance: balances.actual.amountEncrypted!,
+      encryptedActualBalance: balances.actual.getAmountEncrypted(aliceConfidential.publicKey()),
       amountToWithdraw: withdrawAmount,
     });
 

--- a/confidential-assets/tests/units/api/normalize.test.ts
+++ b/confidential-assets/tests/units/api/normalize.test.ts
@@ -29,7 +29,7 @@ describe("Normalize", () => {
       const normalizeTx = await confidentialAsset.normalizeUserBalance({
         tokenAddress: TOKEN_ADDRESS,
         decryptionKey: aliceConfidential,
-        unnormalizedEncryptedBalance: balances.actual.amountEncrypted!,
+        unnormalizedEncryptedBalance: balances.actual.getAmountEncrypted(aliceConfidential.publicKey()),
         balanceAmount: balances.actual.amount,
 
         sender: alice.accountAddress,

--- a/confidential-assets/tests/units/api/safelyRotateKey.test.ts
+++ b/confidential-assets/tests/units/api/safelyRotateKey.test.ts
@@ -33,7 +33,7 @@ describe("Safely rotate Alice's confidential balance key", () => {
       currDecryptionKey: aliceConfidential,
       newDecryptionKey: ALICE_NEW_CONFIDENTIAL_PRIVATE_KEY,
 
-      currEncryptedBalance: balances.actual.amountEncrypted!,
+      currEncryptedBalance: balances.actual.getAmountEncrypted(aliceConfidential.publicKey()),
 
       withUnfreezeBalance: true,
       tokenAddress: TOKEN_ADDRESS,

--- a/confidential-assets/tests/units/api/transfer.test.ts
+++ b/confidential-assets/tests/units/api/transfer.test.ts
@@ -37,7 +37,7 @@ describe("Transfer", () => {
     const transferTx = await confidentialAsset.transferCoin({
       senderDecryptionKey: aliceConfidential,
       recipientEncryptionKey: new TwistedEd25519PublicKey(recipientEncKey),
-      encryptedActualBalance: balances.actual.amountEncrypted!,
+      encryptedActualBalance: balances.actual.getAmountEncrypted(aliceConfidential.publicKey()),
       amountToTransfer: TRANSFER_AMOUNT,
       sender: alice.accountAddress,
       tokenAddress: TOKEN_ADDRESS,

--- a/confidential-assets/tests/units/api/transferWithAuditor.test.ts
+++ b/confidential-assets/tests/units/api/transferWithAuditor.test.ts
@@ -30,7 +30,7 @@ describe("Transfer with auditor", () => {
     const transferTx = await confidentialAsset.transferCoin({
       senderDecryptionKey: aliceConfidential,
       recipientEncryptionKey: aliceConfidential.publicKey(),
-      encryptedActualBalance: balances.actual.amountEncrypted!,
+      encryptedActualBalance: balances.actual.getAmountEncrypted(aliceConfidential.publicKey()),
       amountToTransfer: TRANSFER_AMOUNT,
       sender: alice.accountAddress,
       tokenAddress: TOKEN_ADDRESS,

--- a/confidential-assets/tests/units/api/withdraw.test.ts
+++ b/confidential-assets/tests/units/api/withdraw.test.ts
@@ -29,7 +29,7 @@ describe("Withdraw", () => {
       sender: alice.accountAddress,
       tokenAddress: TOKEN_ADDRESS,
       decryptionKey: aliceConfidential,
-      encryptedActualBalance: balances.actual.amountEncrypted!,
+      encryptedActualBalance: balances.actual.getAmountEncrypted(aliceConfidential.publicKey()),
       amountToWithdraw: WITHDRAW_AMOUNT,
     });
     const txResp = await sendAndWaitTx(withdrawTx, alice);

--- a/confidential-assets/tests/units/kangaroo-decryption.test.ts
+++ b/confidential-assets/tests/units/kangaroo-decryption.test.ts
@@ -62,10 +62,9 @@ const executionBalance = async (
     const newAlice = TwistedEd25519PrivateKey.generate();
 
     const confidentialAmount = ConfidentialAmount.fromAmount(balance);
-    confidentialAmount.encrypt(newAlice.publicKey());
 
     const startMainTime = performance.now();
-    const decryptedBalance = await ConfidentialAmount.fromEncrypted(confidentialAmount.amountEncrypted!, newAlice);
+    const decryptedBalance = await ConfidentialAmount.fromEncrypted(confidentialAmount.getAmountEncrypted(newAlice.publicKey()), newAlice);
     const endMainTime = performance.now();
 
     const elapsedMainTime = endMainTime - startMainTime;


### PR DESCRIPTION
### Description
The previous PR (https://github.com/aptos-labs/aptos-ts-sdk/pull/706) was incomplete, this PR updates the rest of the code to use the new function. There is no need for external callers to call `encrypt` manually anymore, we do it internally when needed.

### Test Plan
See that `pnpm build` passes now.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  