### PR TITLE
ci: bump actions/checkout to v5

### DIFF
--- a/.github/workflows/run-build.yaml
+++ b/.github/workflows/run-build.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-build

--- a/.github/workflows/run-check-version.yaml
+++ b/.github/workflows/run-check-version.yaml
@@ -14,7 +14,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-check-version

--- a/.github/workflows/run-confidential-assets-tests.yaml
+++ b/.github/workflows/run-confidential-assets-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-confidential-assets-tests

--- a/.github/workflows/run-examples.yaml
+++ b/.github/workflows/run-examples.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-examples

--- a/.github/workflows/run-fmt.yaml
+++ b/.github/workflows/run-fmt.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-fmt

--- a/.github/workflows/run-lint.yaml
+++ b/.github/workflows/run-lint.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-lint

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
       - uses: ./.github/actions/run-tests


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0