### PR TITLE
Add npm repository metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Fixed
+
+- Added npm repository metadata so package consumers can discover the source repository from the published package.
+
 # 7.1.0 (2026-05-21)
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "bugs": {
     "url": "https://github.com/aptos-labs/aptos-ts-sdk/issues/new/choose"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aptos-labs/aptos-ts-sdk.git"
+  },
   "homepage": "https://aptos-labs.github.io/aptos-ts-sdk/",
   "type": "module",
   "sideEffects": false,


### PR DESCRIPTION
## Summary
- add the package `repository` metadata field for `@aptos-labs/ts-sdk`
- point npm consumers to the public source repository
- add a short changelog entry under Unreleased

## Validation
- `node -e "const p=require('./package.json'); if (p.name !== '@aptos-labs/ts-sdk' || p.repository?.url !== 'git+https://github.com/aptos-labs/aptos-ts-sdk.git') process.exit(1); console.log(JSON.stringify({name:p.name,repository:p.repository}))"`
- `npm pack --dry-run --json --ignore-scripts`
- `git diff --check`

I did not run `pnpm check` because dependencies are not installed in this checkout; this is a package metadata-only change.