### PR TITLE
ci: update pinned GitHub Actions to latest releases older than 3 days

### DIFF
--- a/.github/actions/run-bun-tests/action.yaml
+++ b/.github/actions/run-bun-tests/action.yaml
@@ -8,7 +8,7 @@ runs:
     - uses: ./.github/actions/setup-node-pnpm
 
     # Install Bun
-    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # pin@v2
+    - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # pin@v2.2.0
       with:
         bun-version: latest
 
@@ -36,7 +36,7 @@ runs:
       shell: bash
 
     # Run the Bun tests
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # pin@v4.0.0
       name: bun-sdk-tests
       env:
         TMPDIR: ${{ runner.temp }}

--- a/.github/actions/run-check-version/action.yaml
+++ b/.github/actions/run-check-version/action.yaml
@@ -6,11 +6,11 @@ runs:
   using: composite
   steps:
     # Install node and pnpm.
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # pin@v6
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # pin@v6.4.0
       with:
         node-version-file: .node-version
         registry-url: "https://registry.npmjs.org"
-    - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # pin@v4
+    - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # pin@v6.0.9
 
     # Run version check
     - run: pnpm check-version

--- a/.github/actions/run-codecov/action.yaml
+++ b/.github/actions/run-codecov/action.yaml
@@ -18,7 +18,7 @@ runs:
       run: pnpm run test:coverage:unit
       shell: bash
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@1e68e06f1dbfde0e4cefc87efeba9e4643565303 # pin@v5.1.2
+      uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # pin@v5.5.5
       with:
         token: ${{ inputs.codecov-token }}
         files: coverage/lcov.info

--- a/.github/actions/run-confidential-asset-tests/action.yaml
+++ b/.github/actions/run-confidential-asset-tests/action.yaml
@@ -23,7 +23,7 @@ runs:
       shell: bash
 
     # Run the Confidential Asset tests.
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # pin@v4.0.0
       name: confidential-asset-pnpm-test
       env:
         # This is important, it ensures that the tempdir we create for cloning the ANS
@@ -41,7 +41,7 @@ runs:
       shell: bash
 
     # Run the Confidential Asset browser tests (unit tests only, no localnet needed).
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # pin@v4.0.0
       name: confidential-asset-browser-test
       with:
         max_attempts: 3

--- a/.github/actions/run-deno-tests/action.yaml
+++ b/.github/actions/run-deno-tests/action.yaml
@@ -37,7 +37,7 @@ runs:
       shell: bash
 
     # Run the Deno tests
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # pin@v4.0.0
       name: deno-sdk-tests
       env:
         TMPDIR: ${{ runner.temp }}

--- a/.github/actions/run-examples/action.yaml
+++ b/.github/actions/run-examples/action.yaml
@@ -33,7 +33,7 @@ runs:
       shell: bash
 
     # Run the typescript examples
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # pin@v4.0.0
       name: sdk-pnpm-examples
       env:
         # This is important, it ensures that the tempdir we create for cloning the ANS
@@ -55,7 +55,7 @@ runs:
         echo "::endgroup::"
 
     # Run the javascript examples
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # pin@v4.0.0
       name: sdk-pnpm-examples
       env:
         # This is important, it ensures that the tempdir we create for cloning the ANS

--- a/.github/actions/run-tests/action.yaml
+++ b/.github/actions/run-tests/action.yaml
@@ -16,7 +16,7 @@ runs:
       shell: bash
 
     # Run the TS SDK tests.
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # pin@v4.0.0
       name: sdk-pnpm-test
       env:
         # This is important, it ensures that the tempdir we create for cloning the ANS

--- a/.github/actions/run-web-tests/action.yaml
+++ b/.github/actions/run-web-tests/action.yaml
@@ -39,7 +39,7 @@ runs:
       shell: bash
 
     # Run the browser tests
-    - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3
+    - uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # pin@v4.0.0
       name: browser-sdk-tests
       env:
         TMPDIR: ${{ runner.temp }}
@@ -60,7 +60,7 @@ runs:
         echo "::endgroup::"
 
     - name: Upload Playwright report on failure
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7.0.1
       if: failure()
       with:
         name: playwright-report

--- a/.github/actions/setup-node-pnpm/action.yaml
+++ b/.github/actions/setup-node-pnpm/action.yaml
@@ -7,13 +7,13 @@ runs:
   using: composite
   steps:
     - name: Setup Node
-      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # pin@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # pin@v6.4.0
       with:
         node-version-file: .node-version
         registry-url: "https://registry.npmjs.org"
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # pin@v4
+      uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # pin@v6.0.9
 
     - name: Add local package binaries to PATH
       run: echo "${GITHUB_WORKSPACE}/node_modules/.bin" >> "${GITHUB_PATH}"
@@ -24,4 +24,4 @@ runs:
       run: echo "SAFE_CHAIN_MINIMUM_PACKAGE_AGE_EXCLUSIONS=@aptos-labs/*" >> "${GITHUB_ENV}"
 
     - name: Setup AikidoSec Safe Chain
-      uses: aptos-labs/actions/aikidosec-safe-chain@528ef7ad9427a8c0720ea3eea790a9190d6e377d # pin@main
+      uses: aptos-labs/actions/aikidosec-safe-chain@fdd3a3a628c840d5c35086a87e9cc3141b635505 # pin@main

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -13,7 +13,7 @@ jobs:
   upload-coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-codecov
@@ -23,7 +23,7 @@ jobs:
   upload-bundle:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-codecov-bundle

--- a/.github/workflows/run-build.yaml
+++ b/.github/workflows/run-build.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-build

--- a/.github/workflows/run-bun-tests.yaml
+++ b/.github/workflows/run-bun-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-bun-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-bun-tests

--- a/.github/workflows/run-check-version.yaml
+++ b/.github/workflows/run-check-version.yaml
@@ -14,7 +14,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-check-version

--- a/.github/workflows/run-confidential-asset-tests.yaml
+++ b/.github/workflows/run-confidential-asset-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-confidential-asset-tests

--- a/.github/workflows/run-deno-tests.yaml
+++ b/.github/workflows/run-deno-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-deno-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-deno-tests

--- a/.github/workflows/run-examples.yaml
+++ b/.github/workflows/run-examples.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-examples

--- a/.github/workflows/run-fmt.yaml
+++ b/.github/workflows/run-fmt.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-fmt

--- a/.github/workflows/run-lint.yaml
+++ b/.github/workflows/run-lint.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-lint

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-tests

--- a/.github/workflows/run-web-tests.yaml
+++ b/.github/workflows/run-web-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-web-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-web-tests

--- a/.github/workflows/run-windows-tests.yaml
+++ b/.github/workflows/run-windows-tests.yaml
@@ -13,7 +13,7 @@ jobs:
   run-windows-tests:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
         with:
           persist-credentials: false
       - uses: ./.github/actions/run-windows-build-and-unit-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Changed
+
+- Update pinned GitHub Actions to the latest releases older than 3 days: `actions/checkout` v7.0.0, `pnpm/action-setup` v6.0.9, `actions/upload-artifact` v7.0.1, `nick-fields/retry` v4.0.0, `codecov/codecov-action` v5.5.5, and `aptos-labs/actions/aikidosec-safe-chain` (main). `actions/setup-node` v6.4.0, `oven-sh/setup-bun` v2.2.0, and `denoland/setup-deno` v2.0.4 were already current.
+
 # 7.1.3 (2026-06-23)
 
 ## Changed


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

All external GitHub Actions were already pinned to full SHA hashes with `# pin@<version>` comments. This PR updates them to the most recent release published before **2026-06-29** (a 3-day safety window from today).

## Updated actions

| Action | Previous | Updated to |
|--------|----------|------------|
| `actions/checkout` | v6 | **v7.0.0** |
| `pnpm/action-setup` | v4 | **v6.0.9** |
| `actions/upload-artifact` | v4 | **v7.0.1** |
| `nick-fields/retry` | v3 | **v4.0.0** |
| `codecov/codecov-action` | v5.1.2 | **v5.5.5** |
| `aptos-labs/actions/aikidosec-safe-chain` | older main | **latest main** |

## Already current (no SHA change)

- `actions/setup-node` v6.4.0
- `oven-sh/setup-bun` v2.2.0
- `denoland/setup-deno` v2.0.4

## Verification

Validated that every external `uses:` reference in `.github/` resolves to a 40-character SHA (no tag-based refs remain).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f22a0-af59-7aa5-94e9-4ea65011642e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f22a0-af59-7aa5-94e9-4ea65011642e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

