### PR TITLE
deps: bump @noble/curves and @noble/hashes to latest 1.x (CJS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Changed
+
+- Bump `@noble/curves` and `@noble/hashes` to the latest 1.x releases (CJS-compatible; noble v2 is ESM-only).
+
 ## Fixed
 
 - Fix `fullnodeConfig.HEADERS` not being forwarded in paginated fullnode requests (`getAccountModules`, `getAccountResources`). Pagination helpers now route through `getAptosFullNode` so custom headers (e.g. `Authorization`) are included consistently. (#872)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Changed
 
-- Bump `@noble/curves` and `@noble/hashes` to the latest 1.x releases (CJS-compatible; noble v2 is ESM-only).
+- Pin `@noble/curves` and `@noble/hashes` to the latest 1.x releases without semver ranges (CJS-compatible; noble v2 is ESM-only).
 
 ## Fixed
 

--- a/confidential-asset/package.json
+++ b/confidential-asset/package.json
@@ -49,8 +49,8 @@
   },
   "dependencies": {
     "@aptos-labs/confidential-asset-bindings": "^1.1.1",
-    "@noble/curves": "^1.9.7",
-    "@noble/hashes": "^1.8.0"
+    "@noble/curves": "1.9.7",
+    "@noble/hashes": "1.8.0"
   },
   "devDependencies": {
     "@swc/cli": "^0.8.0",

--- a/confidential-asset/package.json
+++ b/confidential-asset/package.json
@@ -49,8 +49,8 @@
   },
   "dependencies": {
     "@aptos-labs/confidential-asset-bindings": "^1.1.1",
-    "@noble/curves": "^1.6.0",
-    "@noble/hashes": "^1.5.0"
+    "@noble/curves": "^1.9.7",
+    "@noble/hashes": "^1.8.0"
   },
   "devDependencies": {
     "@swc/cli": "^0.8.0",

--- a/confidential-asset/pnpm-lock.yaml
+++ b/confidential-asset/pnpm-lock.yaml
@@ -21,10 +21,10 @@ importers:
         specifier: ^5.2.1 || ^6.1.0
         version: 6.1.0(got@13.0.0)
       '@noble/curves':
-        specifier: ^1.9.7
+        specifier: 1.9.7
         version: 1.9.7
       '@noble/hashes':
-        specifier: ^1.8.0
+        specifier: 1.8.0
         version: 1.8.0
     devDependencies:
       '@swc/cli':

--- a/confidential-asset/pnpm-lock.yaml
+++ b/confidential-asset/pnpm-lock.yaml
@@ -21,10 +21,10 @@ importers:
         specifier: ^5.2.1 || ^6.1.0
         version: 6.1.0(got@13.0.0)
       '@noble/curves':
-        specifier: ^1.6.0
+        specifier: ^1.9.7
         version: 1.9.7
       '@noble/hashes':
-        specifier: ^1.5.0
+        specifier: ^1.8.0
         version: 1.8.0
     devDependencies:
       '@swc/cli':

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "dependencies": {
     "@aptos-labs/aptos-cli": "^1.1.1",
     "@aptos-labs/aptos-client": "^2.1.0",
-    "@noble/curves": "^1.9.0",
-    "@noble/hashes": "^1.5.0",
+    "@noble/curves": "^1.9.7",
+    "@noble/hashes": "^1.8.0",
     "@scure/bip32": "^1.4.0",
     "@scure/bip39": "^1.3.0",
     "eventemitter3": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -53,8 +53,8 @@
   "dependencies": {
     "@aptos-labs/aptos-cli": "^1.1.1",
     "@aptos-labs/aptos-client": "^2.1.0",
-    "@noble/curves": "^1.9.7",
-    "@noble/hashes": "^1.8.0",
+    "@noble/curves": "1.9.7",
+    "@noble/hashes": "1.8.0",
     "@scure/bip32": "^1.4.0",
     "@scure/bip39": "^1.3.0",
     "eventemitter3": "^5.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(got@11.8.6)
       '@noble/curves':
-        specifier: ^1.9.7
+        specifier: 1.9.7
         version: 1.9.7
       '@noble/hashes':
-        specifier: ^1.8.0
+        specifier: 1.8.0
         version: 1.8.0
       '@scure/bip32':
         specifier: ^1.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,10 +22,10 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0(got@11.8.6)
       '@noble/curves':
-        specifier: ^1.9.0
+        specifier: ^1.9.7
         version: 1.9.7
       '@noble/hashes':
-        specifier: ^1.5.0
+        specifier: ^1.8.0
         version: 1.8.0
       '@scure/bip32':
         specifier: ^1.4.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `@noble/curves` and `@noble/hashes` to the latest **1.x** releases on npm, which remain CommonJS-compatible. Noble **v2** is ESM-only and is intentionally not used.

Dependencies are **pinned to exact versions** (no `^`) per review.

## Changes

- Root `package.json`: `1.9.7` / `1.8.0` with refreshed `pnpm-lock.yaml`
- `confidential-asset/package.json`: same pins and lockfile
- `CHANGELOG.md` under Unreleased

## Testing

- `pnpm check` and `pnpm build` passed locally
- `pnpm unit-test` could not complete here: Vitest globalSetup requires Docker for the local Aptos node; the environment reported Docker socket unavailable

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://aptos-org.slack.com/archives/C05NLAKJM9U/p1776094193575029?thread_ts=1776094193.575029&cid=C05NLAKJM9U)

<div><a href="https://cursor.com/agents/bc-27cf048f-36b5-56db-a8e0-caa71ab59f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-27cf048f-36b5-56db-a8e0-caa71ab59f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

