### PR TITLE
fix: restore hdKey utilities to main barrel export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Fixed
+
+- Restore HD key derivation utilities (`HARDENED_OFFSET`, `mnemonicToSeed`, `deriveKey`, `CKDPriv`, `splitPath`, `isValidHardenedPath`, `DerivedKeys`) to the main barrel export. These were public API in v5/v6 but were accidentally dropped from `src/core/crypto/index.ts` in the v7 tsc migration (PR #885) when they were grouped with keyless/poseidon utilities. Unlike those, `hdKey.ts` has no poseidon-lite dependency and was already pulled in transitively via `ed25519.ts` and `secp256k1.ts`.
+
 # 7.1.0 (2026-05-21)
 
 ## Added

--- a/src/core/crypto/index.ts
+++ b/src/core/crypto/index.ts
@@ -14,6 +14,7 @@ export * from "./signature.js";
 export * from "./singleKey.js";
 export * from "./types.js";
 export * from "./encryption/index.js";
+export * from "./hdKey.js";
 // NOTE: deserializationUtils is NOT re-exported here because it imports keyless types.
 // Import it directly from "./deserializationUtils.js" when needed.
 
@@ -24,4 +25,3 @@ export * from "./encryption/index.js";
 //   - "./keyless"           (KeylessPublicKey, KeylessSignature, etc.)
 //   - "./federatedKeyless"  (FederatedKeylessPublicKey)
 //   - "./poseidon"          (poseidonHash, hashStrToField, etc.)
-//   - "./hdKey"             (deriveKey, etc.)


### PR DESCRIPTION
`HARDENED_OFFSET`, `mnemonicToSeed`, `deriveKey`, `CKDPriv`, `splitPath`, `isValidHardenedPath`, and `DerivedKeys` were accidentally dropped from the main barrel in the v7 tsc migration (PR #885) — they were grouped with keyless/poseidon in the "intentionally not re-exported" comment, but unlike those, `hdKey.ts` has no poseidon-lite dependency and was already pulled in transitively via `ed25519.ts` and `secp256k1.ts`. This was a regression for any consumer (e.g. `@aptos-labs/confidential-asset`) that imported these from `@aptos-labs/ts-sdk`.

### Test Plan
- `pnpm build` — clean compile
- `pnpm check` — Biome clean

### Related Links
- Blocked follow-up: upgrade `@aptos-labs/confidential-asset` devDep to `^7.0.0`

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?