### PR TITLE
Fixes bug where we don't send claimed entry function for address 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Fixed
+
+- Encrypted transactions built with `withFeePayer: true` (deferred gas-station sponsor) now correctly include `claimedEntryFunction` in the payload so the eventual fee payer can inspect which module/function they are sponsoring without decrypting the payload.
+
 # 7.0.0 (2026-05-11)
 
 ## Added

--- a/src/transactions/transactionBuilder/encryptPayload.ts
+++ b/src/transactions/transactionBuilder/encryptPayload.ts
@@ -83,10 +83,11 @@ function resolveClaimedEntryFun(args: {
   options: InputGenerateTransactionOptions;
 }): ClaimedEntryFunction | undefined {
   const { payload, feePayerAddress, options } = args;
-  // Match `buildSignerAuthKeys`: a zero-address fee payer is not a real sponsor, so it should not
-  // force a `claimed_entry_fun` to be exposed/validated.
-  const hasFeePayer =
-    feePayerAddress !== undefined && !AccountAddress.from(feePayerAddress).equals(AccountAddress.ZERO);
+  // Unlike buildSignerAuthKeys, we treat a zero feePayerAddress (deferred gas-station sponsor) the
+  // same as a real one: a fee payer *will* sign, so include claimed_entry_fun so they can inspect
+  // the payload without decrypting it. The zero check in buildSignerAuthKeys is different — adding
+  // a placeholder zero auth key to the cryptographic AAD would corrupt it.
+  const hasFeePayer = feePayerAddress !== undefined;
   if (!hasFeePayer && !payloadHasMultisigAddress(payload)) {
     return undefined;
   }

--- a/tests/unit/transactions/encryptPayload.test.ts
+++ b/tests/unit/transactions/encryptPayload.test.ts
@@ -144,4 +144,30 @@ describe("buildEncryptedPayload input validation", () => {
       }),
     ).rejects.toThrow("node does not provide an encryption key");
   });
+
+  test("includes claimedEntryFunction when feePayerAddress is ZERO (withFeePayer:true gas-station path)", async () => {
+    const mockCiphertext = {} as any;
+    mockFetch.mockResolvedValue({ key: { encrypt: vi.fn().mockReturnValue(mockCiphertext) }, epoch: 1n } as any);
+    const result = await buildEncryptedPayload({
+      aptosConfig: config,
+      sender,
+      payload: makePayload(),
+      options: { encrypted: true, authenticationKey: VALID_AUTH_KEY },
+      feePayerAddress: AccountAddress.ZERO,
+    });
+    expect(result.claimedEntryFunction).not.toBeUndefined();
+    expect(result.claimedEntryFunction?.moduleId.address.toString()).toBe("0x1");
+  });
+
+  test("omits claimedEntryFunction when no feePayerAddress and no multisig", async () => {
+    const mockCiphertext = {} as any;
+    mockFetch.mockResolvedValue({ key: { encrypt: vi.fn().mockReturnValue(mockCiphertext) }, epoch: 1n } as any);
+    const result = await buildEncryptedPayload({
+      aptosConfig: config,
+      sender,
+      payload: makePayload(),
+      options: { encrypted: true, authenticationKey: VALID_AUTH_KEY },
+    });
+    expect(result.claimedEntryFunction).toBeUndefined();
+  });
 });


### PR DESCRIPTION
### Description
I thought 0 meant no fee payer. I was wrong. We were not sending claimed entry functions for encrypted transactions as a result. 

