### PR TITLE
feat(confidential-asset): resolve ANS primary names on activity events (v1.1.1)

### DIFF
--- a/confidential-asset/package.json
+++ b/confidential-asset/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/aptos-labs/aptos-ts-sdk/issues/new/choose"
   },
   "homepage": "https://aptos-labs.github.io/aptos-ts-sdk/",
-  "version": "1.0.0",
+  "version": "1.1.1",
   "sideEffects": false,
   "main": "dist/common/index.js",
   "module": "dist/esm/index.mjs",

--- a/confidential-asset/src/indexer/generated/convert.ts
+++ b/confidential-asset/src/indexer/generated/convert.ts
@@ -29,11 +29,25 @@ import type {
 export type GraphqlActivityRow =
   GetConfidentialAssetActivitiesQuery["confidential_asset_activities"][number];
 
+/**
+ * Converts an array of Aptos name objects (as returned by the indexer) into a
+ * human-readable name string, or `null` if no valid entry exists.
+ *
+ * - With subdomain: `"subdomain.domain"` (no `.apt` suffix)
+ * - Domain only:    `"domain.apt"`
+ */
+export function parseAptosName(names: Array<{ domain?: string | null, subdomain?: string | null }>): string | null {
+  const name = names[0];
+  if (!name?.domain) return null;
+  return name.subdomain ? `${name.subdomain}.${name.domain}` : `${name.domain}.apt`;
+}
+
 function base(row: GraphqlActivityRow): ActivityBase {
   return {
     transaction_version: String(row.transaction_version),
     event_index: String(row.event_index),
     owner_address: row.owner_address,
+    owner_primary_aptos_name: parseAptosName(row.owner_primary_aptos_name),
     event_data_version: row.event_data_version,
     block_height: String(row.block_height),
     is_transaction_success: row.is_transaction_success,
@@ -59,6 +73,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "Registered",
         asset_type: row.asset_type!,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies RegisteredActivity;
@@ -69,6 +84,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "Deposited",
         asset_type: row.asset_type!,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: String(row.amount),
         event_data: row.event_data,
       } satisfies DepositedActivity;
@@ -79,6 +95,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "Withdrawn",
         asset_type: row.asset_type!,
         counterparty_address: row.counterparty_address!,
+        counterparty_primary_aptos_name: parseAptosName(row.counterparty_primary_aptos_name),
         amount: String(row.amount),
         event_data: row.event_data,
       } satisfies WithdrawnActivity;
@@ -89,6 +106,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "Transferred",
         asset_type: row.asset_type!,
         counterparty_address: row.counterparty_address!,
+        counterparty_primary_aptos_name: parseAptosName(row.counterparty_primary_aptos_name),
         amount: null,
         event_data: row.event_data,
       } satisfies TransferredActivity;
@@ -99,6 +117,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "Normalized",
         asset_type: row.asset_type!,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies NormalizedActivity;
@@ -109,6 +128,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "RolledOver",
         asset_type: row.asset_type!,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies RolledOverActivity;
@@ -119,6 +139,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "KeyRotated",
         asset_type: row.asset_type!,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies KeyRotatedActivity;
@@ -129,6 +150,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "IncomingTransfersPauseChanged",
         asset_type: row.asset_type!,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies IncomingTransfersPauseChangedActivity;
@@ -139,6 +161,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "AllowListingChanged",
         asset_type: null,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies AllowListingChangedActivity;
@@ -149,6 +172,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "ConfidentialityForAssetTypeChanged",
         asset_type: row.asset_type!,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies ConfidentialityForAssetTypeChangedActivity;
@@ -159,6 +183,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "GlobalAuditorChanged",
         asset_type: null,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies GlobalAuditorChangedActivity;
@@ -169,6 +194,7 @@ export function convertActivity(row: GraphqlActivityRow): ConfidentialAssetActiv
         event_type: "AssetSpecificAuditorChanged",
         asset_type: row.asset_type!,
         counterparty_address: null,
+        counterparty_primary_aptos_name: null,
         amount: null,
         event_data: row.event_data,
       } satisfies AssetSpecificAuditorChangedActivity;

--- a/confidential-asset/src/indexer/generated/operations.ts
+++ b/confidential-asset/src/indexer/generated/operations.ts
@@ -8,4 +8,4 @@ export type GetConfidentialAssetActivitiesQueryVariables = Types.Exact<{
 }>;
 
 
-export type GetConfidentialAssetActivitiesQuery = { confidential_asset_activities: Array<{ transaction_version: any, event_index: any, event_type: string, owner_address: string, asset_type?: string | null, counterparty_address?: string | null, amount?: any | null, event_data: any, event_data_version: string, block_height: any, is_transaction_success: boolean, entry_function_id_str?: string | null, transaction_timestamp: any }> };
+export type GetConfidentialAssetActivitiesQuery = { confidential_asset_activities: Array<{ transaction_version: any, event_index: any, event_type: string, owner_address: string, asset_type?: string | null, counterparty_address?: string | null, amount?: any | null, event_data: any, event_data_version: string, block_height: any, is_transaction_success: boolean, entry_function_id_str?: string | null, transaction_timestamp: any, owner_primary_aptos_name: Array<{ domain?: string | null, subdomain?: string | null }>, counterparty_primary_aptos_name: Array<{ domain?: string | null, subdomain?: string | null }> }> };

--- a/confidential-asset/src/indexer/generated/queries.ts
+++ b/confidential-asset/src/indexer/generated/queries.ts
@@ -15,8 +15,24 @@ export const GetConfidentialAssetActivities = `
     event_index
     event_type
     owner_address
+    owner_primary_aptos_name: owner_aptos_names(
+      where: {is_active: {_eq: true}, is_primary: {_eq: true}}
+      order_by: {last_transaction_version: desc}
+      limit: 1
+    ) {
+      domain
+      subdomain
+    }
     asset_type
     counterparty_address
+    counterparty_primary_aptos_name: counterparty_aptos_names(
+      where: {is_active: {_eq: true}, is_primary: {_eq: true}}
+      order_by: {last_transaction_version: desc}
+      limit: 1
+    ) {
+      domain
+      subdomain
+    }
     amount
     event_data
     event_data_version

--- a/confidential-asset/src/indexer/generated/types.ts
+++ b/confidential-asset/src/indexer/generated/types.ts
@@ -512,6 +512,10 @@ export type ConfidentialAssetActivities = {
   asset_type?: Maybe<Scalars['String']['output']>;
   block_height: Scalars['bigint']['output'];
   counterparty_address?: Maybe<Scalars['String']['output']>;
+  /** An array relationship */
+  counterparty_aptos_names: Array<CurrentAptosNames>;
+  /** An aggregate relationship */
+  counterparty_aptos_names_aggregate: CurrentAptosNamesAggregate;
   entry_function_id_str?: Maybe<Scalars['String']['output']>;
   event_data: Scalars['jsonb']['output'];
   event_data_version: Scalars['String']['output'];
@@ -521,14 +525,58 @@ export type ConfidentialAssetActivities = {
   /** An object relationship */
   metadata?: Maybe<FungibleAssetMetadata>;
   owner_address: Scalars['String']['output'];
+  /** An array relationship */
+  owner_aptos_names: Array<CurrentAptosNames>;
+  /** An aggregate relationship */
+  owner_aptos_names_aggregate: CurrentAptosNamesAggregate;
   transaction_timestamp: Scalars['timestamp']['output'];
   transaction_version: Scalars['bigint']['output'];
 };
 
 
 /** columns and relationships of "confidential_asset_activities" */
+export type ConfidentialAssetActivitiesCounterpartyAptosNamesArgs = {
+  distinct_on?: InputMaybe<Array<CurrentAptosNamesSelectColumn>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<CurrentAptosNamesOrderBy>>;
+  where?: InputMaybe<CurrentAptosNamesBoolExp>;
+};
+
+
+/** columns and relationships of "confidential_asset_activities" */
+export type ConfidentialAssetActivitiesCounterpartyAptosNamesAggregateArgs = {
+  distinct_on?: InputMaybe<Array<CurrentAptosNamesSelectColumn>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<CurrentAptosNamesOrderBy>>;
+  where?: InputMaybe<CurrentAptosNamesBoolExp>;
+};
+
+
+/** columns and relationships of "confidential_asset_activities" */
 export type ConfidentialAssetActivitiesEventDataArgs = {
   path?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+/** columns and relationships of "confidential_asset_activities" */
+export type ConfidentialAssetActivitiesOwnerAptosNamesArgs = {
+  distinct_on?: InputMaybe<Array<CurrentAptosNamesSelectColumn>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<CurrentAptosNamesOrderBy>>;
+  where?: InputMaybe<CurrentAptosNamesBoolExp>;
+};
+
+
+/** columns and relationships of "confidential_asset_activities" */
+export type ConfidentialAssetActivitiesOwnerAptosNamesAggregateArgs = {
+  distinct_on?: InputMaybe<Array<CurrentAptosNamesSelectColumn>>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  offset?: InputMaybe<Scalars['Int']['input']>;
+  order_by?: InputMaybe<Array<CurrentAptosNamesOrderBy>>;
+  where?: InputMaybe<CurrentAptosNamesBoolExp>;
 };
 
 /** Boolean expression to filter rows from the table "confidential_asset_activities". All fields are combined with a logical 'AND'. */
@@ -540,6 +588,8 @@ export type ConfidentialAssetActivitiesBoolExp = {
   asset_type?: InputMaybe<StringComparisonExp>;
   block_height?: InputMaybe<BigintComparisonExp>;
   counterparty_address?: InputMaybe<StringComparisonExp>;
+  counterparty_aptos_names?: InputMaybe<CurrentAptosNamesBoolExp>;
+  counterparty_aptos_names_aggregate?: InputMaybe<CurrentAptosNamesAggregateBoolExp>;
   entry_function_id_str?: InputMaybe<StringComparisonExp>;
   event_data?: InputMaybe<JsonbComparisonExp>;
   event_data_version?: InputMaybe<StringComparisonExp>;
@@ -548,6 +598,8 @@ export type ConfidentialAssetActivitiesBoolExp = {
   is_transaction_success?: InputMaybe<BooleanComparisonExp>;
   metadata?: InputMaybe<FungibleAssetMetadataBoolExp>;
   owner_address?: InputMaybe<StringComparisonExp>;
+  owner_aptos_names?: InputMaybe<CurrentAptosNamesBoolExp>;
+  owner_aptos_names_aggregate?: InputMaybe<CurrentAptosNamesAggregateBoolExp>;
   transaction_timestamp?: InputMaybe<TimestampComparisonExp>;
   transaction_version?: InputMaybe<BigintComparisonExp>;
 };
@@ -558,6 +610,7 @@ export type ConfidentialAssetActivitiesOrderBy = {
   asset_type?: InputMaybe<OrderBy>;
   block_height?: InputMaybe<OrderBy>;
   counterparty_address?: InputMaybe<OrderBy>;
+  counterparty_aptos_names_aggregate?: InputMaybe<CurrentAptosNamesAggregateOrderBy>;
   entry_function_id_str?: InputMaybe<OrderBy>;
   event_data?: InputMaybe<OrderBy>;
   event_data_version?: InputMaybe<OrderBy>;
@@ -566,6 +619,7 @@ export type ConfidentialAssetActivitiesOrderBy = {
   is_transaction_success?: InputMaybe<OrderBy>;
   metadata?: InputMaybe<FungibleAssetMetadataOrderBy>;
   owner_address?: InputMaybe<OrderBy>;
+  owner_aptos_names_aggregate?: InputMaybe<CurrentAptosNamesAggregateOrderBy>;
   transaction_timestamp?: InputMaybe<OrderBy>;
   transaction_version?: InputMaybe<OrderBy>;
 };

--- a/confidential-asset/src/indexer/queries/getConfidentialAssetActivities.graphql
+++ b/confidential-asset/src/indexer/queries/getConfidentialAssetActivities.graphql
@@ -14,8 +14,24 @@ query getConfidentialAssetActivities(
     event_index
     event_type
     owner_address
+    owner_primary_aptos_name: owner_aptos_names(
+      where: {is_active: {_eq: true}, is_primary: {_eq: true}}
+      order_by: {last_transaction_version: desc}
+      limit: 1
+    ) {
+      domain
+      subdomain
+    }
     asset_type
     counterparty_address
+    counterparty_primary_aptos_name: counterparty_aptos_names(
+      where: {is_active: {_eq: true}, is_primary: {_eq: true}}
+      order_by: {last_transaction_version: desc}
+      limit: 1
+    ) {
+      domain
+      subdomain
+    }
     amount
     event_data
     event_data_version

--- a/confidential-asset/src/indexer/types.ts
+++ b/confidential-asset/src/indexer/types.ts
@@ -88,6 +88,7 @@ export interface ActivityBase {
   transaction_version: string;
   event_index: string;
   owner_address: string;
+  owner_primary_aptos_name: string | null;
   event_data_version: string;
   block_height: string;
   is_transaction_success: boolean;
@@ -108,11 +109,13 @@ interface WithoutAssetType {
 /** Events involving two parties (e.g. transfer, withdraw). */
 interface WithCounterparty {
   counterparty_address: string;
+  counterparty_primary_aptos_name: string | null;
 }
 
 /** Events involving only one party. */
 interface WithoutCounterparty {
   counterparty_address: null;
+  counterparty_primary_aptos_name: null;
 }
 
 /** Events with a plaintext amount (deposit, withdraw). */

--- a/confidential-asset/tests/e2e/confidentialAsset.test.ts
+++ b/confidential-asset/tests/e2e/confidentialAsset.test.ts
@@ -1,7 +1,15 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account, AccountAddress, AccountAddressInput, AnyNumber, Bool, MoveVector } from "@aptos-labs/ts-sdk";
+import {
+  Account,
+  AccountAddress,
+  AccountAddressInput,
+  AnyNumber,
+  Bool,
+  Ed25519Account,
+  MoveVector,
+} from "@aptos-labs/ts-sdk";
 import { TwistedEd25519PrivateKey } from "../../src";
 import {
   getTestAccount,


### PR DESCRIPTION
## Summary

Activity rows previously exposed only raw addresses for the event owner and counterparty. The indexer query now joins ANS to resolve each participant's primary active name, surfacing it as `owner_primary_aptos_name` and `counterparty_primary_aptos_name` (`string | null`) directly on the typed activity objects — no separate lookup needed by consumers.

Names are formatted as `subdomain.domain` when a subdomain exists, or `domain.apt` otherwise. Generated GraphQL types were regenerated to match, and a missing test import was fixed alongside.

## Test plan

- [x] `owner_primary_aptos_name` / `counterparty_primary_aptos_name` populated for addresses with a registered ANS primary name
- [x] Both fields are `null` when no name is registered
- [x] Subdomain format: `subdomain.domain` · Domain-only format: `domain.apt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)