### PR TITLE
update shelbynet keyless endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Remove unused dependency `form-data`
 - Add `createUserDerivedObjectAddress` function for creating user-derived object addresses from source and derive_from addresses
 - Add support for passing extra CLI arguments to `LocalNode` via the `extraArgs` constructor parameter
+- Update the default keyless endpoints for shelbynet config
 
 # 5.1.1 (2025-9-23)
 

--- a/src/utils/apiEndpoints.ts
+++ b/src/utils/apiEndpoints.ts
@@ -43,7 +43,7 @@ export const NetworkToPepperAPI: Record<string, string> = {
   mainnet: "https://api.mainnet.aptoslabs.com/keyless/pepper/v0",
   testnet: "https://api.testnet.aptoslabs.com/keyless/pepper/v0",
   devnet: "https://api.devnet.aptoslabs.com/keyless/pepper/v0",
-  shelbynet: "https://api.devnet.aptoslabs.com/keyless/pepper/v0",
+  shelbynet: "https://api.shelbynet.aptoslabs.com/keyless/pepper/v0",
   // Use the devnet service for local environment
   local: "https://api.devnet.aptoslabs.com/keyless/pepper/v0",
 };
@@ -56,7 +56,7 @@ export const NetworkToProverAPI: Record<string, string> = {
   mainnet: "https://api.mainnet.aptoslabs.com/keyless/prover/v0",
   testnet: "https://api.testnet.aptoslabs.com/keyless/prover/v0",
   devnet: "https://api.devnet.aptoslabs.com/keyless/prover/v0",
-  shelbynet: "https://api.devnet.aptoslabs.com/keyless/prover/v0",
+  shelbynet: "https://api.shelbynet.aptoslabs.com/keyless/prover/v0",
   // Use the devnet service for local environment
   local: "https://api.devnet.aptoslabs.com/keyless/prover/v0",
 };


### PR DESCRIPTION
### Description

Shelbynet client config should default to shelbynet-specific keyless infra.

### Test Plan

Verified with that keyless e2e tests against shelbynet with the SDK changes can pass.

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  