### PR TITLE
Support `uint8array` for parsing `AccountAddress` with remote ABI

### DIFF
--- a/src/transactions/transactionBuilder/remoteAbi.ts
+++ b/src/transactions/transactionBuilder/remoteAbi.ts
@@ -369,10 +369,15 @@ function parseArg(
      */
     throwTypeMismatch("boolean", position);
   }
-  // TODO: support uint8array?
   if (param.isAddress()) {
     if (isString(arg)) {
       return AccountAddress.fromString(arg);
+    }
+    // Support for Uint8Array coming from external sources
+    // Usually, dapps will be getting the account address as a Uint8Array from the wallet (following
+    // the wallet standard).
+    if (arg && typeof arg === "object" && "data" in arg && arg.data instanceof Uint8Array) {
+      return new AccountAddress(arg.data);
     }
     throwTypeMismatch("string | AccountAddress", position);
   }
@@ -473,6 +478,10 @@ function parseArg(
       // The inner type of Object doesn't matter, since it's just syntactic sugar
       if (isString(arg)) {
         return AccountAddress.fromString(arg);
+      }
+      // Support for Uint8Array coming from external sources
+      if (arg && typeof arg === "object" && "data" in arg && arg.data instanceof Uint8Array) {
+        return new AccountAddress(arg.data);
       }
       throwTypeMismatch("string | AccountAddress", position);
     }


### PR DESCRIPTION
### Description
Add support for Uint8Array coming from external sources when parsing the function arguments using the remoteAbi.

Usually, dapps will be getting the account address as an object of `{data:Uint8Array}` from the Wallet (following
the aptos wallet standard), and use it to construct a transaction and pass it to the wallet adapter.

From there the wallet adapter either passes it along to the wallet (which works, might have some kind of internal normalization logic) or directly to the ts-sdk. If the later, the process fails with `type mismatch` as the sdk does not handle `uint8array` types

### Test Plan
tested with local build against the wallet adapter

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  