### PR TITLE
Add is_enum field to MoveStruct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Unreleased
+- Add `is_enum` field to `MoveStruct`.
+
 # 5.2.0 (2025-12-10)
 
 - Add `http2` as an optional parameter in `ClientConfig`

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1521,6 +1521,11 @@ export type MoveStruct = {
    */
   is_event: boolean;
   /**
+   * True if the struct is an enum (e.g. enum MyEnum { A, B, C }), false if it is a
+   * regular struct (e.g. struct MyStruct { a: u8, b: u8 }).
+   */
+  is_enum: boolean;
+  /**
    * Abilities associated with the struct
    */
   abilities: Array<MoveAbility>;


### PR DESCRIPTION
### Description
This PR exposes the new ABI field added in https://github.com/aptos-labs/aptos-core/pull/17816.
<!-- Please describe your change and its motivation. -->

### Test Plan
CI
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  