### PR TITLE
[txns] Add support for orderless transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Make the default max gas amount and exipry time from now values for transaction generation configurable.
 - Adds restriction on construction of a `MultiKey`s with more than 3 Keyless public keys when signature threshold is more than 3 as well. The limit on the number of keyless signatures is 3 so to prevent sending funds to accounts that are not accessible we add this safeguard.
 - Adds support for `TurboTransactions` which allow for submitting transactions with a nonce rather than a sequence number.
+- [`Breaking`] Change possible inputs to the `GenerateTransactionOptions` to include turbo
 
 # 2.0.1 (2025-05-21)
 - Adds `deserializePublicKey` and `deserializeSignature` which takes in `HexInput` and will try all possible ways to deserialize so callers no longer need to derive a proper type before deserializing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Make the default max gas amount and exipry time from now values for transaction generation configurable.
 - Adds restriction on construction of a `MultiKey`s with more than 3 Keyless public keys when signature threshold is more than 3 as well. The limit on the number of keyless signatures is 3 so to prevent sending funds to accounts that are not accessible we add this safeguard.
 - Adds support for `TurboTransactions` which allow for submitting transactions with a nonce rather than a sequence number.
-- [`Breaking`] Change possible inputs to the `GenerateTransactionOptions` to include turbo
+- [`Breaking`] Change possible inputs to the `GenerateTransactionOptions` to include orderless
 
 # 2.0.1 (2025-05-21)
 - Adds `deserializePublicKey` and `deserializeSignature` which takes in `HexInput` and will try all possible ways to deserialize so callers no longer need to derive a proper type before deserializing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - Make the default max gas amount and exipry time from now values for transaction generation configurable.
 - Adds restriction on construction of a `MultiKey`s with more than 3 Keyless public keys when signature threshold is more than 3 as well. The limit on the number of keyless signatures is 3 so to prevent sending funds to accounts that are not accessible we add this safeguard.
+- Adds support for `TurboTransactions` which allow for submitting transactions with a nonce rather than a sequence number.
 
 # 2.0.1 (2025-05-21)
 - Adds `deserializePublicKey` and `deserializeSignature` which takes in `HexInput` and will try all possible ways to deserialize so callers no longer need to derive a proper type before deserializing.

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build": "tsc",
     "simple_transfer": "ts-node simple_transfer.ts",
+    "simple_turbo_transfer": "ts-node simple_turbo_transfer.ts",
     "multi_agent_transfer": "ts-node multi_agent_transfer.ts",
     "simple_sponsored_transaction": "ts-node simple_sponsored_transaction.ts",
     "transfer_coin": "ts-node transfer_coin.ts",
@@ -30,19 +31,19 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@noble/curves": "1.8.1",
+    "@noble/curves": "1.9.1",
     "@types/readline-sync": "1.4.8",
-    "dotenv": "16.4.7",
+    "dotenv": "16.5.0",
     "npm-run-all": "4.1.5",
     "readline-sync": "1.4.10",
-    "superagent": "10.2.0"
+    "superagent": "10.2.1"
   },
   "peerDependencies": {
     "@aptos-labs/ts-sdk": "link:../.."
   },
   "devDependencies": {
-    "@types/node": "^22.13.11",
+    "@types/node": "^22.15.29",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.2"
+    "typescript": "^5.8.3"
   }
 }

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "tsc",
     "simple_transfer": "ts-node simple_transfer.ts",
-    "simple_turbo_transfer": "ts-node simple_turbo_transfer.ts",
+    "simple_orderless_transfer": "ts-node simple_orderless_transfer.ts",
     "multi_agent_transfer": "ts-node multi_agent_transfer.ts",
     "simple_sponsored_transaction": "ts-node simple_sponsored_transaction.ts",
     "transfer_coin": "ts-node transfer_coin.ts",

--- a/examples/typescript/pnpm-lock.yaml
+++ b/examples/typescript/pnpm-lock.yaml
@@ -9,14 +9,14 @@ dependencies:
     specifier: link:../..
     version: link:../..
   '@noble/curves':
-    specifier: 1.8.1
-    version: 1.8.1
+    specifier: 1.9.1
+    version: 1.9.1
   '@types/readline-sync':
     specifier: 1.4.8
     version: 1.4.8
   dotenv:
-    specifier: 16.4.7
-    version: 16.4.7
+    specifier: 16.5.0
+    version: 16.5.0
   npm-run-all:
     specifier: 4.1.5
     version: 4.1.5
@@ -24,19 +24,19 @@ dependencies:
     specifier: 1.4.10
     version: 1.4.10
   superagent:
-    specifier: 10.2.0
-    version: 10.2.0
+    specifier: 10.2.1
+    version: 10.2.1
 
 devDependencies:
   '@types/node':
-    specifier: ^22.13.11
-    version: 22.13.11
+    specifier: ^22.15.29
+    version: 22.15.29
   ts-node:
     specifier: ^10.9.2
-    version: 10.9.2(@types/node@22.13.11)(typescript@5.8.2)
+    version: 10.9.2(@types/node@22.15.29)(typescript@5.8.3)
   typescript:
-    specifier: ^5.8.2
-    version: 5.8.2
+    specifier: ^5.8.3
+    version: 5.8.3
 
 packages:
 
@@ -63,16 +63,27 @@ packages:
       '@jridgewell/sourcemap-codec': 1.4.15
     dev: true
 
-  /@noble/curves@1.8.1:
-    resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
+  /@noble/curves@1.9.1:
+    resolution: {integrity: sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==}
     engines: {node: ^14.21.3 || >=16}
     dependencies:
-      '@noble/hashes': 1.7.1
+      '@noble/hashes': 1.8.0
     dev: false
 
   /@noble/hashes@1.7.1:
     resolution: {integrity: sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==}
     engines: {node: ^14.21.3 || >=16}
+    dev: false
+
+  /@noble/hashes@1.8.0:
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
+    engines: {node: ^14.21.3 || >=16}
+    dev: false
+
+  /@paralleldrive/cuid2@2.2.2:
+    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
+    dependencies:
+      '@noble/hashes': 1.7.1
     dev: false
 
   /@tsconfig/node10@1.0.9:
@@ -91,10 +102,10 @@ packages:
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
     dev: true
 
-  /@types/node@22.13.11:
-    resolution: {integrity: sha512-iEUCUJoU0i3VnrCmgoWCXttklWcvoCIx4jzcP22fioIVSdTmjgoEvmAO/QPw6TcS9k5FrNgn4w7q5lGOd1CT5g==}
+  /@types/node@22.15.29:
+    resolution: {integrity: sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==}
     dependencies:
-      undici-types: 6.20.0
+      undici-types: 6.21.0
     dev: true
 
   /@types/readline-sync@1.4.8:
@@ -275,8 +286,8 @@ packages:
     engines: {node: '>=0.3.1'}
     dev: true
 
-  /dotenv@16.4.7:
-    resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+  /dotenv@16.5.0:
+    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
     engines: {node: '>=12'}
     dev: false
 
@@ -373,11 +384,12 @@ packages:
       mime-types: 2.1.35
     dev: false
 
-  /formidable@3.5.2:
-    resolution: {integrity: sha512-Jqc1btCy3QzRbJaICGwKcBfGWuLADRerLzDqi2NwSt/UkXLsHJw2TVResiaoBufHVHy9aSgClOHCeJsSsFLTbg==}
+  /formidable@3.5.4:
+    resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
+    engines: {node: '>=14.0.0'}
     dependencies:
+      '@paralleldrive/cuid2': 2.2.2
       dezalgo: 1.0.4
-      hexoid: 2.0.0
       once: 1.4.0
     dev: false
 
@@ -484,11 +496,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: false
-
-  /hexoid@2.0.0:
-    resolution: {integrity: sha512-qlspKUK7IlSQv2o+5I7yhUd7TxlOG2Vr5LTa3ve2XSNVKAL/n/u/7KLvKmFNimomDIKvZFXWHv0T12mv7rT8Aw==}
-    engines: {node: '>=8'}
     dev: false
 
   /hosted-git-info@2.8.9:
@@ -920,8 +927,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /superagent@10.2.0:
-    resolution: {integrity: sha512-IKeoGox6oG9zyDeizaezkJ2/aK0wc5la9st7WsAKyrAkfJ56W3whVbVtF68k6wuc87/y9T85NyON5FLz7Mrzzw==}
+  /superagent@10.2.1:
+    resolution: {integrity: sha512-O+PCv11lgTNJUzy49teNAWLjBZfc+A1enOwTpLlH6/rsvKcTwcdTT8m9azGkVqM7HBl5jpyZ7KTPhHweokBcdg==}
     engines: {node: '>=14.18.0'}
     dependencies:
       component-emitter: 1.3.0
@@ -929,7 +936,7 @@ packages:
       debug: 4.3.4
       fast-safe-stringify: 2.1.1
       form-data: 4.0.0
-      formidable: 3.5.2
+      formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
       qs: 6.11.2
@@ -949,7 +956,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /ts-node@10.9.2(@types/node@22.13.11)(typescript@5.8.2):
+  /ts-node@10.9.2(@types/node@22.15.29)(typescript@5.8.3):
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
     peerDependencies:
@@ -968,14 +975,14 @@ packages:
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 22.13.11
+      '@types/node': 22.15.29
       acorn: 8.10.0
       acorn-walk: 8.2.0
       arg: 4.1.3
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.2
+      typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     dev: true
@@ -1018,8 +1025,8 @@ packages:
       is-typed-array: 1.1.12
     dev: false
 
-  /typescript@5.8.2:
-    resolution: {integrity: sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==}
+  /typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
     dev: true
@@ -1033,8 +1040,8 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: false
 
-  /undici-types@6.20.0:
-    resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
+  /undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
     dev: true
 
   /v8-compile-cache-lib@3.0.1:

--- a/examples/typescript/simple_turbo_transfer.ts
+++ b/examples/typescript/simple_turbo_transfer.ts
@@ -93,7 +93,7 @@ const example = async () => {
       functionArguments: [bob.accountAddress, TRANSFER_AMOUNT],
     },
     options: {
-      replayNonce: 12345,
+      replayProtectionNonce: 12345,
     },
   });
 

--- a/examples/typescript/simple_turbo_transfer.ts
+++ b/examples/typescript/simple_turbo_transfer.ts
@@ -1,0 +1,119 @@
+/* eslint-disable no-console */
+
+/**
+ * This example shows how to use the Aptos client to create accounts, fund them, and transfer between them.
+ */
+
+import {
+  Account,
+  AccountAddress,
+  Aptos,
+  AptosConfig,
+  InputViewFunctionJsonData,
+  Network,
+  NetworkToNetworkName,
+} from "@aptos-labs/ts-sdk";
+import dotenv from "dotenv";
+dotenv.config();
+
+const APTOS_COIN = "0x1::aptos_coin::AptosCoin";
+const ALICE_INITIAL_BALANCE = 100_000_000;
+const BOB_INITIAL_BALANCE = 100;
+const TRANSFER_AMOUNT = 100;
+
+// Default to devnet, but allow for overriding
+const APTOS_NETWORK: Network = NetworkToNetworkName[process.env.APTOS_NETWORK ?? Network.DEVNET];
+
+/**
+ * Prints the balance of an account
+ * @param aptos
+ * @param name
+ * @param address
+ * @returns {Promise<*>}
+ *
+ */
+const balance = async (aptos: Aptos, name: string, address: AccountAddress): Promise<any> => {
+  const payload: InputViewFunctionJsonData = {
+    function: "0x1::coin::balance",
+    typeArguments: ["0x1::aptos_coin::AptosCoin"],
+    functionArguments: [address.toString()],
+  };
+  const [balance] = await aptos.viewJson<[number]>({ payload: payload });
+
+  console.log(`${name}'s balance is: ${balance}`);
+  return Number(balance);
+};
+
+const example = async () => {
+  console.log("This example will create two accounts (Alice and Bob), fund them, and transfer between them.");
+
+  // Set up the client
+  const config = new AptosConfig({ network: APTOS_NETWORK });
+  const aptos = new Aptos(config);
+
+  // Create two accounts
+  const alice = Account.generate();
+  const bob = Account.generate();
+
+  console.log("=== Addresses ===\n");
+  console.log(`Alice's address is: ${alice.accountAddress}`);
+  console.log(`Bob's address is: ${bob.accountAddress}`);
+
+  // Fund the accounts
+  console.log("\n=== Funding accounts ===\n");
+
+  const aliceFundTxn = await aptos.fundAccount({
+    accountAddress: alice.accountAddress,
+    amount: ALICE_INITIAL_BALANCE,
+  });
+  console.log("Alice's fund transaction: ", aliceFundTxn);
+
+  const bobFundTxn = await aptos.fundAccount({
+    accountAddress: bob.accountAddress,
+    amount: BOB_INITIAL_BALANCE,
+  });
+  console.log("Bob's fund transaction: ", bobFundTxn);
+
+  // Show the balances
+  console.log("\n=== Balances ===\n");
+  const aliceBalance = await balance(aptos, "Alice", alice.accountAddress);
+  const bobBalance = await balance(aptos, "Bob", bob.accountAddress);
+
+  console.log("aliceBalance", aliceBalance);
+  console.log("ALICE_INITIAL_BALANCE", ALICE_INITIAL_BALANCE);
+  if (aliceBalance !== ALICE_INITIAL_BALANCE) throw new Error("Alice's balance is incorrect");
+  if (bobBalance !== BOB_INITIAL_BALANCE) throw new Error("Bob's balance is incorrect");
+
+  // Transfer between users
+  const txn = await aptos.transaction.build.simple({
+    sender: alice.accountAddress,
+    data: {
+      function: "0x1::coin::transfer",
+      typeArguments: [APTOS_COIN],
+      functionArguments: [bob.accountAddress, TRANSFER_AMOUNT],
+    },
+    options: {
+      replayNonce: 12345,
+    },
+  });
+
+  console.log("\n=== Transfer transaction ===\n");
+  const committedTxn = await aptos.signAndSubmitTransaction({ signer: alice, transaction: txn });
+
+  await aptos.waitForTransaction({ transactionHash: committedTxn.hash });
+  console.log(`Committed transaction: ${committedTxn.hash}`);
+
+  console.log("\n=== Balances after transfer ===\n");
+  const newAliceBalance = await balance(aptos, "Alice", alice.accountAddress);
+  const newBobBalance = await balance(aptos, "Bob", bob.accountAddress);
+
+  // Bob should have the transfer amount
+  if (newBobBalance !== TRANSFER_AMOUNT + BOB_INITIAL_BALANCE)
+    throw new Error("Bob's balance after transfer is incorrect");
+
+  // Alice should have the remainder minus gas
+  if (newAliceBalance >= ALICE_INITIAL_BALANCE - TRANSFER_AMOUNT)
+    throw new Error("Alice's balance after transfer is incorrect");
+};
+
+example();

--- a/src/api/transactionSubmission/build.ts
+++ b/src/api/transactionSubmission/build.ts
@@ -6,7 +6,7 @@ import { generateTransaction } from "../../internal/transactionSubmission";
 import {
   InputGenerateTransactionPayloadData,
   InputGenerateTransactionOptions,
-  InputGenerateOrderlessTransactionOptions,
+  InputGenerateTurboTransactionOptions,
 } from "../../transactions";
 import { MultiAgentTransaction } from "../../transactions/instances/multiAgentTransaction";
 import { SimpleTransaction } from "../../transactions/instances/simpleTransaction";

--- a/src/api/transactionSubmission/build.ts
+++ b/src/api/transactionSubmission/build.ts
@@ -6,7 +6,7 @@ import { generateTransaction } from "../../internal/transactionSubmission";
 import {
   InputGenerateTransactionPayloadData,
   InputGenerateTransactionOptions,
-  InputGenerateTurboTransactionOptions,
+  InputGenerateOrderlessTransactionOptions,
 } from "../../transactions";
 import { MultiAgentTransaction } from "../../transactions/instances/multiAgentTransaction";
 import { SimpleTransaction } from "../../transactions/instances/simpleTransaction";

--- a/src/api/transactionSubmission/build.ts
+++ b/src/api/transactionSubmission/build.ts
@@ -3,7 +3,11 @@
 
 import { AccountAddressInput } from "../../core";
 import { generateTransaction } from "../../internal/transactionSubmission";
-import { InputGenerateTransactionPayloadData, InputGenerateTransactionOptions } from "../../transactions";
+import {
+  InputGenerateTransactionPayloadData,
+  InputGenerateTransactionOptions,
+  InputGenerateOrderlessTransactionOptions,
+} from "../../transactions";
 import { MultiAgentTransaction } from "../../transactions/instances/multiAgentTransaction";
 import { SimpleTransaction } from "../../transactions/instances/simpleTransaction";
 import { AptosConfig } from "../aptosConfig";

--- a/src/transactions/instances/transactionPayload.ts
+++ b/src/transactions/instances/transactionPayload.ts
@@ -525,7 +525,7 @@ export class MultiSigTransactionPayload extends Serializable {
 /**
  * Represents any transaction payload that can be submitted to the Aptos chain for execution.
  *
- * This is specifically required for turbo transactions, but can be used for any transaction payload.
+ * This is specifically required for orderless transactions, but can be used for any transaction payload.
  */
 export abstract class TransactionInnerPayload extends TransactionPayload {
   abstract serialize(serializer: Serializer): void;

--- a/src/transactions/instances/transactionPayload.ts
+++ b/src/transactions/instances/transactionPayload.ts
@@ -638,7 +638,7 @@ export class TransactionExecutableEmpty extends TransactionExecutable {
 export abstract class TransactionExtraConfig {
   abstract serialize(serializer: Serializer): void;
 
-  static deserialize(deserializer: Deserializer): TransactionExecutable {
+  static deserialize(deserializer: Deserializer): TransactionExtraConfig {
     // index enum variant
     const index = deserializer.deserializeUleb128AsU32();
     switch (index) {

--- a/src/transactions/management/transactionWorker.ts
+++ b/src/transactions/management/transactionWorker.ts
@@ -340,7 +340,7 @@ export class TransactionWorker extends EventEmitter<TransactionWorkerEvents> {
       aptosConfig: this.aptosConfig,
       sender: account.accountAddress,
       data: transactionData,
-      options: { ...options, accountSequenceNumber: sequenceNumber },
+      options: { ...options, accountSequenceNumber: sequenceNumber, replayNonce: undefined },
     });
   }
 

--- a/src/transactions/management/transactionWorker.ts
+++ b/src/transactions/management/transactionWorker.ts
@@ -340,7 +340,7 @@ export class TransactionWorker extends EventEmitter<TransactionWorkerEvents> {
       aptosConfig: this.aptosConfig,
       sender: account.accountAddress,
       data: transactionData,
-      options: { ...options, accountSequenceNumber: sequenceNumber, replayNonce: undefined },
+      options: { ...options, accountSequenceNumber: sequenceNumber, replayProtectionNonce: undefined },
     });
   }
 

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -21,6 +21,7 @@ import { AccountAuthenticator } from "./authenticator/account";
 import { SimpleTransaction } from "./instances/simpleTransaction";
 import { MultiAgentTransaction } from "./instances/multiAgentTransaction";
 import { Serialized } from "../bcs";
+import { TransactionPayloadPayload } from "./instances/transactionPayload";
 
 /**
  * Entry function arguments for building a raw transaction using remote ABI, supporting various data types including primitives and arrays.
@@ -113,11 +114,22 @@ export type AnyRawTransactionInstance = RawTransaction | MultiAgentRawTransactio
  * @group Implementation
  * @category Transactions
  */
-export type InputGenerateTransactionOptions = {
+export type InputGenerateTransactionOptions =
+  | InputGenerateSequenceNumberTransactionOptions
+  | InputGenerateOrderlessTransactionOptions;
+
+export type InputGenerateSequenceNumberTransactionOptions = {
   maxGasAmount?: number;
   gasUnitPrice?: number;
   expireTimestamp?: number;
   accountSequenceNumber?: AnyNumber;
+};
+
+export type InputGenerateOrderlessTransactionOptions = {
+  maxGasAmount?: number;
+  gasUnitPrice?: number;
+  expireTimestamp?: number;
+  replayNonce: AnyNumber;
 };
 
 /**
@@ -129,7 +141,8 @@ export type InputGenerateTransactionOptions = {
 export type AnyTransactionPayloadInstance =
   | TransactionPayloadEntryFunction
   | TransactionPayloadScript
-  | TransactionPayloadMultiSig;
+  | TransactionPayloadMultiSig
+  | TransactionPayloadPayload;
 
 /**
  * The data needed to generate a transaction payload for Entry Function, Script, or Multi Sig types.

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -126,7 +126,7 @@ export type InputGenerateSequenceNumberTransactionOptions = {
   gasUnitPrice?: number;
   expireTimestamp?: number;
   accountSequenceNumber?: AnyNumber;
-  replayNonce?: undefined;
+  replayProtectionNonce?: undefined;
 };
 
 /**
@@ -137,7 +137,7 @@ export type InputGenerateTurboTransactionOptions = {
   gasUnitPrice?: number;
   expireTimestamp?: number;
   accountSequenceNumber?: undefined;
-  replayNonce: AnyNumber;
+  replayProtectionNonce: AnyNumber;
 };
 
 /**

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -14,6 +14,7 @@ import {
   TransactionPayloadEntryFunction,
   TransactionPayloadMultiSig,
   TransactionPayloadScript,
+  TransactionInnerPayload,
 } from "./instances";
 import { AnyNumber, HexInput, MoveFunctionGenericTypeParam, MoveFunctionId, MoveStructId, MoveValue } from "../types";
 import { TypeTag } from "./typeTag";
@@ -21,7 +22,6 @@ import { AccountAuthenticator } from "./authenticator/account";
 import { SimpleTransaction } from "./instances/simpleTransaction";
 import { MultiAgentTransaction } from "./instances/multiAgentTransaction";
 import { Serialized } from "../bcs";
-import { TransactionPayloadPayload } from "./instances/transactionPayload";
 
 /**
  * Entry function arguments for building a raw transaction using remote ABI, supporting various data types including primitives and arrays.
@@ -150,7 +150,7 @@ export type AnyTransactionPayloadInstance =
   | TransactionPayloadEntryFunction
   | TransactionPayloadScript
   | TransactionPayloadMultiSig
-  | TransactionPayloadPayload;
+  | TransactionInnerPayload;
 
 /**
  * The data needed to generate a transaction payload for Entry Function, Script, or Multi Sig types.

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -116,7 +116,7 @@ export type AnyRawTransactionInstance = RawTransaction | MultiAgentRawTransactio
  */
 export type InputGenerateTransactionOptions =
   | InputGenerateSequenceNumberTransactionOptions
-  | InputGenerateTurboTransactionOptions;
+  | InputGenerateOrderlessTransactionOptions;
 
 /**
  * Input options for generating a transaction that requires an account sequence number, which is the default method.
@@ -130,9 +130,9 @@ export type InputGenerateSequenceNumberTransactionOptions = {
 };
 
 /**
- * Input options for generating a transaction using the turbo method, which does not require an account sequence number.
+ * Input options for generating a transaction using the orderless method, which does not require an account sequence number.
  */
-export type InputGenerateTurboTransactionOptions = {
+export type InputGenerateOrderlessTransactionOptions = {
   maxGasAmount?: number;
   gasUnitPrice?: number;
   expireTimestamp?: number;

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -116,19 +116,27 @@ export type AnyRawTransactionInstance = RawTransaction | MultiAgentRawTransactio
  */
 export type InputGenerateTransactionOptions =
   | InputGenerateSequenceNumberTransactionOptions
-  | InputGenerateOrderlessTransactionOptions;
+  | InputGenerateTurboTransactionOptions;
 
+/**
+ * Input options for generating a transaction that requires an account sequence number, which is the default method.
+ */
 export type InputGenerateSequenceNumberTransactionOptions = {
   maxGasAmount?: number;
   gasUnitPrice?: number;
   expireTimestamp?: number;
   accountSequenceNumber?: AnyNumber;
+  replayNonce?: undefined;
 };
 
-export type InputGenerateOrderlessTransactionOptions = {
+/**
+ * Input options for generating a transaction using the turbo method, which does not require an account sequence number.
+ */
+export type InputGenerateTurboTransactionOptions = {
   maxGasAmount?: number;
   gasUnitPrice?: number;
   expireTimestamp?: number;
+  accountSequenceNumber?: undefined;
   replayNonce: AnyNumber;
 };
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -632,6 +632,7 @@ export type UserTransactionResponse = {
   changes: Array<WriteSetChange>;
   sender: string;
   sequence_number: string;
+  replay_protection_nonce: string;
   max_gas_amount: string;
   gas_unit_price: string;
   expiration_timestamp_secs: string;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -73,6 +73,7 @@ export enum TransactionPayloadVariants {
   Script = 0,
   EntryFunction = 2,
   Multisig = 3,
+  Payload = 4,
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -77,6 +77,34 @@ export enum TransactionPayloadVariants {
 }
 
 /**
+ * The inner payload type to support turbo transactions and all future transaction types.
+ * {@link https://github.com/aptos-labs/aptos-core/blob/main/types/src/transaction/mod.rs#L478}
+ */
+export enum TransactionInnerPayloadVariants {
+  V1 = 0,
+}
+
+/**
+ * Executable types for transactions, which can be either a script or an entry function.
+ *
+ * Empty is reserved for Multisig voting transactions, which do not have an executable payload.
+ * {@link https://github.com/aptos-labs/aptos-core/blob/main/types/src/transaction/mod.rs#L685}
+ */
+export enum TransactionExecutableVariants {
+  Script = 0,
+  EntryFunction = 1,
+  Empty = 2,
+}
+
+/**
+ * Variants of transaction extra configurations, which can include additional settings or parameters.
+ * {@link https://github.com/aptos-labs/aptos-core/blob/main/types/src/transaction/mod.rs#L737}
+ */
+export enum TransactionExtraConfigVariants {
+  V1 = 0,
+}
+
+/**
  * Variants of transactions used in the system.
  * {@link https://github.com/aptos-labs/aptos-core/blob/main/types/src/transaction/mod.rs#L440}
  */

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -77,7 +77,7 @@ export enum TransactionPayloadVariants {
 }
 
 /**
- * The inner payload type to support turbo transactions and all future transaction types.
+ * The inner payload type to support orderless transactions and all future transaction types.
  * {@link https://github.com/aptos-labs/aptos-core/blob/main/types/src/transaction/mod.rs#L478}
  */
 export enum TransactionInnerPayloadVariants {

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -988,7 +988,7 @@ describe("transaction submission", () => {
           functionArguments: [1, receiverAccounts[0].accountAddress],
         },
         options: {
-          replayNonce: 0xcafebabedeadbeefn,
+          replayProtectionNonce: 0xcafebabedeadbeefn,
         },
       });
       const response = await aptos.signAndSubmitTransaction({
@@ -1009,7 +1009,7 @@ describe("transaction submission", () => {
         functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
       },
       options: {
-        replayNonce: 101,
+        replayProtectionNonce: 101,
       },
     });
     const response = await aptos.signAndSubmitTransaction({

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -979,8 +979,8 @@ describe("transaction submission", () => {
       }
     });
   });
-  describe("turbo transactions", () => {
-    test("it submits a turbo transaction with an entry function payload", async () => {
+  describe("orderless transactions", () => {
+    test("it submits a orderless transaction with an entry function payload", async () => {
       const transaction = await aptos.transaction.build.simple({
         sender: legacyED25519SenderAccount.accountAddress,
         data: {
@@ -1001,7 +1001,7 @@ describe("transaction submission", () => {
       expect(response.signature?.type).toBe("ed25519_signature");
     });
   });
-  test("it submits a turbo transaction with a script payload", async () => {
+  test("it submits a orderless transaction with a script payload", async () => {
     const transaction = await aptos.transaction.build.simple({
       sender: legacyED25519SenderAccount.accountAddress,
       data: {

--- a/tests/e2e/transaction/transactionSubmission.test.ts
+++ b/tests/e2e/transaction/transactionSubmission.test.ts
@@ -979,4 +979,46 @@ describe("transaction submission", () => {
       }
     });
   });
+  describe("turbo transactions", () => {
+    test("it submits a turbo transaction with an entry function payload", async () => {
+      const transaction = await aptos.transaction.build.simple({
+        sender: legacyED25519SenderAccount.accountAddress,
+        data: {
+          function: `${contractPublisherAccount.accountAddress}::transfer::transfer`,
+          functionArguments: [1, receiverAccounts[0].accountAddress],
+        },
+        options: {
+          replayNonce: 0xcafebabedeadbeefn,
+        },
+      });
+      const response = await aptos.signAndSubmitTransaction({
+        signer: legacyED25519SenderAccount,
+        transaction,
+      });
+      await aptos.waitForTransaction({
+        transactionHash: response.hash,
+      });
+      expect(response.signature?.type).toBe("ed25519_signature");
+    });
+  });
+  test("it submits a turbo transaction with a script payload", async () => {
+    const transaction = await aptos.transaction.build.simple({
+      sender: legacyED25519SenderAccount.accountAddress,
+      data: {
+        bytecode: singleSignerScriptBytecode,
+        functionArguments: [new U64(1), receiverAccounts[0].accountAddress],
+      },
+      options: {
+        replayNonce: 101,
+      },
+    });
+    const response = await aptos.signAndSubmitTransaction({
+      signer: legacyED25519SenderAccount,
+      transaction,
+    });
+    await aptos.waitForTransaction({
+      transactionHash: response.hash,
+    });
+    expect(response.signature?.type).toBe("ed25519_signature");
+  });
 });

--- a/tests/unit/transactionPayload.test.ts
+++ b/tests/unit/transactionPayload.test.ts
@@ -1,0 +1,53 @@
+import {
+  EntryFunction,
+  Hex,
+  TransactionExecutableEntryFunction,
+  TransactionExtraConfigV1,
+  TransactionInnerPayloadV1,
+  TransactionPayload,
+  TransactionPayloadPayload,
+} from "../../src";
+import { Serializer, Deserializer } from "../../src";
+
+const TURBO_TXN =
+  "0x04000100000000000000000000000000000000000000000000000000000000000000010d6170746f735f6163636f756e74087472616e73666572000220bd3c821fc733b9e0a022c7fa2fe24e5a5a0c5b66c9624d5a63ea735628818f1008e8030000000000000000010001000000000000";
+
+// This is specifically to ensure compatibility with other SDKs and nodes
+describe("parseEncodedTransactions", () => {
+  test("parse a valid turbo transaction", () => {
+    const des = new Deserializer(Hex.fromHexInput(TURBO_TXN).toUint8Array());
+    const payload = TransactionPayload.deserialize(des);
+    expect(payload).toBeDefined();
+  });
+
+  test("serializes and deserializes a turbo transaction", () => {
+    const input = Hex.fromHexInput(TURBO_TXN).toUint8Array();
+    const des = new Deserializer(input);
+    const payload = TransactionPayload.deserialize(des);
+    const ser = new Serializer();
+    ser.serialize(payload);
+    const serialized = ser.toUint8Array();
+    expect(serialized).toEqual(input);
+
+    const reDes = new Deserializer(serialized);
+    const rePayload = TransactionPayload.deserialize(reDes);
+    expect(rePayload).toEqual(payload);
+  });
+
+  test("building a turbo transaction payload", () => {
+    const payload = new TransactionPayloadPayload(
+      new TransactionInnerPayloadV1(
+        new TransactionExecutableEntryFunction(EntryFunction.build("0x1::aptos_account", "transfer", [], [])),
+        new TransactionExtraConfigV1(),
+      ),
+    );
+
+    const ser = new Serializer();
+    ser.serialize(payload);
+    const serialized = ser.toUint8Array();
+
+    const reDes = new Deserializer(serialized);
+    const rePayload = TransactionPayload.deserialize(reDes);
+    expect(rePayload).toEqual(payload);
+  });
+});

--- a/tests/unit/transactionPayload.test.ts
+++ b/tests/unit/transactionPayload.test.ts
@@ -13,13 +13,13 @@ const TURBO_TXN =
 
 // This is specifically to ensure compatibility with other SDKs and nodes
 describe("parseEncodedTransactions", () => {
-  test("parse a valid turbo transaction", () => {
+  test("parse a valid orderless transaction", () => {
     const des = new Deserializer(Hex.fromHexInput(TURBO_TXN).toUint8Array());
     const payload = TransactionPayload.deserialize(des);
     expect(payload).toBeDefined();
   });
 
-  test("serializes and deserializes a turbo transaction", () => {
+  test("serializes and deserializes a orderless transaction", () => {
     const input = Hex.fromHexInput(TURBO_TXN).toUint8Array();
     const des = new Deserializer(input);
     const payload = TransactionPayload.deserialize(des);
@@ -33,7 +33,7 @@ describe("parseEncodedTransactions", () => {
     expect(rePayload).toEqual(payload);
   });
 
-  test("building a turbo transaction payload", () => {
+  test("building a orderless transaction payload", () => {
     const payload = new TransactionInnerPayloadV1(
       new TransactionExecutableEntryFunction(EntryFunction.build("0x1::aptos_account", "transfer", [], [])),
       new TransactionExtraConfigV1(),

--- a/tests/unit/transactionPayload.test.ts
+++ b/tests/unit/transactionPayload.test.ts
@@ -5,7 +5,6 @@ import {
   TransactionExtraConfigV1,
   TransactionInnerPayloadV1,
   TransactionPayload,
-  TransactionPayloadPayload,
 } from "../../src";
 import { Serializer, Deserializer } from "../../src";
 
@@ -35,11 +34,9 @@ describe("parseEncodedTransactions", () => {
   });
 
   test("building a turbo transaction payload", () => {
-    const payload = new TransactionPayloadPayload(
-      new TransactionInnerPayloadV1(
-        new TransactionExecutableEntryFunction(EntryFunction.build("0x1::aptos_account", "transfer", [], [])),
-        new TransactionExtraConfigV1(),
-      ),
+    const payload = new TransactionInnerPayloadV1(
+      new TransactionExecutableEntryFunction(EntryFunction.build("0x1::aptos_account", "transfer", [], [])),
+      new TransactionExtraConfigV1(),
     );
 
     const ser = new Serializer();


### PR DESCRIPTION
### Description
This enables orderless transactions to be submitted.  Instead of submitting account sequence number, users would submit the replayProtectionNonce

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  