### PR TITLE
Updates encrypted transaction authentication key type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 ## Added
 
 - CI uploads unit test coverage to Codecov (`codecov.yaml` via `.github/actions/run-codecov`, `pnpm test:coverage:unit`). Uploads use the Codecov `unit` flag; Vitest coverage is scoped to `src/**/*.ts` (excluding generated GraphQL queries and indexer types) so metrics reflect SDK sources. Repository owners should enable the Codecov GitHub app and optionally set `CODECOV_TOKEN` for uploads.
-- Encrypted transactions: when `options.senderAuthenticationKey` (and `options.feePayerAuthenticationKey` / `options.secondarySignerAuthenticationKeys[i]`) is omitted, the SDK now fetches the corresponding `authentication_key` from the fullnode and memoizes it per `(network, address)` for ~1 hour. Pass the auth key explicitly to skip the lookup (e.g. immediately after a key rotation).
+- Encrypted transactions: when `options.senderAuthenticationKey` (and `options.feePayerAuthenticationKey` / `options.secondarySignerAuthenticationKeys[i]`) is omitted, the SDK now fetches the corresponding `authentication_key` from the fullnode and memoizes it per `(network, address)` for ~1 hour. If the address has no `0x1::account::Account` resource on chain (a not-yet-created or light account), the SDK uses the address bytes as the auth key, matching the chain's account-creation convention — this enables fee-payer-sponsored encrypted transactions where the sender hasn't been created yet. Pass the auth key explicitly to skip the lookup (e.g. immediately after a key rotation).
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 ## Added
 
 - CI uploads unit test coverage to Codecov (`codecov.yaml` via `.github/actions/run-codecov`, `pnpm test:coverage:unit`). Uploads use the Codecov `unit` flag; Vitest coverage is scoped to `src/**/*.ts` (excluding generated GraphQL queries and indexer types) so metrics reflect SDK sources. Repository owners should enable the Codecov GitHub app and optionally set `CODECOV_TOKEN` for uploads.
+- Encrypted transactions: when `options.senderAuthenticationKey` (and `options.feePayerAuthenticationKey` / `options.secondarySignerAuthenticationKeys[i]`) is omitted, the SDK now fetches the corresponding `authentication_key` from the fullnode and memoizes it per `(network, address)` for ~1 hour. Pass the auth key explicitly to skip the lookup (e.g. immediately after a key rotation).
+
+## Changed
+
+- **Encrypted transactions (breaking)**: renamed `options.authenticationKey` → `options.senderAuthenticationKey` in `InputEncryptedTransactionBuildOptions` for clarity and parity with `feePayerAuthenticationKey` / `secondarySignerAuthenticationKeys`. Narrowed the accepted input type for all three fields to `AuthenticationKey | string | Uint8Array` (an explicit `AuthenticationKey` instance is now the preferred input; callers previously passing `AccountPublicKey` should call `.authKey()` themselves). All three fields are now genuinely optional — omitted entries are fetched and cached from chain.
 
 # 7.0.1 (2026-05-14)
 

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -388,18 +388,33 @@ export async function lookupOriginalAccountAddress(args: {
  * derive auth keys when the caller does not pass them explicitly. Callers that just rotated their
  * key and need an immediate fresh read should pass the auth key explicitly instead of relying on
  * this cache.
+ *
+ * If the address has no `0x1::account::Account` resource on chain (a brand-new account, or a light
+ * account with balance/objects but no explicit resource), returns the address bytes as the
+ * authentication key — matching the chain's account-creation convention (see
+ * [`doesAccountExistAtAddress`]). This makes encrypted-transaction builds work for not-yet-created
+ * signers (e.g., fee-payer sponsorship of an uncreated sender).
  */
 export async function fetchAndCacheAuthKeyForAddress(args: {
   aptosConfig: AptosConfig;
   accountAddress: AccountAddressInput;
 }): Promise<AuthenticationKey> {
   const { aptosConfig, accountAddress } = args;
-  const addr = AccountAddress.from(accountAddress).toString();
+  const address = AccountAddress.from(accountAddress);
+  const addr = address.toString();
   const cacheKey = `auth-key-${aptosConfig.fullnode ?? aptosConfig.network}-${addr}`;
   return memoizeAsync(
     async () => {
-      const info = await getInfoUtil({ aptosConfig, accountAddress: addr });
-      return new AuthenticationKey({ data: info.authentication_key });
+      try {
+        const info = await getInfoUtil({ aptosConfig, accountAddress: addr });
+        return new AuthenticationKey({ data: info.authentication_key });
+      } catch (err) {
+        if (err instanceof AptosApiError && err.data?.error_code === "account_not_found") {
+          // Chain convention: with no Account resource the auth key is the address itself.
+          return new AuthenticationKey({ data: address.toUint8Array() });
+        }
+        throw err;
+      }
     },
     cacheKey,
     60 * 60 * 1000,

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -83,6 +83,7 @@ import { Hex } from "../core/hex.js";
 import { CurrentFungibleAssetBalancesBoolExp } from "../types/generated/types.js";
 import { getTableItem } from "./table.js";
 import { APTOS_COIN } from "../utils/index.js";
+import { memoizeAsync } from "../utils/memoize.js";
 import { AptosApiError } from "../errors/index.js";
 import { Deserializer, U8, MoveVector } from "../bcs/index.js";
 import { generateTransaction } from "./transactionSubmission.js";
@@ -379,6 +380,30 @@ export async function lookupOriginalAccountAddress(args: {
 
     throw err;
   }
+}
+
+/**
+ * Fetches the on-chain `authentication_key` for an account address and memoizes it for ~1 hour,
+ * keyed by `(network or fullnode URL, address)`. Used by the encrypted-transaction builder to
+ * derive auth keys when the caller does not pass them explicitly. Callers that just rotated their
+ * key and need an immediate fresh read should pass the auth key explicitly instead of relying on
+ * this cache.
+ */
+export async function fetchAndCacheAuthKeyForAddress(args: {
+  aptosConfig: AptosConfig;
+  accountAddress: AccountAddressInput;
+}): Promise<AuthenticationKey> {
+  const { aptosConfig, accountAddress } = args;
+  const addr = AccountAddress.from(accountAddress).toString();
+  const cacheKey = `auth-key-${aptosConfig.fullnode ?? aptosConfig.network}-${addr}`;
+  return memoizeAsync(
+    async () => {
+      const info = await getInfoUtil({ aptosConfig, accountAddress: addr });
+      return new AuthenticationKey({ data: info.authentication_key });
+    },
+    cacheKey,
+    60 * 60 * 1000,
+  )();
 }
 
 /**

--- a/src/transactions/transactionBuilder/encryptPayload.ts
+++ b/src/transactions/transactionBuilder/encryptPayload.ts
@@ -4,7 +4,7 @@
 import { AptosConfig } from "../../api/aptosConfig.js";
 import { AccountAddress, AccountAddressInput } from "../../core/index.js";
 import { AuthenticationKey } from "../../core/authenticationKey.js";
-import { AccountPublicKey } from "../../core/crypto/index.js";
+import { fetchAndCacheAuthKeyForAddress } from "../../internal/account.js";
 import { fetchAndCacheEncryptionKey } from "../../internal/encryptionKey.js";
 import {
   ClaimedEntryFunction,
@@ -103,76 +103,81 @@ function resolveClaimedEntryFun(args: {
   return undefined;
 }
 
-function resolveAuthKey(input: HexInput | AccountPublicKey): AuthenticationKey {
-  if (input instanceof AccountPublicKey) {
-    return input.authKey();
+function resolveAuthKey(input: AuthenticationKey | HexInput): AuthenticationKey {
+  if (input instanceof AuthenticationKey) {
+    return input;
   }
   return new AuthenticationKey({ data: input });
 }
 
 /**
- * Validates auth-key options and assembles `(address, authenticationKey)` pairs in
- * `TransactionAuthenticator::all_signer_auth_keys` order: sender, secondaries, fee payer last.
+ * Assembles `(address, authenticationKey)` pairs in `TransactionAuthenticator::all_signer_auth_keys` order
+ * (sender, secondaries, fee payer last). Auth keys not supplied in `options` are fetched from chain via
+ * `fetchAndCacheAuthKeyForAddress`, which caches per `(network, address)` for ~1 hour.
  */
-function buildSignerAuthKeys(args: {
+async function buildSignerAuthKeys(args: {
+  aptosConfig: AptosConfig;
   sender: AccountAddress;
   options: InputGenerateTransactionOptions;
   feePayerAddress?: AccountAddressInput;
   secondarySignerAddresses?: AccountAddressInput[];
-}): { sender: SignerAuthKeyPair; additional: SignerAuthKeyPair[] | undefined } {
-  const { sender, options, feePayerAddress, secondarySignerAddresses } = args;
+}): Promise<{ sender: SignerAuthKeyPair; additional: SignerAuthKeyPair[] | undefined }> {
+  const { aptosConfig, sender, options, feePayerAddress, secondarySignerAddresses } = args;
 
-  if (options.authenticationKey === undefined) {
-    throw new Error(
-      "options.authenticationKey is required when options.encrypted is true. " +
-        "Pass the sender's AccountPublicKey or a raw 32-byte auth key hex string.",
-    );
-  }
   const secondaryAddrs = secondarySignerAddresses ?? [];
-  const secondaryAuthHex = options.secondarySignerAuthenticationKeys;
-  if (secondaryAddrs.length > 0) {
-    if (!secondaryAuthHex || secondaryAuthHex.length !== secondaryAddrs.length) {
-      throw new Error(
-        "Encrypted multi-agent transactions require options.secondarySignerAuthenticationKeys with one entry per secondarySignerAddresses entry, in the same order. " +
-          "Each entry may be an AccountPublicKey or a raw 32-byte auth key hex string.",
-      );
-    }
-  } else if (secondaryAuthHex !== undefined && secondaryAuthHex.length > 0) {
+  const secondaryAuthInputs = options.secondarySignerAuthenticationKeys;
+  if (secondaryAddrs.length === 0 && secondaryAuthInputs !== undefined && secondaryAuthInputs.length > 0) {
     throw new Error(
       "options.secondarySignerAuthenticationKeys was set but no secondarySignerAddresses were provided to generateRawTransaction.",
+    );
+  }
+  if (
+    secondaryAddrs.length > 0 &&
+    secondaryAuthInputs !== undefined &&
+    secondaryAuthInputs.length !== secondaryAddrs.length
+  ) {
+    throw new Error(
+      "Encrypted multi-agent transactions require options.secondarySignerAuthenticationKeys (when provided) to have one entry per secondarySignerAddresses entry, in the same order. " +
+        "Leave individual entries undefined to fetch them from chain.",
     );
   }
 
   const feePayerAddr = feePayerAddress !== undefined ? AccountAddress.from(feePayerAddress) : undefined;
   const hasNonZeroFeePayer = feePayerAddr !== undefined && !feePayerAddr.equals(AccountAddress.ZERO);
-  if (hasNonZeroFeePayer && options.feePayerAuthenticationKey === undefined) {
-    throw new Error(
-      "options.feePayerAuthenticationKey is required when options.encrypted is true and feePayerAddress is a non-zero sponsor. " +
-        "Must match the fee payer authenticator; AAD order is sender, then secondaries, then fee payer (aptos-core `all_signer_auth_keys`).",
-    );
-  }
   if (options.feePayerAuthenticationKey !== undefined && !hasNonZeroFeePayer) {
     throw new Error(
       "options.feePayerAuthenticationKey was set but feePayerAddress is missing or the zero address (no on-chain fee payer for AAD).",
     );
   }
 
-  const senderPair: SignerAuthKeyPair = {
-    address: sender,
-    authenticationKey: resolveAuthKey(options.authenticationKey),
+  const resolveFor = async (
+    address: AccountAddress,
+    input: AuthenticationKey | HexInput | undefined,
+  ): Promise<AuthenticationKey> => {
+    if (input !== undefined) {
+      return resolveAuthKey(input);
+    }
+    return fetchAndCacheAuthKeyForAddress({ aptosConfig, accountAddress: address });
   };
-  const additional: SignerAuthKeyPair[] =
-    secondaryAddrs.length > 0 && secondaryAuthHex
-      ? secondaryAddrs.map((addr, i) => ({
-          address: AccountAddress.from(addr),
-          authenticationKey: resolveAuthKey(secondaryAuthHex[i]!),
-        }))
-      : [];
-  if (hasNonZeroFeePayer && options.feePayerAuthenticationKey !== undefined) {
-    additional.push({
-      address: feePayerAddr,
-      authenticationKey: resolveAuthKey(options.feePayerAuthenticationKey),
-    });
+
+  const secondaryPairsPromise = Promise.all(
+    secondaryAddrs.map(async (addr, i) => {
+      const address = AccountAddress.from(addr);
+      const authenticationKey = await resolveFor(address, secondaryAuthInputs?.[i]);
+      return { address, authenticationKey };
+    }),
+  );
+
+  const [senderAuthKey, secondaryPairs, feePayerAuthKey] = await Promise.all([
+    resolveFor(sender, options.senderAuthenticationKey),
+    secondaryPairsPromise,
+    hasNonZeroFeePayer ? resolveFor(feePayerAddr, options.feePayerAuthenticationKey) : Promise.resolve(undefined),
+  ]);
+
+  const senderPair: SignerAuthKeyPair = { address: sender, authenticationKey: senderAuthKey };
+  const additional: SignerAuthKeyPair[] = [...secondaryPairs];
+  if (hasNonZeroFeePayer && feePayerAuthKey !== undefined) {
+    additional.push({ address: feePayerAddr, authenticationKey: feePayerAuthKey });
   }
   return { sender: senderPair, additional: additional.length > 0 ? additional : undefined };
 }
@@ -197,7 +202,8 @@ export async function buildEncryptedPayload(args: {
     args;
 
   const senderAddr = AccountAddress.from(sender);
-  const { sender: senderPair, additional } = buildSignerAuthKeys({
+  const { sender: senderPair, additional } = await buildSignerAuthKeys({
+    aptosConfig,
     sender: senderAddr,
     options,
     feePayerAddress,

--- a/src/transactions/types.ts
+++ b/src/transactions/types.ts
@@ -19,8 +19,8 @@ import {
   U8,
 } from "../bcs/serializable/movePrimitives.js";
 import { FixedBytes } from "../bcs/serializable/fixedBytes.js";
-import { AccountAddress, AccountAddressInput } from "../core/index.js";
-import { AccountPublicKey, PublicKey } from "../core/crypto/index.js";
+import { AccountAddress, AccountAddressInput, AuthenticationKey } from "../core/index.js";
+import { PublicKey } from "../core/crypto/index.js";
 import {
   MultiAgentRawTransaction,
   FeePayerRawTransaction,
@@ -182,23 +182,27 @@ export type InputEncryptedTransactionBuildOptions = {
    */
   encrypted?: boolean;
   /**
-   * Authentication key for the primary sender. Required when `encrypted` is true.
-   * Accept either an `AccountPublicKey` (auth key is derived automatically via `.authKey()`) or a raw 32-byte hex
-   * string. Must match the on-chain authenticator identity (aptos-core `PayloadAssociatedData::V1.signer_auth_keys`).
+   * Authentication key for the primary sender. Optional: when omitted (and `encrypted` is true), the SDK fetches
+   * the sender's `authentication_key` from the fullnode and caches it for ~1 hour. Pass it explicitly to skip the
+   * lookup (useful right after a key rotation). Accepts an `AuthenticationKey` or a raw 32-byte hex string /
+   * `Uint8Array`. Must match the on-chain authenticator identity (aptos-core
+   * `PayloadAssociatedData::V1.signer_auth_keys`).
    */
-  authenticationKey?: HexInput | AccountPublicKey;
+  senderAuthenticationKey?: AuthenticationKey | HexInput;
   /**
    * For encrypted **multi-agent** transactions: each secondary signer's authentication key, in the same order
-   * as `secondarySignerAddresses` on the transaction build input. Accepts `AccountPublicKey` or raw 32-byte hex.
+   * as `secondarySignerAddresses` on the transaction build input. Any entry left undefined (or the entire array
+   * omitted) will be fetched from chain and cached. Accepts `AuthenticationKey` or a raw 32-byte hex string /
+   * `Uint8Array`.
    */
-  secondarySignerAuthenticationKeys?: (HexInput | AccountPublicKey)[];
+  secondarySignerAuthenticationKeys?: (AuthenticationKey | HexInput | undefined)[];
   /**
-   * For encrypted **fee-payer** transactions: the fee payer's authentication key. Required when `encrypted` is true
-   * and `feePayerAddress` is set to a **non-zero** sponsor address. Appended **last** in AAD `signer_auth_keys`,
-   * matching aptos-core `TransactionAuthenticator::all_signer_auth_keys` (after sender and secondaries).
-   * Accepts `AccountPublicKey` or raw 32-byte hex.
+   * For encrypted **fee-payer** transactions: the fee payer's authentication key. Optional when `feePayerAddress`
+   * is a **non-zero** sponsor — omitted values are fetched from chain and cached. Appended **last** in AAD
+   * `signer_auth_keys`, matching aptos-core `TransactionAuthenticator::all_signer_auth_keys` (after sender and
+   * secondaries). Accepts `AuthenticationKey` or a raw 32-byte hex string / `Uint8Array`.
    */
-  feePayerAuthenticationKey?: HexInput | AccountPublicKey;
+  feePayerAuthenticationKey?: AuthenticationKey | HexInput;
   /**
    * Overrides `claimed_entry_fun` for encrypted transactions when a fee payer is set, the payload is multisig, or the
    * payload is `TransactionInnerPayload` with a multisig address in `TransactionExtraConfigV1`.

--- a/tests/e2e/transaction/encryptedTransaction.test.ts
+++ b/tests/e2e/transaction/encryptedTransaction.test.ts
@@ -45,11 +45,11 @@ const SKIP_ENCRYPTED_TESTS_REASON =
  */
 const ENCRYPTED_E2E_DEFAULT_MAX_GAS = 600_000;
 
-/** Required for `options.encrypted` builds: must match the authenticator that will sign the transaction. */
+/** For `options.encrypted` builds: pass `senderAuthenticationKey` to skip the on-chain fetch (must match the authenticator that will sign the transaction). */
 function encryptedBuildOptions(account: Account, extra: Record<string, unknown> = {}) {
   return {
     encrypted: true as const,
-    authenticationKey: account.publicKey,
+    senderAuthenticationKey: account.publicKey.authKey(),
     gasUnitPrice: BigInt(MIN_ENCRYPTED_TXN_GAS_UNIT_PRICE),
     maxGasAmount: ENCRYPTED_E2E_DEFAULT_MAX_GAS,
     ...extra,

--- a/tests/unit/transactions/encryptPayload.test.ts
+++ b/tests/unit/transactions/encryptPayload.test.ts
@@ -3,20 +3,44 @@
 
 import { vi, describe, test, expect, beforeEach, type MockedFunction } from "vitest";
 import { AptosConfig, Network } from "../../../src";
-import { AccountAddress } from "../../../src/core";
+import { AccountAddress, AuthenticationKey } from "../../../src/core";
 import { EntryFunction, TransactionPayloadEntryFunction } from "../../../src/transactions/instances/transactionPayload";
+import { PayloadAssociatedData } from "../../../src/transactions/instances/encryptedPayload";
 import { buildEncryptedPayload } from "../../../src/transactions/transactionBuilder/encryptPayload";
 import { fetchAndCacheEncryptionKey } from "../../../src/internal/encryptionKey";
+import * as accountModule from "../../../src/internal/account";
 
 vi.mock("../../../src/internal/encryptionKey", () => ({
   fetchAndCacheEncryptionKey: vi.fn(),
 }));
 
 const mockFetch = fetchAndCacheEncryptionKey as MockedFunction<typeof fetchAndCacheEncryptionKey>;
+const mockFetchAuthKey = vi.spyOn(accountModule, "fetchAndCacheAuthKeyForAddress");
 
 const config = new AptosConfig({ network: Network.MAINNET });
 const sender = AccountAddress.ONE;
 const VALID_AUTH_KEY = `0x${"ab".repeat(32)}`;
+const FETCHED_AUTH_KEY = new AuthenticationKey({ data: `0x${"cd".repeat(32)}` });
+
+/**
+ * Returns a mock encryption key whose `encrypt` records the `associatedData` argument so tests can
+ * assert on `PayloadAssociatedData.signerAuthKeys` without running the BLS12-381 IBE path.
+ */
+function mockEncryptionWithCapture(): { encrypt: ReturnType<typeof vi.fn>; lastAd: () => PayloadAssociatedData } {
+  let captured: PayloadAssociatedData | undefined;
+  const encrypt = vi.fn().mockImplementation((_payload, ad: PayloadAssociatedData) => {
+    captured = ad;
+    return {};
+  });
+  mockFetch.mockResolvedValue({ key: { encrypt }, epoch: 1n } as any);
+  return {
+    encrypt,
+    lastAd: () => {
+      if (!captured) throw new Error("encrypt was not called");
+      return captured;
+    },
+  };
+}
 
 function makePayload(): TransactionPayloadEntryFunction {
   return new TransactionPayloadEntryFunction(EntryFunction.build("0x1::aptos_account", "transfer", [], []));
@@ -25,17 +49,87 @@ function makePayload(): TransactionPayloadEntryFunction {
 describe("buildEncryptedPayload input validation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockFetchAuthKey.mockResolvedValue(FETCHED_AUTH_KEY);
   });
 
-  test("throws when authenticationKey is missing", async () => {
-    await expect(
-      buildEncryptedPayload({
+  test("fetches sender auth key from chain when senderAuthenticationKey is omitted and threads it into the AAD", async () => {
+    const { lastAd } = mockEncryptionWithCapture();
+    await buildEncryptedPayload({
+      aptosConfig: config,
+      sender,
+      payload: makePayload(),
+      options: { encrypted: true },
+    });
+    expect(mockFetchAuthKey).toHaveBeenCalledWith(
+      expect.objectContaining({ aptosConfig: config, accountAddress: sender }),
+    );
+    expect(lastAd().signerAuthKeys[0]?.authenticationKey.toString()).toBe(FETCHED_AUTH_KEY.toString());
+  });
+
+  test("does not fetch sender auth key when senderAuthenticationKey is provided", async () => {
+    mockFetch.mockResolvedValue({ key: { encrypt: vi.fn().mockReturnValue({}) }, epoch: 1n } as any);
+    await buildEncryptedPayload({
+      aptosConfig: config,
+      sender,
+      payload: makePayload(),
+      options: { encrypted: true, senderAuthenticationKey: VALID_AUTH_KEY },
+    });
+    expect(mockFetchAuthKey).not.toHaveBeenCalled();
+  });
+
+  test("accepts a Uint8Array senderAuthenticationKey and threads it into the AAD", async () => {
+    const { lastAd } = mockEncryptionWithCapture();
+    const bytes = new Uint8Array(32).fill(0xab);
+    await buildEncryptedPayload({
+      aptosConfig: config,
+      sender,
+      payload: makePayload(),
+      options: { encrypted: true, senderAuthenticationKey: bytes },
+    });
+    expect(lastAd().signerAuthKeys[0]?.authenticationKey.toString()).toBe(`0x${"ab".repeat(32)}`);
+  });
+
+  test("hex string, Uint8Array, and AuthenticationKey inputs with the same bytes produce the same AAD auth key", async () => {
+    const bytes = new Uint8Array(32).fill(0xab);
+    const hex = `0x${"ab".repeat(32)}`;
+    const authKey = new AuthenticationKey({ data: bytes });
+    const captureFor = async (input: any): Promise<string> => {
+      const { lastAd } = mockEncryptionWithCapture();
+      await buildEncryptedPayload({
         aptosConfig: config,
         sender,
         payload: makePayload(),
-        options: { encrypted: true } as any,
-      }),
-    ).rejects.toThrow("options.authenticationKey is required");
+        options: { encrypted: true, senderAuthenticationKey: input },
+      });
+      return lastAd().signerAuthKeys[0]!.authenticationKey.toString();
+    };
+    const a = await captureFor(hex);
+    const b = await captureFor(bytes);
+    const c = await captureFor(authKey);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  test("an unrotated account address (bytes or string) produces the same auth key in the AAD as fetching it from chain", async () => {
+    // For accounts that have never rotated, the on-chain authentication_key equals the account address bytes.
+    // Passing the address as `senderAuthenticationKey` (in any 32-byte form) should therefore produce a bit-identical
+    // AAD to what the on-chain fetch fallback would have produced — and skip the network call.
+    const freshSender = AccountAddress.from(`0x${"01".repeat(32)}`);
+    const expectedAuthKey = new AuthenticationKey({ data: freshSender.toUint8Array() }).toString();
+
+    const captureFor = async (input: any): Promise<string> => {
+      const { lastAd } = mockEncryptionWithCapture();
+      await buildEncryptedPayload({
+        aptosConfig: config,
+        sender: freshSender,
+        payload: makePayload(),
+        options: { encrypted: true, senderAuthenticationKey: input },
+      });
+      return lastAd().signerAuthKeys[0]!.authenticationKey.toString();
+    };
+    expect(await captureFor(freshSender.toUint8Array())).toBe(expectedAuthKey);
+    expect(await captureFor(freshSender.toString())).toBe(expectedAuthKey);
+    expect(mockFetchAuthKey).not.toHaveBeenCalled();
   });
 
   test("throws when secondarySignerAuthenticationKeys count does not match secondaries", async () => {
@@ -46,7 +140,7 @@ describe("buildEncryptedPayload input validation", () => {
         payload: makePayload(),
         options: {
           encrypted: true,
-          authenticationKey: VALID_AUTH_KEY,
+          senderAuthenticationKey: VALID_AUTH_KEY,
           secondarySignerAuthenticationKeys: [VALID_AUTH_KEY],
         },
         secondarySignerAddresses: [AccountAddress.TWO, AccountAddress.THREE],
@@ -62,26 +156,25 @@ describe("buildEncryptedPayload input validation", () => {
         payload: makePayload(),
         options: {
           encrypted: true,
-          authenticationKey: VALID_AUTH_KEY,
+          senderAuthenticationKey: VALID_AUTH_KEY,
           secondarySignerAuthenticationKeys: [VALID_AUTH_KEY],
         },
       }),
     ).rejects.toThrow("secondarySignerAuthenticationKeys was set but no secondarySignerAddresses");
   });
 
-  test("throws when feePayerAuthenticationKey is missing for a non-zero fee payer", async () => {
-    await expect(
-      buildEncryptedPayload({
-        aptosConfig: config,
-        sender,
-        payload: makePayload(),
-        options: {
-          encrypted: true,
-          authenticationKey: VALID_AUTH_KEY,
-        },
-        feePayerAddress: AccountAddress.TWO,
-      }),
-    ).rejects.toThrow("feePayerAuthenticationKey is required");
+  test("fetches fee payer auth key from chain when feePayerAuthenticationKey is omitted for a non-zero fee payer", async () => {
+    mockFetch.mockResolvedValue({ key: { encrypt: vi.fn().mockReturnValue({}) }, epoch: 1n } as any);
+    await buildEncryptedPayload({
+      aptosConfig: config,
+      sender,
+      payload: makePayload(),
+      options: { encrypted: true, senderAuthenticationKey: VALID_AUTH_KEY },
+      feePayerAddress: AccountAddress.TWO,
+    });
+    expect(mockFetchAuthKey).toHaveBeenCalledWith(
+      expect.objectContaining({ aptosConfig: config, accountAddress: AccountAddress.TWO }),
+    );
   });
 
   test("throws when feePayerAuthenticationKey is provided but feePayerAddress is absent", async () => {
@@ -92,7 +185,7 @@ describe("buildEncryptedPayload input validation", () => {
         payload: makePayload(),
         options: {
           encrypted: true,
-          authenticationKey: VALID_AUTH_KEY,
+          senderAuthenticationKey: VALID_AUTH_KEY,
           feePayerAuthenticationKey: VALID_AUTH_KEY,
         },
       }),
@@ -107,7 +200,7 @@ describe("buildEncryptedPayload input validation", () => {
         payload: makePayload(),
         options: {
           encrypted: true,
-          authenticationKey: VALID_AUTH_KEY,
+          senderAuthenticationKey: VALID_AUTH_KEY,
           feePayerAuthenticationKey: VALID_AUTH_KEY,
           claimedEntryFunction: { module: "0x1::coin", functionName: "transfer" },
         },
@@ -124,7 +217,7 @@ describe("buildEncryptedPayload input validation", () => {
         payload: makePayload(),
         options: {
           encrypted: true,
-          authenticationKey: VALID_AUTH_KEY,
+          senderAuthenticationKey: VALID_AUTH_KEY,
           feePayerAuthenticationKey: VALID_AUTH_KEY,
           claimedEntryFunction: { module: "0x1::aptos_account", functionName: "wrong_function" },
         },
@@ -140,7 +233,7 @@ describe("buildEncryptedPayload input validation", () => {
         aptosConfig: config,
         sender,
         payload: makePayload(),
-        options: { encrypted: true, authenticationKey: VALID_AUTH_KEY },
+        options: { encrypted: true, senderAuthenticationKey: VALID_AUTH_KEY },
       }),
     ).rejects.toThrow("node does not provide an encryption key");
   });
@@ -152,7 +245,7 @@ describe("buildEncryptedPayload input validation", () => {
       aptosConfig: config,
       sender,
       payload: makePayload(),
-      options: { encrypted: true, authenticationKey: VALID_AUTH_KEY },
+      options: { encrypted: true, senderAuthenticationKey: VALID_AUTH_KEY },
       feePayerAddress: AccountAddress.ZERO,
     });
     expect(result.claimedEntryFunction).not.toBeUndefined();
@@ -166,7 +259,7 @@ describe("buildEncryptedPayload input validation", () => {
       aptosConfig: config,
       sender,
       payload: makePayload(),
-      options: { encrypted: true, authenticationKey: VALID_AUTH_KEY },
+      options: { encrypted: true, senderAuthenticationKey: VALID_AUTH_KEY },
     });
     expect(result.claimedEntryFunction).toBeUndefined();
   });

--- a/tests/unit/transactions/encryptedGasFloor.test.ts
+++ b/tests/unit/transactions/encryptedGasFloor.test.ts
@@ -57,7 +57,7 @@ describe("encrypted transaction gas floor", () => {
       payload,
       options: {
         encrypted: true,
-        authenticationKey: VALID_AUTH_KEY,
+        senderAuthenticationKey: VALID_AUTH_KEY,
         gasUnitPrice: 50,
         accountSequenceNumber: 0,
       },
@@ -72,7 +72,7 @@ describe("encrypted transaction gas floor", () => {
       payload,
       options: {
         encrypted: true,
-        authenticationKey: VALID_AUTH_KEY,
+        senderAuthenticationKey: VALID_AUTH_KEY,
         gasUnitPrice: 300,
         accountSequenceNumber: 0,
       },

--- a/tests/unit/transactions/fetchAuthKeyForAddress.test.ts
+++ b/tests/unit/transactions/fetchAuthKeyForAddress.test.ts
@@ -5,11 +5,27 @@ import { vi, describe, test, expect, beforeEach } from "vitest";
 import { AptosConfig, Network } from "../../../src";
 import { AccountAddress, AuthenticationKey } from "../../../src/core";
 import { fetchAndCacheAuthKeyForAddress } from "../../../src/internal/account";
+import { AptosApiError } from "../../../src/errors";
+import { AptosApiType } from "../../../src/utils/const";
 import * as utilsModule from "../../../src/internal/utils/utils";
 import { clearMemoizeCache } from "../../../src/utils/memoize";
 
 const ON_CHAIN_AUTH_KEY = `0x${"ab".repeat(32)}`;
 const OTHER_AUTH_KEY = `0x${"cd".repeat(32)}`;
+
+function makeAptosApiError(errorCode: string, status = 404): AptosApiError {
+  return new AptosApiError({
+    apiType: AptosApiType.FULLNODE,
+    aptosRequest: { url: "http://test/v1/accounts/0x1", method: "GET" },
+    aptosResponse: {
+      data: { message: "x", error_code: errorCode },
+      status,
+      statusText: status === 404 ? "Not Found" : "Error",
+      url: "http://test/v1/accounts/0x1",
+      headers: {},
+    },
+  });
+}
 
 describe("fetchAndCacheAuthKeyForAddress", () => {
   const getInfoSpy = vi.spyOn(utilsModule, "getInfo");
@@ -49,6 +65,34 @@ describe("fetchAndCacheAuthKeyForAddress", () => {
     expect(a.toString()).toBe(ON_CHAIN_AUTH_KEY);
     expect(b.toString()).toBe(OTHER_AUTH_KEY);
     expect(getInfoSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns the address as the auth key when no Account resource exists on chain", async () => {
+    getInfoSpy.mockRejectedValue(makeAptosApiError("account_not_found"));
+    const config = new AptosConfig({ network: Network.MAINNET });
+    const result = await fetchAndCacheAuthKeyForAddress({
+      aptosConfig: config,
+      accountAddress: AccountAddress.ONE,
+    });
+    expect(result).toBeInstanceOf(AuthenticationKey);
+    expect(result.toString()).toBe(AccountAddress.ONE.toStringLong());
+  });
+
+  test("caches the address-fallback result like a normal hit", async () => {
+    getInfoSpy.mockRejectedValue(makeAptosApiError("account_not_found"));
+    const config = new AptosConfig({ network: Network.MAINNET });
+    await fetchAndCacheAuthKeyForAddress({ aptosConfig: config, accountAddress: AccountAddress.ONE });
+    await fetchAndCacheAuthKeyForAddress({ aptosConfig: config, accountAddress: AccountAddress.ONE });
+    expect(getInfoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("other API errors still propagate (no silent fallback)", async () => {
+    const apiErr = makeAptosApiError("rate_limited", 429);
+    getInfoSpy.mockRejectedValue(apiErr);
+    const config = new AptosConfig({ network: Network.MAINNET });
+    await expect(
+      fetchAndCacheAuthKeyForAddress({ aptosConfig: config, accountAddress: AccountAddress.ONE }),
+    ).rejects.toBe(apiErr);
   });
 
   test("uses separate cache entries for the same address on different networks", async () => {

--- a/tests/unit/transactions/fetchAuthKeyForAddress.test.ts
+++ b/tests/unit/transactions/fetchAuthKeyForAddress.test.ts
@@ -1,0 +1,66 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { vi, describe, test, expect, beforeEach } from "vitest";
+import { AptosConfig, Network } from "../../../src";
+import { AccountAddress, AuthenticationKey } from "../../../src/core";
+import { fetchAndCacheAuthKeyForAddress } from "../../../src/internal/account";
+import * as utilsModule from "../../../src/internal/utils/utils";
+import { clearMemoizeCache } from "../../../src/utils/memoize";
+
+const ON_CHAIN_AUTH_KEY = `0x${"ab".repeat(32)}`;
+const OTHER_AUTH_KEY = `0x${"cd".repeat(32)}`;
+
+describe("fetchAndCacheAuthKeyForAddress", () => {
+  const getInfoSpy = vi.spyOn(utilsModule, "getInfo");
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearMemoizeCache();
+  });
+
+  test("returns an AuthenticationKey whose bytes match the on-chain authentication_key", async () => {
+    getInfoSpy.mockResolvedValue({ sequence_number: "0", authentication_key: ON_CHAIN_AUTH_KEY });
+    const config = new AptosConfig({ network: Network.MAINNET });
+    const result = await fetchAndCacheAuthKeyForAddress({ aptosConfig: config, accountAddress: AccountAddress.ONE });
+    expect(result).toBeInstanceOf(AuthenticationKey);
+    expect(result.toString()).toBe(ON_CHAIN_AUTH_KEY);
+  });
+
+  test("memoizes per (network, address) — second call for the same address skips getInfo", async () => {
+    getInfoSpy.mockResolvedValue({ sequence_number: "0", authentication_key: ON_CHAIN_AUTH_KEY });
+    const config = new AptosConfig({ network: Network.MAINNET });
+    await fetchAndCacheAuthKeyForAddress({ aptosConfig: config, accountAddress: AccountAddress.ONE });
+    await fetchAndCacheAuthKeyForAddress({ aptosConfig: config, accountAddress: AccountAddress.ONE });
+    expect(getInfoSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses separate cache entries for different addresses on the same network", async () => {
+    getInfoSpy.mockImplementation(async ({ accountAddress }: { accountAddress: any }) => ({
+      sequence_number: "0",
+      authentication_key:
+        AccountAddress.from(accountAddress).toString() === AccountAddress.ONE.toString()
+          ? ON_CHAIN_AUTH_KEY
+          : OTHER_AUTH_KEY,
+    }));
+    const config = new AptosConfig({ network: Network.MAINNET });
+    const a = await fetchAndCacheAuthKeyForAddress({ aptosConfig: config, accountAddress: AccountAddress.ONE });
+    const b = await fetchAndCacheAuthKeyForAddress({ aptosConfig: config, accountAddress: AccountAddress.TWO });
+    expect(a.toString()).toBe(ON_CHAIN_AUTH_KEY);
+    expect(b.toString()).toBe(OTHER_AUTH_KEY);
+    expect(getInfoSpy).toHaveBeenCalledTimes(2);
+  });
+
+  test("uses separate cache entries for the same address on different networks", async () => {
+    getInfoSpy
+      .mockResolvedValueOnce({ sequence_number: "0", authentication_key: ON_CHAIN_AUTH_KEY })
+      .mockResolvedValueOnce({ sequence_number: "0", authentication_key: OTHER_AUTH_KEY });
+    const mainnet = new AptosConfig({ network: Network.MAINNET });
+    const testnet = new AptosConfig({ network: Network.TESTNET });
+    const a = await fetchAndCacheAuthKeyForAddress({ aptosConfig: mainnet, accountAddress: AccountAddress.ONE });
+    const b = await fetchAndCacheAuthKeyForAddress({ aptosConfig: testnet, accountAddress: AccountAddress.ONE });
+    expect(a.toString()).toBe(ON_CHAIN_AUTH_KEY);
+    expect(b.toString()).toBe(OTHER_AUTH_KEY);
+    expect(getInfoSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
### Description
- Renames `authenticationKey` for encrypted transactions to `senderAuthenticationKey` (similarly for fee payer). 
- Adds helper to fetch authentication key from on chain (and cache result).
- Makes `senderAuthenticationKey` optional, fetches form on chain when not present.


### Test Plan
New tests added, all passing