### PR TITLE
Add a `http2` optional parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to the Aptos TypeScript SDK will be captured in this file. This changelog is written by hand for now. It adheres to the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+- Add `http2` as an optional parameter in `ClientConfig`
+
 # 5.1.6 (2025-12-06)
 
 - Remove orphaned `Event` mixin that was left over after the Indexer API event queries were removed in 4.0.0
@@ -483,7 +485,6 @@ Release Stable version `1.0.0`
 ## 0.0.7 (2023-11-16)
 
 - Adds additional ANS APIs
-
   - Transactions
     - setPrimaryName
     - setTargetAddress

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@aptos-labs/aptos-cli": "^1.0.2",
-    "@aptos-labs/aptos-client": "^2.0.0",
+    "@aptos-labs/aptos-client": "^2.1.0",
     "@noble/curves": "^1.9.0",
     "@noble/hashes": "^1.5.0",
     "@scure/bip32": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ dependencies:
     specifier: ^1.0.2
     version: 1.0.2
   '@aptos-labs/aptos-client':
-    specifier: ^2.0.0
-    version: 2.0.0(got@11.8.6)
+    specifier: ^2.1.0
+    version: 2.1.0(got@11.8.6)
   '@noble/curves':
     specifier: ^1.9.0
     version: 1.9.0
@@ -151,8 +151,8 @@ packages:
       commander: 12.1.0
     dev: false
 
-  /@aptos-labs/aptos-client@2.0.0(got@11.8.6):
-    resolution: {integrity: sha512-A23T3zTCRXEKURodp00dkadVtIrhWjC9uo08dRDBkh69OhCnBAxkENmUy/rcBarfLoFr60nRWt7cBkc8wxr1mg==}
+  /@aptos-labs/aptos-client@2.1.0(got@11.8.6):
+    resolution: {integrity: sha512-ttdY0qclRvbYAAwzijkFeipuqTfLFJnoXlNIm58tIw3DKhIlfYdR6iLqTeCpI23oOPghnO99FZecej/0MTrtuA==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       got: ^11.8.6
@@ -4003,7 +4003,7 @@ packages:
     dependencies:
       clone-response: 1.0.3
       get-stream: 5.2.0
-      http-cache-semantics: 4.1.1
+      http-cache-semantics: 4.2.0
       keyv: 4.5.4
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
@@ -4577,8 +4577,8 @@ packages:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
     dev: true
 
-  /end-of-stream@1.4.4:
-    resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
+  /end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
     dependencies:
       once: 1.4.0
     dev: false
@@ -5342,7 +5342,7 @@ packages:
     resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
     engines: {node: '>=8'}
     dependencies:
-      pump: 3.0.2
+      pump: 3.0.3
     dev: false
 
   /get-stream@6.0.1:
@@ -5641,8 +5641,8 @@ packages:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
     dev: true
 
-  /http-cache-semantics@4.1.1:
-    resolution: {integrity: sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==}
+  /http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
     dev: false
 
   /http2-wrapper@1.0.3:
@@ -7476,10 +7476,10 @@ packages:
     resolution: {integrity: sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==}
     dev: true
 
-  /pump@3.0.2:
-    resolution: {integrity: sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==}
+  /pump@3.0.3:
+    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
     dependencies:
-      end-of-stream: 1.4.4
+      end-of-stream: 1.4.5
       once: 1.4.0
     dev: false
 

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -20,6 +20,7 @@ import { AptosApiError } from "../errors";
  * @param options.overrides.HEADERS - Custom headers to include in the request.
  * @param options.overrides.AUTH_TOKEN - The authorization token for the request.
  * @param options.overrides.API_KEY - The API key for the request.
+ * @param options.overrides.http2 - Whether to use HTTP/2 for the request.
  * @param options.originMethod - The origin method for the request.
  * @param client - The client used to make the request.
  *
@@ -54,6 +55,7 @@ export async function request<Req, Res>(options: ClientRequest<Req>, client: Cli
     params,
     headers,
     overrides,
+    http2: overrides?.http2,
   });
 }
 

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -365,6 +365,7 @@ export interface WhereArg<T extends {}> {
 export type ClientConfig = ClientHeadersType & {
   WITH_CREDENTIALS?: boolean;
   API_KEY?: string;
+  http2?: boolean;
 };
 
 /**
@@ -481,6 +482,7 @@ export interface ClientRequest<Req> {
   params?: any;
   overrides?: ClientConfig & FullNodeConfig & IndexerConfig & FaucetConfig;
   headers?: Record<string, any>;
+  http2?: boolean;
 }
 
 export interface ClientResponse<Res> {

--- a/tests/e2e/client/aptosRequest.test.ts
+++ b/tests/e2e/client/aptosRequest.test.ts
@@ -338,4 +338,29 @@ describe("aptos request", () => {
       );
     });
   });
+
+  describe("no http2", () => {
+    const { aptos } = getAptosClient({ clientConfig: { http2: false } });
+    test(
+      "should work when http2 is disabled",
+      async () => {
+        const sender = Account.generate();
+        const receiverAccounts = Account.generate();
+        await aptos.fundAccount({ accountAddress: sender.accountAddress, amount: 100_000_000 });
+        const transaction = await aptos.transaction.build.simple({
+          sender: sender.accountAddress,
+          data: {
+            bytecode: singleSignerScriptBytecode,
+            functionArguments: [new U64(1), receiverAccounts.accountAddress],
+          },
+        });
+        const response = await aptos.signAndSubmitTransaction({
+          signer: sender,
+          transaction,
+        });
+        expect(response.hash).toBeDefined();
+      },
+      longTestTimeout,
+    );
+  });
 });


### PR DESCRIPTION
### Description
Following https://github.com/aptos-labs/aptos-client/pull/12

Adding an optional `http2` parameter.

```ts
const aptosConfig = new AptosConfig({
  network: Network.DEVNET,
  clientConfig: {
    http2: false,
  },
});
```

### Test Plan
added a test

### Related Links
<!-- Please link to any relevant issues or pull requests! -->

### Checklist
  - [ ] Have you ran `pnpm fmt`?
  - [ ] Have you updated the `CHANGELOG.md`?
  