### PR TITLE
Skip validateFeePayerDataOnSubmission if a custom txn submitter is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
+- Skip `validateFeePayerDataOnSubmission` if a custom txn submitter is provided.
 
 # 3.1.0 (2025-06-30)
 - Add account derivation APIs, `getAccountsForPublicKey` and `deriveOwnedAccountsFromSigner` which handle multi-key accounts and key rotations

--- a/src/api/transactionSubmission/submit.ts
+++ b/src/api/transactionSubmission/submit.ts
@@ -5,7 +5,7 @@ import { submitTransaction } from "../../internal/transactionSubmission";
 import { AccountAuthenticator, AnyRawTransaction, InputTransactionPluginData } from "../../transactions";
 import { PendingTransactionResponse } from "../../types";
 import { AptosConfig } from "../aptosConfig";
-import { ValidateFeePayerDataOnSubmission } from "./helpers";
+import { validateFeePayerDataOnSubmission } from "./helpers";
 
 /**
  * A class to handle all `Submit` transaction operations.
@@ -86,7 +86,6 @@ export class Submit {
    * ```
    * @group Implementation
    */
-  @ValidateFeePayerDataOnSubmission
   async simple(
     args: {
       transaction: AnyRawTransaction;
@@ -94,6 +93,7 @@ export class Submit {
       feePayerAuthenticator?: AccountAuthenticator;
     } & InputTransactionPluginData,
   ): Promise<PendingTransactionResponse> {
+    validateFeePayerDataOnSubmission(this.config, args);
     return submitTransaction({ aptosConfig: this.config, ...args });
   }
 
@@ -142,7 +142,6 @@ export class Submit {
    * ```
    * @group Implementation
    */
-  @ValidateFeePayerDataOnSubmission
   async multiAgent(
     args: {
       transaction: AnyRawTransaction;
@@ -151,6 +150,7 @@ export class Submit {
       feePayerAuthenticator?: AccountAuthenticator;
     } & InputTransactionPluginData,
   ): Promise<PendingTransactionResponse> {
+    validateFeePayerDataOnSubmission(this.config, args);
     return submitTransaction({ aptosConfig: this.config, ...args });
   }
 }


### PR DESCRIPTION
### Description
In this PR we skip `validateFeePayerDataOnSubmission` if a custom txn submitter is provided. The validation is invalid in the case where your custom txn submitter sends the txn to a gas station, there is no need to set the fee payer authenticator yet client side in this scenario.

We also change it from a decorator to just a normal function. The decorator was neat but also hard to work with for this and untyped, the new approach is safer. The function is not exported by the SDK so this doesn't qualify as a breaking change.

### Test Plan
CI

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  