### PR TITLE
feat(confidential-asset)!: domain-separated decryption-key derivation

### DIFF
--- a/confidential-asset/CHANGELOG.md
+++ b/confidential-asset/CHANGELOG.md
@@ -6,6 +6,23 @@ For changes to the main Aptos TypeScript SDK (`@aptos-labs/ts-sdk`), see the [ro
 
 # Unreleased
 
+## Breaking
+
+- **Confidential-asset decryption-key derivation now uses a domain-separated signing message.** The plaintext `TwistedEd25519PrivateKey.decryptionKeyDerivationMessage` constant has been **removed**. Callers must now use `TwistedEd25519PrivateKey.getDecryptionKeySigningMessage(network)`, which returns the 32-byte signing message `sha3_256("APTOS_CONFIDENTIAL_ASSETS::DK_DERIVATION::" || network)`. `network` is any `Network` value from `@aptos-labs/ts-sdk` (e.g. `Network.MAINNET`); the underlying enum string is what gets hashed. The previous plaintext message lacked any domain separation (no protocol tag, no chain binding, no envelope), so any other signing surface producing an Ed25519 signature over those exact bytes would recover the decryption key. New `TwistedEd25519PrivateKey.DK_DERIVATION_DOMAIN_PREFIX` constant exported alongside.
+
+  **Migration.** Any pre-existing decryption keys derived under the old plaintext message will not be reproducible by this SDK after upgrade; users holding balances under such keys must rotate to a new key derived under the new scheme via `ConfidentialAssetTransactionBuilder.rotateEncryptionKey` *before* upgrading the SDK in their toolchain. Pseudocode:
+
+  ```ts
+  // OLD (removed):
+  const sig = account.sign(TwistedEd25519PrivateKey.decryptionKeyDerivationMessage);
+  const dk = TwistedEd25519PrivateKey.fromSignature(sig);
+
+  // NEW:
+  const msg = TwistedEd25519PrivateKey.getDecryptionKeySigningMessage(Network.MAINNET);
+  const sig = account.sign(msg);
+  const dk = TwistedEd25519PrivateKey.fromSignature(sig);
+  ```
+
 ## Fixed
 
 - Fix CI browser test job for `@aptos-labs/confidential-asset`:

--- a/confidential-asset/package.json
+++ b/confidential-asset/package.json
@@ -15,7 +15,7 @@
     "url": "git+https://github.com/aptos-labs/aptos-ts-sdk.git",
     "directory": "confidential-asset"
   },
-  "version": "1.1.1",
+  "version": "2.0.0",
   "type": "module",
   "sideEffects": false,
   "exports": {

--- a/confidential-asset/src/crypto/twistedEd25519.ts
+++ b/confidential-asset/src/crypto/twistedEd25519.ts
@@ -3,6 +3,8 @@
 
 import { ed25519, ristretto255 } from "@noble/curves/ed25519.js";
 import { bytesToNumberLE, numberToBytesLE } from "@noble/curves/utils.js";
+import { sha3_256 } from "@noble/hashes/sha3.js";
+import { utf8ToBytes } from "@noble/hashes/utils.js";
 import {
   CKDPriv,
   deriveKey,
@@ -13,6 +15,7 @@ import {
   HexInput,
   isValidHardenedPath,
   mnemonicToSeed,
+  Network,
   Serializable,
   Serializer,
   splitPath,
@@ -166,7 +169,27 @@ export class TwistedEd25519PrivateKey extends Serializable {
     return TwistedEd25519PrivateKey.fromDerivationPathInner(path, mnemonicToSeed(mnemonics));
   }
 
-  static decryptionKeyDerivationMessage = "Sign this message to derive decryption key from your private key";
+  /**
+   * Domain-separation prefix for the decryption-key derivation signing message.
+   */
+  static readonly DK_DERIVATION_DOMAIN_PREFIX = "APTOS_CONFIDENTIAL_ASSETS::DK_DERIVATION::";
+
+  /**
+   * Returns the 32-byte signing message a wallet must sign with the user's Ed25519
+   * private key to derive a confidential-asset decryption key for the given network.
+   *
+   *   signing_message = sha3_256("APTOS_CONFIDENTIAL_ASSETS::DK_DERIVATION::" || network)
+   *
+   * The resulting Ed25519 signature is then passed to {@link fromSignature} to obtain
+   * the {@link TwistedEd25519PrivateKey}.
+   *
+   * @param network a {@link Network} value (e.g. `Network.MAINNET`). The underlying
+   *   string literal is what gets hashed into the signing message; renaming any
+   *   {@link Network} member would make previously derived keys unreachable.
+   */
+  static getDecryptionKeySigningMessage(network: Network): Uint8Array {
+    return sha3_256(utf8ToBytes(TwistedEd25519PrivateKey.DK_DERIVATION_DOMAIN_PREFIX + network));
+  }
 
   static fromSignature(signature: Ed25519Signature): TwistedEd25519PrivateKey {
     const scalarLE = bytesToNumberLE(signature.toUint8Array());

--- a/confidential-asset/tests/helpers/index.mts
+++ b/confidential-asset/tests/helpers/index.mts
@@ -117,7 +117,8 @@ export const getTestConfidentialAccount = (account?: Ed25519Account) => {
 
   if (!account) return TwistedEd25519PrivateKey.generate();
 
-  const signature = account.sign(TwistedEd25519PrivateKey.decryptionKeyDerivationMessage);
+  const signingMessage = TwistedEd25519PrivateKey.getDecryptionKeySigningMessage(APTOS_NETWORK);
+  const signature = account.sign(signingMessage);
 
   return TwistedEd25519PrivateKey.fromSignature(signature);
 };

--- a/confidential-asset/tests/units/twistedEd25519.test.mts
+++ b/confidential-asset/tests/units/twistedEd25519.test.mts
@@ -1,0 +1,45 @@
+/**
+ * Unit tests for the domain-separated confidential-asset decryption-key derivation.
+ *
+ * The 32-byte signing message per chain is fixed; these tests pin the values so any
+ * change to the derivation surface (constant string, chain literals, hash algorithm)
+ * fails CI loudly.
+ */
+
+import { describe, it, expect } from "vitest";
+import { Hex, Network } from "@aptos-labs/ts-sdk";
+import { TwistedEd25519PrivateKey } from "../../src/index.js";
+
+const VECTORS: Array<{ network: Network; expectedHex: string }> = [
+  {
+    network: Network.MAINNET,
+    expectedHex: "0xb22523cee15e8a94819a13ae96b7d5d8d8ef42213aa2b56f4fe5c40ea848e46c",
+  },
+  {
+    network: Network.TESTNET,
+    expectedHex: "0xcc51262a1ec8b1fc392dd02e9cd92e13f53fec4fd481ee5d5b3c3d8f58e247e6",
+  },
+  {
+    network: Network.DEVNET,
+    expectedHex: "0xfa56c4a0724a76979f09c7dbff5c31865ba5ef1d08eef0446581a450124c88e9",
+  },
+];
+
+describe("TwistedEd25519PrivateKey.getDecryptionKeySigningMessage", () => {
+  it("uses the canonical domain-separation prefix", () => {
+    expect(TwistedEd25519PrivateKey.DK_DERIVATION_DOMAIN_PREFIX).toBe("APTOS_CONFIDENTIAL_ASSETS::DK_DERIVATION::");
+  });
+
+  it.each(VECTORS)("matches the test vector for $network", ({ network, expectedHex }) => {
+    const signingMessage = TwistedEd25519PrivateKey.getDecryptionKeySigningMessage(network);
+    expect(signingMessage.length).toBe(32);
+    expect(Hex.fromHexInput(signingMessage).toString()).toBe(expectedHex);
+  });
+
+  it("produces a distinct message for each network", () => {
+    const messages = VECTORS.map((v) =>
+      Hex.fromHexInput(TwistedEd25519PrivateKey.getDecryptionKeySigningMessage(v.network)).toString(),
+    );
+    expect(new Set(messages).size).toBe(messages.length);
+  });
+});


### PR DESCRIPTION
## Summary

Replace the plaintext decryption-key derivation message with a 32-byte domain-separated signing message bound to a `Network`:

```
signing_message = sha3_256("APTOS_CONFIDENTIAL_ASSETS::DK_DERIVATION::" || network)
```

- New: `TwistedEd25519PrivateKey.getDecryptionKeySigningMessage(network: Network)` returns the 32-byte signing message.
- New: `TwistedEd25519PrivateKey.DK_DERIVATION_DOMAIN_PREFIX` exported for audit/reference.
- Removed: `TwistedEd25519PrivateKey.decryptionKeyDerivationMessage` (the plaintext `"Sign this message to derive decryption key from your private key"`).
- Bumps `@aptos-labs/confidential-asset` from `1.1.1` to `2.0.0`.

## Why

The previous plaintext message had no protocol tag, chain binding, or envelope. Any other signing surface that produced an Ed25519 signature over those exact bytes would recover the decryption key — there was no provable separation from arbitrary `signMessage` flows or other future Aptos signing schemes. The new derivation is a fixed 32-byte SHA3-256 output from a domain-tagged seed, byte-disjoint from every other signing scheme in the ecosystem (Petra `signMessage`, SIWA, Rust struct signing, Move struct signing).

## Breaking change


Migration:

```ts
// OLD (removed):
const sig = account.sign(TwistedEd25519PrivateKey.decryptionKeyDerivationMessage);
const dk  = TwistedEd25519PrivateKey.fromSignature(sig);

// NEW:
const msg = TwistedEd25519PrivateKey.getDecryptionKeySigningMessage(Network.MAINNET);
const sig = account.sign(msg);
const dk  = TwistedEd25519PrivateKey.fromSignature(sig);
```

## Test plan

- [x] `pnpm check` (biome) clean
- [x] `pnpm build` (tsc) clean
- [x] `SKIP_SETUP=1 vitest run tests/units/` — 45 passed, 12 skipped, no regressions
- [x] New `tests/units/twistedEd25519.test.mts` pins the 32-byte signing message for `mainnet`, `testnet`, `devnet` and verifies distinctness