### PR TITLE
fix: await rejects assertions to prevent Vitest 3 breakage

### DIFF
--- a/tests/e2e/api/abstraction.test.ts
+++ b/tests/e2e/api/abstraction.test.ts
@@ -169,7 +169,7 @@ describe("abstraction api", () => {
           authenticationFunction,
         });
 
-        expect(async () => {
+        await expect(async () => {
           await aptos.transaction.signAndSubmitTransaction({
             signer: abstractAccount,
             transaction: await aptos.transferCoinTransaction({

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -441,7 +441,7 @@ describe("account api", () => {
       test("fails when account not created/funded and throwIfNoAccountFound is true", async () => {
         const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
 
-        expect(async () => {
+        await expect(async () => {
           await aptos.deriveAccountFromPrivateKey({
             privateKey: account.privateKey,
             options: { throwIfNoAccountFound: true },


### PR DESCRIPTION
## Summary
- Add missing `await` to two `.rejects.toThrow()` assertions that Vitest warns will fail in Vitest 3
- `tests/e2e/api/account.test.ts:449` — `deriveAccountFromPrivateKey` rejection test
- `tests/e2e/api/abstraction.test.ts:181` — invalid custom signer rejection test

## Test plan
- [ ] Verify warnings no longer appear in `pnpm test` output for these two test files
- [ ] Confirm both tests still pass (they should — the assertions were already passing, just unawaited)