### PR TITLE
Add Codecov automation for unit test coverage

### DIFF
--- a/.github/actions/run-codecov/action.yaml
+++ b/.github/actions/run-codecov/action.yaml
@@ -1,0 +1,27 @@
+name: "Unit test coverage and Codecov upload"
+description: |
+  Install dependencies, run Vitest unit tests with coverage, and upload lcov to Codecov.
+
+inputs:
+  codecov-token:
+    description: Optional Codecov token (tokenless uploads work for many public repos).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup-node-pnpm
+    - run: pnpm install --frozen-lockfile
+      shell: bash
+    - name: Unit tests with coverage
+      run: pnpm run test:coverage:unit
+      shell: bash
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # pin@v5.1.2
+      with:
+        token: ${{ inputs.codecov-token }}
+        files: coverage/lcov.info
+        flags: unit
+        name: unit
+        fail_ci_if_error: false

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -1,0 +1,30 @@
+name: Codecov
+on:
+  pull_request:
+    types: [labeled, opened, synchronize, reopened, auto_merge_enabled]
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-pnpm
+      - run: pnpm install --frozen-lockfile
+        shell: bash
+      - name: Unit tests with coverage
+        run: pnpm run test:coverage:unit
+        shell: bash
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # pin@v5.1.2
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage/lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -16,15 +16,6 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-node-pnpm
-      - run: pnpm install --frozen-lockfile
-        shell: bash
-      - name: Unit tests with coverage
-        run: pnpm run test:coverage:unit
-        shell: bash
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # pin@v5.1.2
+      - uses: ./.github/actions/run-codecov
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: coverage/lcov.info
-          fail_ci_if_error: false
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Added
+
+- CI uploads unit-test coverage to Codecov (`codecov.yaml` workflow, `pnpm test:coverage:unit`). Repository owners should enable the Codecov GitHub app and optionally set `CODECOV_TOKEN` for uploads.
+
 # 7.0.1 (2026-05-14)
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Added
 
-- CI uploads unit-test coverage to Codecov (`codecov.yaml` workflow, `pnpm test:coverage:unit`). Repository owners should enable the Codecov GitHub app and optionally set `CODECOV_TOKEN` for uploads.
+- CI uploads unit test coverage to Codecov (`codecov.yaml` via `.github/actions/run-codecov`, `pnpm test:coverage:unit`). Uploads use the Codecov `unit` flag; Vitest coverage is scoped to `src/**/*.ts` (excluding generated GraphQL queries and indexer types) so metrics reflect SDK sources. Repository owners should enable the Codecov GitHub app and optionally set `CODECOV_TOKEN` for uploads.
 
 # 7.0.1 (2026-05-14)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,5 @@
 # https://docs.codecov.com/docs/codecov-yaml
+# CI uploads only the `unit` flag (Vitest unit suite); e2e / localnet coverage is not included.
 coverage:
   status:
     project:

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
     "check": "biome check",
     "test": "vitest run",
     "unit-test": "vitest run --config vitest.config.unit.ts",
+    "test:coverage:unit": "vitest run --coverage --config vitest.config.unit.ts",
     "e2e-test": "vitest run tests/e2e",
     "e2e-encrypted": "vitest run tests/e2e/transaction/encryptedTransaction.test.ts --config vitest.config.e2e-devnet.ts",
     "indexer-codegen": "graphql-codegen --config ./src/types/codegen.yaml && pnpm fmt",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,13 +15,9 @@ export default defineConfig({
     exclude: ["dist/**", "examples/**", "confidential-asset/**"],
     coverage: {
       provider: "v8",
+      include: ["src/**/*.ts"],
       reporter: ["text", "html", "clover", "json", "lcov"],
-      exclude: [
-        "src/internal/queries/**",
-        "src/types/generated/**",
-        "tests/e2e/ans/publishANSContracts.ts",
-        "confidential-asset/**",
-      ],
+      exclude: ["tests/**", "src/internal/queries/**", "src/types/generated/**"],
       thresholds: {
         branches: 40,
         functions: 50,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     exclude: ["dist/**", "examples/**", "confidential-asset/**"],
     coverage: {
       provider: "v8",
+      reporter: ["text", "html", "clover", "json", "lcov"],
       exclude: [
         "src/internal/queries/**",
         "src/types/generated/**",

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -16,14 +16,10 @@ export default defineConfig({
     testTimeout: 30000,
     coverage: {
       provider: "v8",
+      include: ["src/**/*.ts"],
       reporter: ["text", "lcov"],
       reportsDirectory: "./coverage",
-      exclude: [
-        "src/internal/queries/**",
-        "src/types/generated/**",
-        "tests/e2e/ans/publishANSContracts.ts",
-        "confidential-asset/**",
-      ],
+      exclude: ["tests/**", "src/internal/queries/**", "src/types/generated/**"],
     },
   },
   resolve: {

--- a/vitest.config.unit.ts
+++ b/vitest.config.unit.ts
@@ -14,6 +14,17 @@ export default defineConfig({
     pool: "forks",
     maxWorkers: 4,
     testTimeout: 30000,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov"],
+      reportsDirectory: "./coverage",
+      exclude: [
+        "src/internal/queries/**",
+        "src/types/generated/**",
+        "tests/e2e/ans/publishANSContracts.ts",
+        "confidential-asset/**",
+      ],
+    },
   },
   resolve: {
     extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds automated coverage reporting to Codecov without running the Docker-backed e2e suite twice.

- New GitHub Actions workflow `.github/workflows/codecov.yaml` triggers on the same PR events as `run-tests.yaml`, delegates to **`.github/actions/run-codecov`**, runs `pnpm test:coverage:unit`, and uploads `coverage/lcov.info` with `codecov/codecov-action` (pinned to v5.1.2).
- **`pnpm test:coverage:unit`** runs Vitest with `--coverage` using `vitest.config.unit.ts` (no local testnet).
- Vitest **`coverage.include: ["src/**/*.ts"]`** plus **`tests/**`** and generated-code **`coverage.exclude`** so lcov reflects SDK sources only (addresses review feedback on misleading reports).
- Uploads set Codecov **`flags: unit`** and **`name: unit`** so the dashboard distinguishes this from any future full-suite uploads.
- Root **`codecov.yml`** documents the `unit`-only scope; project/patch status remains **informational** so PRs are not blocked until gates are tuned.
- **`vitest.config.ts`** uses the same `src/**` coverage scope for consistent local full-suite lcov output.

## Maintainer setup

1. Install the [Codecov GitHub app](https://github.com/apps/codecov) on this repository (if not already).
2. Optionally add a `CODECOV_TOKEN` repository secret for more reliable uploads; tokenless uploads work for many public repos.

## Verification

- `pnpm run test:coverage:unit` (642 tests, `coverage/lcov.info` contains only `src/**` paths)
- `pnpm check`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52c0fe3e-d67a-4fe0-bbca-ec9cdf04e4af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52c0fe3e-d67a-4fe0-bbca-ec9cdf04e4af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

