### PR TITLE
[account-restoration] Fix null assertion issue with multikeys and null account_public_key's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,16 @@
 
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+# Unreleased
+
+- Fix `getMultiKeysForPublicKey` to only return accounts that have a non-null account public key.
+
 # 5.1.4 (2025-11-13)
+
 - Add serialization for signed integers
 
 # 5.1.3 (2025-11-13)
+
 - Add signed integers
 
 # 5.1.2 (2025-11-11)


### PR DESCRIPTION
### Description
For some reason, these `account_public_key`'s are null. We can ignore them for now and consider them unrecoverable.

### Test Plan
- [x] CI Passes

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
  