### PR TITLE
Warn on Indexer API events query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Unreleased
 
+# 3.1.3 (2025-07-08) 
+
+- Add a warning to Indexer API events queries that the endpoint will be deprecated by the end of July. To migrate your events queries, follow the details in https://aptoslabs.notion.site/Indexer-Feature-Updates-Events-v1-table-deprecation-and-end-of-support-July-1st-1ec8b846eb7280ffa042c0d3d7f45633?source=copy_link.
+
 # 3.1.2 (2025-07-01)
 
 - Support `Uint8Array` for parsing `AccountAddress` with remote ABI

--- a/src/internal/event.ts
+++ b/src/internal/event.ts
@@ -129,6 +129,11 @@ export async function getEvents(args: {
   aptosConfig: AptosConfig;
   options?: PaginationArgs & OrderByArg<GetEventsResponse[0]> & WhereArg<EventsBoolExp>;
 }): Promise<GetEventsResponse> {
+  // eslint-disable-next-line no-console
+  console.warn(
+    // eslint-disable-next-line max-len
+    `[Aptos SDK] Events queries will be deprecated by the end of July 2025. Follow the details in https://aptoslabs.notion.site/Indexer-Feature-Updates-Events-v1-table-deprecation-and-end-of-support-July-1st-1ec8b846eb7280ffa042c0d3d7f45633?source=copy_link to migrate your events queries.`,
+  );
   const { aptosConfig, options } = args;
 
   /**


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
https://aptoslabs.notion.site/Indexer-Feature-Updates-Events-v1-table-deprecation-and-end-of-support-July-1st-1ec8b846eb7280ffa042c0d3d7f45633?source=copy_link

The GraphQL schema is generated from the devnet Indexer API endpoint. We will follow-up in August to remove the events queries from the schema and SDK

### Test Plan
```
    console.warn
      [Aptos SDK] Events queries will be deprecated by the end of July 2025. Follow the details in https://aptoslabs.notion.site/Indexer-Feature-Updates-Events-v1-table-deprecation-and-end-of-support-July-1st-1ec8b846eb7280ffa042c0d3d7f45633?source=copy_link to migrate your events queries.
      131 | }): Promise<GetEventsResponse> {
      132 |   // eslint-disable-next-line no-console
    > 133 |   console.warn(
          |           ^
      134 |     // eslint-disable-next-line max-len
      135 |     `[Aptos SDK] Events queries will be deprecated by the end of July 2025. Follow the details in https://aptoslabs.notion.site/Indexer-Feature-Updates-Events-v1-table-deprecation-and-end-of-support-July-1st-1ec8b846eb7280ffa042c0d3d7f45633?source=copy_link to migrate your events queries.`,
      136 |   );
      at warn (src/internal/event.ts:133:11)
      at Event.getEvents (src/api/event.ts:228:21)
      at Object.<anonymous> (tests/e2e/api/paginateQuery.test.ts:15:34)
```
### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  