### PR TITLE
Fix orphaned Event mixin

### DIFF
--- a/src/api/aptos.ts
+++ b/src/api/aptos.ts
@@ -118,7 +118,6 @@ export interface Aptos
     ANS,
     Coin,
     DigitalAsset,
-    Event,
     Faucet,
     FungibleAsset,
     General,
@@ -160,7 +159,6 @@ applyMixin(Aptos, AccountAbstraction, "abstraction");
 applyMixin(Aptos, ANS, "ans");
 applyMixin(Aptos, Coin, "coin");
 applyMixin(Aptos, DigitalAsset, "digitalAsset");
-applyMixin(Aptos, Event, "event");
 applyMixin(Aptos, Faucet, "faucet");
 applyMixin(Aptos, FungibleAsset, "fungibleAsset");
 applyMixin(Aptos, General, "general");


### PR DESCRIPTION
### Description
In commit 7aa5c286 ("Remove events queries from SDK #745"), the Event class was deleted from src/api/event.ts, but two references to it were accidentally left behind in src/api/aptos.ts:

Line 121 - Interface extension includes Event
Line 163 - Mixin call applyMixin(Aptos, Event, "event")

Since there is no import for Event, these references resolve to the global browser Event constructor. This works in browsers and Node.js 15+, but React Native lacks a global Event class, causing:

ReferenceError: Property 'Event' doesn't exist

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
After building and running the SDK I ran this script:
```
/**
 * Test script to validate that Aptos client is NOT extending
 * the global Event class (which would be a bug)
 *
 * Run with: node test-rn-compat.mjs
 */

console.log("Checking if SDK incorrectly extends global Event class...\n");

const sdk = await import("./dist/esm/index.mjs");
const aptos = new sdk.Aptos();

// Check if Aptos prototype has methods from global Event
// These are actual methods on Event.prototype (NOT EventTarget)
const eventMethods = ['stopPropagation', 'preventDefault', 'stopImmediatePropagation', 'composedPath', 'initEvent'];
const hasGlobalEventMethods = eventMethods.some(
  method => typeof aptos[method] === 'function'
);

if (hasGlobalEventMethods) {
  console.log("FAILED: Aptos client has global Event methods mixed in!");
  console.log("Found methods:", eventMethods.filter(m => typeof aptos[m] === 'function'));
  process.exit(1);
} else {
  console.log("SUCCESS: Aptos client does NOT extend global Event class");
}
```

Before this change it prints: `FAILED: Aptos client has global Event methods mixed in!` 

After this change it prints: `SUCCESS: Aptos client does NOT extend global Event class`

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

I also opened [this issue](https://github.com/aptos-labs/aptos-ts-sdk/issues/797).

### Checklist
  - [X] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  