### PR TITLE
Make default gas and expiry time configurable at client construction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Unreleased
 
+- Make the default max gas amount and exipry time from now values for transaction generation configurable.
 - Adds restriction on construction of a `MultiKey`s with more than 3 Keyless public keys when signature threshold is more than 3 as well. The limit on the number of keyless signatures is 3 so to prevent sending funds to accounts that are not accessible we add this safeguard.
 
 # 2.0.1 (2025-05-21)

--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import aptosClient from "@aptos-labs/aptos-client";
-import { AptosSettings, ClientConfig, Client, FullNodeConfig, IndexerConfig, FaucetConfig } from "../types";
+import { AptosSettings, ClientConfig, Client, FullNodeConfig, IndexerConfig, FaucetConfig, TransactionGenerationConfig } from "../types";
 import {
   NetworkToNodeAPI,
   NetworkToFaucetAPI,
@@ -11,7 +11,7 @@ import {
   NetworkToPepperAPI,
   NetworkToProverAPI,
 } from "../utils/apiEndpoints";
-import { AptosApiType } from "../utils/const";
+import { AptosApiType, DEFAULT_MAX_GAS_AMOUNT, DEFAULT_TXN_EXP_SEC_FROM_NOW } from "../utils/const";
 
 /**
  * Represents the configuration settings for an Aptos SDK client instance.
@@ -102,6 +102,12 @@ export class AptosConfig {
   readonly faucetConfig?: FaucetConfig;
 
   /**
+   * Optional specific Transaction Generation configurations
+   * @group Client
+   */
+  readonly transactionGenerationConfig?: TransactionGenerationConfig;
+
+  /**
    * Initializes an instance of the Aptos client with the specified settings.
    * This allows users to configure various aspects of the client, such as network and endpoints.
    *
@@ -154,6 +160,10 @@ export class AptosConfig {
     this.fullnodeConfig = settings?.fullnodeConfig ?? {};
     this.indexerConfig = settings?.indexerConfig ?? {};
     this.faucetConfig = settings?.faucetConfig ?? {};
+    this.transactionGenerationConfig = settings?.transactionGenerationConfig ?? {
+      DEFAULT_MAX_GAS_AMOUNT: 200000,
+      DEFAULT_TXN_EXPIRY_SEC_FROM_NOW: 20,
+    };
   }
 
   /**
@@ -264,5 +274,13 @@ export class AptosConfig {
    */
   isProverServiceRequest(url: string): boolean {
     return NetworkToProverAPI[this.network] === url;
+  }
+
+  getDefaultMaxGasAmount(): number {
+    return this.transactionGenerationConfig?.DEFAULT_MAX_GAS_AMOUNT ?? DEFAULT_MAX_GAS_AMOUNT;
+  }
+
+  getDefaultTxnExpirySecFromNow(): number {
+    return this.transactionGenerationConfig?.DEFAULT_TXN_EXPIRY_SEC_FROM_NOW ?? DEFAULT_TXN_EXP_SEC_FROM_NOW;
   }
 }

--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -2,7 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import aptosClient from "@aptos-labs/aptos-client";
-import { AptosSettings, ClientConfig, Client, FullNodeConfig, IndexerConfig, FaucetConfig, TransactionGenerationConfig } from "../types";
+import {
+  AptosSettings,
+  ClientConfig,
+  Client,
+  FullNodeConfig,
+  IndexerConfig,
+  FaucetConfig,
+  TransactionGenerationConfig,
+} from "../types";
 import {
   NetworkToNodeAPI,
   NetworkToFaucetAPI,

--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -168,10 +168,7 @@ export class AptosConfig {
     this.fullnodeConfig = settings?.fullnodeConfig ?? {};
     this.indexerConfig = settings?.indexerConfig ?? {};
     this.faucetConfig = settings?.faucetConfig ?? {};
-    this.transactionGenerationConfig = settings?.transactionGenerationConfig ?? {
-      DEFAULT_MAX_GAS_AMOUNT: 200000,
-      DEFAULT_TXN_EXPIRY_SEC_FROM_NOW: 20,
-    };
+    this.transactionGenerationConfig = settings?.transactionGenerationConfig ?? {};
   }
 
   /**
@@ -285,10 +282,10 @@ export class AptosConfig {
   }
 
   getDefaultMaxGasAmount(): number {
-    return this.transactionGenerationConfig?.DEFAULT_MAX_GAS_AMOUNT ?? DEFAULT_MAX_GAS_AMOUNT;
+    return this.transactionGenerationConfig?.defaultMaxGasAmount ?? DEFAULT_MAX_GAS_AMOUNT;
   }
 
   getDefaultTxnExpirySecFromNow(): number {
-    return this.transactionGenerationConfig?.DEFAULT_TXN_EXPIRY_SEC_FROM_NOW ?? DEFAULT_TXN_EXP_SEC_FROM_NOW;
+    return this.transactionGenerationConfig?.defaultTxnExpirySecFromNow ?? DEFAULT_TXN_EXP_SEC_FROM_NOW;
   }
 }

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -412,7 +412,8 @@ export async function generateRawTransaction(args: {
   const { maxGasAmount, gasUnitPrice, expireTimestamp } = {
     maxGasAmount: options?.maxGasAmount ? BigInt(options.maxGasAmount) : BigInt(aptosConfig.getDefaultMaxGasAmount()),
     gasUnitPrice: options?.gasUnitPrice ?? BigInt(gasEstimate),
-    expireTimestamp: options?.expireTimestamp ?? BigInt(Math.floor(Date.now() / 1000) + aptosConfig.getDefaultTxnExpirySecFromNow()),
+    expireTimestamp:
+      options?.expireTimestamp ?? BigInt(Math.floor(Date.now() / 1000) + aptosConfig.getDefaultTxnExpirySecFromNow()),
   };
 
   return new RawTransaction(

--- a/src/transactions/transactionBuilder/transactionBuilder.ts
+++ b/src/transactions/transactionBuilder/transactionBuilder.ts
@@ -24,7 +24,6 @@ import { getInfo } from "../../internal/utils";
 import { getLedgerInfo } from "../../internal/general";
 import { getGasPriceEstimation } from "../../internal/transaction";
 import { NetworkToChainId } from "../../utils/apiEndpoints";
-import { DEFAULT_MAX_GAS_AMOUNT, DEFAULT_TXN_EXP_SEC_FROM_NOW } from "../../utils/const";
 import { normalizeBundle } from "../../utils/normalizeBundle";
 import {
   AccountAuthenticator,
@@ -411,9 +410,9 @@ export async function generateRawTransaction(args: {
   ]);
 
   const { maxGasAmount, gasUnitPrice, expireTimestamp } = {
-    maxGasAmount: options?.maxGasAmount ? BigInt(options.maxGasAmount) : BigInt(DEFAULT_MAX_GAS_AMOUNT),
+    maxGasAmount: options?.maxGasAmount ? BigInt(options.maxGasAmount) : BigInt(aptosConfig.getDefaultMaxGasAmount()),
     gasUnitPrice: options?.gasUnitPrice ?? BigInt(gasEstimate),
-    expireTimestamp: options?.expireTimestamp ?? BigInt(Math.floor(Date.now() / 1000) + DEFAULT_TXN_EXP_SEC_FROM_NOW),
+    expireTimestamp: options?.expireTimestamp ?? BigInt(Math.floor(Date.now() / 1000) + aptosConfig.getDefaultTxnExpirySecFromNow()),
   };
 
   return new RawTransaction(

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -299,8 +299,8 @@ export type FaucetConfig = ClientHeadersType & {
  * A configuration object for default parameters for transaction generation.
  */
 export type TransactionGenerationConfig = {
-  DEFAULT_MAX_GAS_AMOUNT?: number;
-  DEFAULT_TXN_EXPIRY_SEC_FROM_NOW?: number;
+  defaultMaxGasAmount?: number;
+  defaultTxnExpirySecFromNow?: number;
 };
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -225,6 +225,8 @@ export type AptosSettings = {
   readonly indexerConfig?: IndexerConfig;
 
   readonly faucetConfig?: FaucetConfig;
+
+  readonly transactionGenerationConfig?: TransactionGenerationConfig;
 };
 
 /**
@@ -291,6 +293,14 @@ export type IndexerConfig = ClientHeadersType;
  */
 export type FaucetConfig = ClientHeadersType & {
   AUTH_TOKEN?: string;
+};
+
+/**
+ * A configuration object for default parameters for transaction generation.
+ */
+export type TransactionGenerationConfig = {
+  DEFAULT_MAX_GAS_AMOUNT?: number;
+  DEFAULT_TXN_EXPIRY_SEC_FROM_NOW?: number;
 };
 
 /**


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
This allows for the dev to change the default without setting it in every call

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  