### PR TITLE
ci: add Codecov bundle analysis alongside coverage upload

### DIFF
--- a/.github/actions/run-codecov-bundle/action.yaml
+++ b/.github/actions/run-codecov-bundle/action.yaml
@@ -1,0 +1,29 @@
+name: "Bundle analysis and Codecov upload"
+description: |
+  Install dependencies, build the SDK, and upload bundle stats for `dist/`
+  to Codecov via @codecov/bundle-analyzer. The SDK is tsc-built (no bundler),
+  so the standalone analyzer is the appropriate fit.
+
+inputs:
+  codecov-token:
+    description: Optional Codecov token (tokenless OIDC uploads work for many public repos).
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup-node-pnpm
+    - run: pnpm install --frozen-lockfile
+      shell: bash
+    - name: Build SDK
+      run: pnpm build
+      shell: bash
+    - name: Upload bundle stats to Codecov
+      env:
+        CODECOV_TOKEN: ${{ inputs.codecov-token }}
+      run: |
+        npx --yes @codecov/bundle-analyzer@2.0.1 ./dist \
+          --bundle-name=@aptos-labs/ts-sdk \
+          --upload-token="${CODECOV_TOKEN}"
+      shell: bash

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -10,12 +10,22 @@ permissions:
   contents: read
 
 jobs:
-  upload:
+  upload-coverage:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-codecov
+        with:
+          codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  upload-bundle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/run-codecov-bundle
         with:
           codecov-token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Added
 
+- CI uploads bundle stats for `dist/` to Codecov via `@codecov/bundle-analyzer` (`codecov.yaml` → `.github/actions/run-codecov-bundle`). The SDK is tsc-built with no bundler, so the standalone analyzer is used to produce bundle reports under the `@aptos-labs/ts-sdk` bundle name. Runs as a parallel job alongside the existing coverage upload; both share the `CODECOV_TOKEN` secret.
 - Unambiguous signing/verification API split across `Ed25519`, `Secp256k1`, and `Secp256r1`:
   - `signBytes(message: Uint8Array)` and `signText(message: string)` on each `PrivateKey` class. `signBytes` signs exactly the provided bytes; `signText` UTF-8-encodes the string before signing. No hex/text heuristic — the input type determines the interpretation unambiguously.
   - `verifyBytes({ message: Uint8Array, signature })` and `verifyText({ message: string, signature })` on each `PublicKey` class, mirroring the sign side.


### PR DESCRIPTION
## Summary

- Adds a parallel `upload-bundle` job to `.github/workflows/codecov.yaml` that builds `dist/` and uploads bundle stats to Codecov via `@codecov/bundle-analyzer@2.0.1`. The SDK is tsc-built (no bundler), so the standalone analyzer is the right fit — the bundler plugins (Vite/Webpack/Rollup) don't apply here.
- New composite action `.github/actions/run-codecov-bundle/action.yaml` mirrors the shape of `run-codecov`: setup → install → build → upload.
- Renames the existing job from `upload` → `upload-coverage` for clarity. Both jobs share the same triggers and `CODECOV_TOKEN` secret; bundle uploads also work tokenlessly on public repos via GitHub OIDC.

## Notes

- The bundle name registered with Codecov is `@aptos-labs/ts-sdk` (matches `package.json`).
- `npx --yes @codecov/bundle-analyzer@2.0.1` is version-pinned in the command so CI is reproducible without adding a devDependency consumers would never use.
- No production code changes — CI-only.

## Test plan

- [ ] Confirm the `upload-coverage` job still runs and uploads `lcov.info` as before.
- [ ] Confirm the new `upload-bundle` job runs `pnpm build`, scans `dist/`, and posts bundle stats to Codecov.
- [ ] After merge, verify the bundle dashboard appears in Codecov under the `@aptos-labs/ts-sdk` bundle name.
- [ ] Verify a follow-up PR shows the Codecov bundle status check (PR comment with size delta).