### PR TITLE
fix(cli): resolve CodeQL "Unsafe shell command constructed from library input"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 ## Fixed
 
+- Resolve the CodeQL "Unsafe shell command constructed from library input" alert for the Move/LocalNode CLI helpers. The existing `assertSafeCliArg` validation rejected shell metacharacters but ran in a separate function, so CodeQL still tracked library input into the `spawn(..., { shell: true })` call used on Windows. CLI arguments are now both validated and scrubbed via `sanitizeCliArg`/`sanitizeCliArgs` (a `String.prototype.replace` chain covering every shell metacharacter) before being passed to `spawn`. Validation continues to throw on unsafe input, so the scrub is a runtime no-op; the validation blocklist now also covers `#`, `[`, and `]`.
 - Skip the `installs jwks for a firebase iss` e2e test. It installs the Firebase issuer's live JWK set fetched from Google's shared `securetoken@system.gserviceaccount.com` endpoint, which now publishes 5 RSA keys. The resulting `0x1::jwks::update_federated_jwk_set` resource serializes to ~2158 bytes, exceeding the on-chain `MAX_FEDERATED_JWKS_SIZE_BYTES` limit of 2 KiB and aborting with `EFEDERATED_JWKS_TOO_LARGE`. The test depends on the live endpoint, so it is skipped until the key set fits within the on-chain budget (or the SDK handles oversized sets explicitly).
 
 # 7.1.2 (2026-06-17)

--- a/src/cli/localNode.ts
+++ b/src/cli/localNode.ts
@@ -3,7 +3,7 @@ import kill from "tree-kill";
 import { platform } from "node:os";
 
 import { sleep } from "../utils/helpers.js";
-import { assertSafeCliArgs } from "./spawnArgs.js";
+import { sanitizeCliArgs } from "./spawnArgs.js";
 
 /**
  * Represents a local node for running a localnet environment.
@@ -87,14 +87,13 @@ export class LocalNode {
    * @category CLI
    */
   start(): void {
-    // Reject shell-metacharacter-bearing extras up front. On Windows we have
-    // to spawn with `shell: true` (npx is a .cmd shim and Node refuses to
-    // spawn .cmd/.bat without the shell since CVE-2024-27980), so unsafe
-    // characters in extraArgs would otherwise be interpreted by cmd.exe.
-    assertSafeCliArgs(this.extraArgs);
-
+    // Reject shell-metacharacter-bearing extras up front and pass the scrubbed
+    // copy to `spawn`. On Windows we have to spawn with `shell: true` (npx is a
+    // .cmd shim and Node refuses to spawn .cmd/.bat without the shell since
+    // CVE-2024-27980), so unsafe characters in extraArgs would otherwise be
+    // interpreted by cmd.exe.
     const cliCommand = "npx";
-    const cliArgs = [
+    const cliArgs = sanitizeCliArgs([
       "aptos",
       "node",
       "run-localnet",
@@ -102,7 +101,7 @@ export class LocalNode {
       "--assume-yes",
       "--with-indexer-api",
       ...this.extraArgs,
-    ];
+    ]);
 
     const currentPlatform = platform();
     const spawnConfig = {

--- a/src/cli/move.ts
+++ b/src/cli/move.ts
@@ -3,7 +3,7 @@ import { platform } from "node:os";
 
 import { AccountAddress } from "../core/index.js";
 import { Network } from "../utils/index.js";
-import { assertSafeCliArgs } from "./spawnArgs.js";
+import { sanitizeCliArgs } from "./spawnArgs.js";
 
 /**
  * Class representing a Move package management utility for the Aptos blockchain.
@@ -356,18 +356,18 @@ export class Move {
    */
 
   private async runCommand(args: Array<string>, showStdout: boolean = true): Promise<{ result?: any; output: string }> {
-    // Reject shell-metacharacter-bearing args up front. On Windows we have to
-    // spawn with `shell: true` (npx is a .cmd shim and Node refuses to spawn
-    // .cmd/.bat without the shell since CVE-2024-27980), so unsafe characters
-    // in args would otherwise be interpreted by cmd.exe. We validate on all
-    // platforms for consistency — extraArguments shouldn't contain shell
-    // metacharacters regardless of OS.
-    assertSafeCliArgs(args);
+    // Reject shell-metacharacter-bearing args up front and pass the scrubbed
+    // copy to `spawn`. On Windows we have to spawn with `shell: true` (npx is a
+    // .cmd shim and Node refuses to spawn .cmd/.bat without the shell since
+    // CVE-2024-27980), so unsafe characters in args would otherwise be
+    // interpreted by cmd.exe. We validate on all platforms for consistency —
+    // extraArguments shouldn't contain shell metacharacters regardless of OS.
+    const safeArgs = sanitizeCliArgs(args);
 
     return new Promise((resolve, reject) => {
       const isWindows = platform() === "win32";
       const spawnOptions = isWindows ? { shell: true } : undefined;
-      const childProcess = spawn("npx", args, spawnOptions);
+      const childProcess = spawn("npx", safeArgs, spawnOptions);
       let stdout = "";
       // CLI final stdout is the Result/Error JSON string output
       // so we need to keep track of the last stdout

--- a/src/cli/spawnArgs.ts
+++ b/src/cli/spawnArgs.ts
@@ -25,7 +25,7 @@
  * Common, legitimate CLI argument characters (letters, digits, `-`, `_`,
  * `=`, `.`, `,`, `:`, `/`, `\`, space) are unaffected.
  */
-const UNSAFE_SHELL_CHARS = /[&|;<>`$()"'\n\r^!*?%]/;
+const UNSAFE_SHELL_CHARS = /[&|;<>`$()[\]#"'\n\r^!*?%]/;
 
 /**
  * Validates that a CLI argument does not contain shell metacharacters that
@@ -40,7 +40,7 @@ export function assertSafeCliArg(arg: string): void {
   if (UNSAFE_SHELL_CHARS.test(arg)) {
     throw new Error(
       `CLI argument contains characters that could be interpreted by the shell: ${JSON.stringify(arg)}. ` +
-        "Remove shell metacharacters (& | ; < > \" ' ` $ ( ) ^ ! * ? % newlines).",
+        "Remove shell metacharacters (& | ; < > \" ' ` $ ( ) [ ] # ^ ! * ? % newlines).",
     );
   }
 }
@@ -52,4 +52,47 @@ export function assertSafeCliArgs(args: ReadonlyArray<string>): void {
   for (const arg of args) {
     assertSafeCliArg(arg);
   }
+}
+
+/**
+ * Validates a single CLI argument and returns a copy with any shell
+ * metacharacters stripped out.
+ *
+ * {@link assertSafeCliArg} already rejects every shell metacharacter, so the
+ * scrubbing chain below is a runtime no-op for any argument that passes
+ * validation. We keep it as defense-in-depth and, importantly, so that static
+ * analysis (e.g. CodeQL's "Unsafe shell command constructed from library
+ * input" query) can see that the value flowing into `spawn(..., { shell: true })`
+ * on Windows has been stripped of shell metacharacters. CodeQL only recognizes
+ * a sequence of `String.prototype.replace` calls that covers every shell
+ * metacharacter as a sanitizer barrier; a `RegExp.test`-based guard in a
+ * separate function is not enough to break the tracked data flow.
+ *
+ * @returns the validated argument with shell metacharacters removed.
+ * @throws Error if `arg` contains any unsafe shell character.
+ */
+export function sanitizeCliArg(arg: string): string {
+  assertSafeCliArg(arg);
+  return arg
+    .replace(/&/g, "")
+    .replace(/`/g, "")
+    .replace(/\$/g, "")
+    .replace(/\|/g, "")
+    .replace(/>/g, "")
+    .replace(/</g, "")
+    .replace(/#/g, "")
+    .replace(/;/g, "")
+    .replace(/\(/g, "")
+    .replace(/\)/g, "")
+    .replace(/\[/g, "")
+    .replace(/\]/g, "")
+    .replace(/\n/g, "");
+}
+
+/**
+ * Validates and scrubs every element of an args array, returning the sanitized
+ * array that should be passed to `spawn`. See {@link sanitizeCliArg}.
+ */
+export function sanitizeCliArgs(args: ReadonlyArray<string>): string[] {
+  return args.map(sanitizeCliArg);
 }

--- a/src/cli/spawnArgs.ts
+++ b/src/cli/spawnArgs.ts
@@ -68,6 +68,10 @@ export function assertSafeCliArgs(args: ReadonlyArray<string>): void {
  * metacharacter as a sanitizer barrier; a `RegExp.test`-based guard in a
  * separate function is not enough to break the tracked data flow.
  *
+ * The chain strips every character that {@link UNSAFE_SHELL_CHARS}/
+ * {@link assertSafeCliArg} reject, so the scrub is a complete superset of the
+ * validation blocklist rather than only the subset CodeQL requires.
+ *
  * @returns the validated argument with shell metacharacters removed.
  * @throws Error if `arg` contains any unsafe shell character.
  */
@@ -75,18 +79,26 @@ export function sanitizeCliArg(arg: string): string {
   assertSafeCliArg(arg);
   return arg
     .replace(/&/g, "")
+    .replace(/\|/g, "")
+    .replace(/;/g, "")
+    .replace(/</g, "")
+    .replace(/>/g, "")
     .replace(/`/g, "")
     .replace(/\$/g, "")
-    .replace(/\|/g, "")
-    .replace(/>/g, "")
-    .replace(/</g, "")
-    .replace(/#/g, "")
-    .replace(/;/g, "")
     .replace(/\(/g, "")
     .replace(/\)/g, "")
     .replace(/\[/g, "")
     .replace(/\]/g, "")
-    .replace(/\n/g, "");
+    .replace(/#/g, "")
+    .replace(/"/g, "")
+    .replace(/'/g, "")
+    .replace(/\^/g, "")
+    .replace(/!/g, "")
+    .replace(/\*/g, "")
+    .replace(/\?/g, "")
+    .replace(/%/g, "")
+    .replace(/\n/g, "")
+    .replace(/\r/g, "");
 }
 
 /**

--- a/tests/unit/cli-spawnArgs.test.ts
+++ b/tests/unit/cli-spawnArgs.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, it } from "vitest";
-import { assertSafeCliArg, assertSafeCliArgs } from "../../src/cli/spawnArgs.js";
+import { assertSafeCliArg, assertSafeCliArgs, sanitizeCliArg, sanitizeCliArgs } from "../../src/cli/spawnArgs.js";
 
 describe("assertSafeCliArg", () => {
   it("accepts typical CLI argument shapes", () => {
@@ -40,6 +40,9 @@ describe("assertSafeCliArg", () => {
     ["glob question", "foo?"],
     ["cmd.exe env-var expansion", "foo%USERPROFILE%bar"],
     ["cmd.exe single percent", "foo%bar"],
+    ["hash", "foo#bar"],
+    ["open bracket", "foo[bar"],
+    ["close bracket", "foo]bar"],
   ])("rejects shell metacharacter (%s)", (_label, arg) => {
     expect(() => assertSafeCliArg(arg)).toThrow(/shell/);
   });
@@ -57,5 +60,41 @@ describe("assertSafeCliArgs", () => {
 
   it("rejects when any element is unsafe", () => {
     expect(() => assertSafeCliArgs(["aptos", "node", "& calc.exe"])).toThrow(/shell/);
+  });
+});
+
+describe("sanitizeCliArg", () => {
+  it("returns safe args unchanged", () => {
+    const safe = [
+      "--assume-yes",
+      "--gas-unit-price=10",
+      "--named-addresses",
+      "alice=0x123,bob=0x456",
+      "/abs/path/to/package",
+      "C:\\Program\\Files\\package",
+      "0xdeadbeef",
+      "node",
+      "run-localnet",
+      "",
+    ];
+    for (const arg of safe) {
+      expect(sanitizeCliArg(arg)).toBe(arg);
+    }
+  });
+
+  it("throws on unsafe args rather than silently scrubbing them", () => {
+    expect(() => sanitizeCliArg("foo & calc.exe")).toThrow(/shell/);
+    expect(() => sanitizeCliArg("foo#bar")).toThrow(/shell/);
+  });
+});
+
+describe("sanitizeCliArgs", () => {
+  it("returns an array of safe args unchanged", () => {
+    const args = ["aptos", "node", "run-localnet", "--assume-yes"];
+    expect(sanitizeCliArgs(args)).toEqual(args);
+  });
+
+  it("throws when any element is unsafe", () => {
+    expect(() => sanitizeCliArgs(["aptos", "node", "& calc.exe"])).toThrow(/shell/);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

CodeQL's `js/shell-command-constructed-from-input` query ("Unsafe shell command constructed from library input") flagged the Move and LocalNode CLI helpers:

> This shell argument which depends on library input is later used in a shell command.

On Windows we must spawn with `{ shell: true }` because `npx` resolves to `npx.cmd` and Node.js refuses to spawn `.cmd`/`.bat` shims without a shell since the CVE‑2024‑27980 mitigation. That makes the `args` array a shell sink, and the values come from exported function parameters (library input).

The repo already had `assertSafeCliArg`, which rejects shell metacharacters via a `RegExp.test` guard. However, that validation lives in a **separate function** that returns `void`, so it does not break the data‑flow path CodeQL tracks from the library input into `spawn(...)`. CodeQL's `UnsafeShellCommandConstruction` query only recognizes a specific set of sanitizer barriers — notably a `String.prototype.replace` chain that covers every shell metacharacter — and a throwing `RegExp.test` guard in another function is not one of them.

## Fix

Introduce `sanitizeCliArg` / `sanitizeCliArgs` in `src/cli/spawnArgs.ts`. They:

1. Call the existing `assertSafeCliArg` validation (still throws on unsafe input — same UX and primary defense).
2. Return a scrubbed copy produced by a chained `String.prototype.replace` over every shell metacharacter (`& \` $ | > < # ; ( ) [ ] \n`), which CodeQL recognizes as a sanitizer barrier.

`src/cli/move.ts` and `src/cli/localNode.ts` now pass the **sanitized** array to `spawn`, so the tracked value reaching the shell sink has passed through the recognized barrier.

Because validation throws before the scrub runs, the scrub is a runtime no‑op for any argument that passes validation. To guarantee the scrub never silently mutates a valid argument, the validation blocklist now also rejects `#`, `[`, and `]` (so the rejected set is a superset of the scrubbed set).

## Notes

- Behavior is unchanged for valid inputs: `sanitizeCliArg(arg) === arg` for any argument that passes validation.
- `shell: true` on Windows is retained — it is required for `npx.cmd` and cannot be removed.

## Testing

- `pnpm check` (Biome lint + format) — clean
- `pnpm build` (tsc) — clean
- `pnpm unit-test cli-spawnArgs` — 27 tests pass (added coverage for `sanitizeCliArg`/`sanitizeCliArgs` and the newly rejected `#`, `[`, `]` characters)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ec060165-e578-4e2a-9cc0-1a1e760fa99c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ec060165-e578-4e2a-9cc0-1a1e760fa99c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

