### PR TITLE
feat(keyless): add aptos.keyless.getPepperBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Added
+
+- `aptos.keyless.getPepperBase(...)` fetches a keyless account's `pepper_base` (the 48-byte VUF signature / compressed BLS12-381 G1 point from which the final pepper is derived) from the pepper service's `signature` endpoint. Unlike `getPepper` (which returns the 31-byte derived pepper), `pepper_base` is independent of the ephemeral key and the derivation path, making it a stable per-identity seed. It is the seed for the confidential-asset keyless decryption-key derivation (`@aptos-labs/confidential-asset`'s `TwistedEd25519PrivateKey.fromPepperBase`); deriving from `pepper_base` rather than the final pepper ensures a leaked pepper cannot recover the decryption key.
+
 ## Changed
 
 - Update pinned GitHub Actions to the latest releases older than 3 days: `actions/checkout` v7.0.0, `pnpm/action-setup` v6.0.9, `actions/upload-artifact` v7.0.1, `nick-fields/retry` v4.0.0, `codecov/codecov-action` v5.5.5, and `aptos-labs/actions/aikidosec-safe-chain` (main). `actions/setup-node` v6.4.0, `oven-sh/setup-bun` v2.2.0, and `denoland/setup-deno` v2.0.4 were already current.

--- a/src/api/keyless.ts
+++ b/src/api/keyless.ts
@@ -11,6 +11,7 @@ import { ZeroKnowledgeSig } from "../core/crypto/keyless.js";
 import {
   deriveKeylessAccount,
   getPepper,
+  getPepperBase,
   getProof,
   updateFederatedKeylessJwkSetTransaction,
 } from "../internal/keyless.js";
@@ -91,6 +92,34 @@ export class Keyless {
     derivationPath?: string;
   }): Promise<Uint8Array> {
     return getPepper({ aptosConfig: this.config, ...args });
+  }
+
+  /**
+   * Fetches the `pepper_base` from the Aptos pepper service API.
+   *
+   * The `pepper_base` is the VUF signature from which the final pepper is derived — a 48-byte compressed
+   * BLS12-381 G1 point. It is deterministic for a given OIDC identity and independent of the ephemeral key
+   * and derivation path, making it a stable seed for deriving a confidential-asset decryption key (DK) via
+   * `@aptos-labs/confidential-asset`'s `TwistedEd25519PrivateKey.fromPepperBase`. Deriving the DK from
+   * `pepper_base` (rather than the final pepper, which is a one-way hash of it) ensures a leaked pepper does
+   * not compromise confidentiality.
+   *
+   * @param args - The arguments for fetching the pepper base.
+   * @param args.jwt - JWT token.
+   * @param args.ephemeralKeyPair - The EphemeralKeyPair used to generate the nonce in the JWT token.
+   * @param args.uidKey - An optional key in the JWT token to use to set the uidVal in the IdCommitment.
+   * @param args.derivationPath - A derivation path used for creating multiple accounts per user via the
+   * BIP-44 standard. Note: `pepper_base` itself does not depend on the derivation path.
+   * @returns The `pepper_base` as a Uint8Array of length 48.
+   * @group Keyless
+   */
+  async getPepperBase(args: {
+    jwt: string;
+    ephemeralKeyPair: EphemeralKeyPair;
+    uidKey?: string;
+    derivationPath?: string;
+  }): Promise<Uint8Array> {
+    return getPepperBase({ aptosConfig: this.config, ...args });
   }
 
   /**

--- a/src/internal/keyless.ts
+++ b/src/internal/keyless.ts
@@ -27,7 +27,13 @@ import { Account } from "../account/index.js";
 import { EphemeralKeyPair } from "../account/EphemeralKeyPair.js";
 import { KeylessAccount } from "../account/KeylessAccount.js";
 import { ProofFetchCallback } from "../account/AbstractKeylessAccount.js";
-import { PepperFetchRequest, PepperFetchResponse, ProverRequest, ProverResponse } from "../types/keyless.js";
+import {
+  PepperFetchRequest,
+  PepperFetchResponse,
+  ProverRequest,
+  ProverResponse,
+  SignatureFetchResponse,
+} from "../types/keyless.js";
 import { lookupOriginalAccountAddress } from "./account.js";
 import { FederatedKeylessPublicKey } from "../core/crypto/federatedKeyless.js";
 import { FederatedKeylessAccount } from "../account/FederatedKeylessAccount.js";
@@ -74,6 +80,52 @@ export async function getPepper(args: {
     overrides: { WITH_CREDENTIALS: false },
   });
   return Hex.fromHexInput(data.pepper).toUint8Array();
+}
+
+/**
+ * Retrieves the `pepper_base` for an account — the VUF signature from which the final pepper is derived.
+ *
+ * Unlike {@link getPepper} (which hits the pepper service `fetch` endpoint and returns the 31-byte derived
+ * pepper), this hits the `signature` endpoint and returns the raw 48-byte `pepper_base` (a compressed
+ * BLS12-381 G1 point). `pepper_base` is deterministic for a given OIDC identity, independent of the ephemeral
+ * key and of the derivation path, which makes it a stable seed for deriving a confidential-asset decryption
+ * key (see `@aptos-labs/confidential-asset`'s `TwistedEd25519PrivateKey.fromPepperBase`). Deriving secrets
+ * from `pepper_base` rather than the final pepper also ensures a leaked pepper does not compromise them.
+ *
+ * @param args - The arguments required to fetch the pepper base.
+ * @param args.aptosConfig - The configuration object for Aptos.
+ * @param args.jwt - The JSON Web Token used for authentication.
+ * @param args.ephemeralKeyPair - The ephemeral key pair used for the operation.
+ * @param args.uidKey - An optional unique identifier key (defaults to "sub").
+ * @param args.derivationPath - An optional derivation path for the key.
+ * @returns A Uint8Array containing the 48-byte `pepper_base`.
+ * @group Implementation
+ */
+export async function getPepperBase(args: {
+  aptosConfig: AptosConfig;
+  jwt: string;
+  ephemeralKeyPair: EphemeralKeyPair;
+  uidKey?: string;
+  derivationPath?: string;
+}): Promise<Uint8Array> {
+  const { aptosConfig, jwt, ephemeralKeyPair, uidKey = "sub", derivationPath } = args;
+
+  const body = {
+    jwt_b64: jwt,
+    epk: ephemeralKeyPair.getPublicKey().bcsToHex().toStringWithoutPrefix(),
+    exp_date_secs: ephemeralKeyPair.expiryDateSecs,
+    epk_blinder: Hex.fromHexInput(ephemeralKeyPair.blinder).toStringWithoutPrefix(),
+    uid_key: uidKey,
+    derivation_path: derivationPath,
+  };
+  const { data } = await postAptosPepperService<PepperFetchRequest, SignatureFetchResponse>({
+    aptosConfig,
+    path: "signature",
+    body,
+    originMethod: "getPepperBase",
+    overrides: { WITH_CREDENTIALS: false },
+  });
+  return Hex.fromHexInput(data.signature).toUint8Array();
 }
 
 /**

--- a/src/types/keyless.ts
+++ b/src/types/keyless.ts
@@ -46,6 +46,14 @@ export type PepperFetchRequest = {
 export type PepperFetchResponse = { pepper: string; address: string };
 
 /**
+ * The response from the pepper service `signature` endpoint, containing the VUF signature — i.e. the
+ * 48-byte `pepper_base` (compressed BLS12-381 G1 point) from which the final pepper is derived.
+ * @group Implementation
+ * @category Types
+ */
+export type SignatureFetchResponse = { signature: string };
+
+/**
  * The response for keyless configuration containing the maximum committed EPK bytes.
  * @group Implementation
  * @category Types

--- a/tests/unit/internal/keyless-pepper.test.ts
+++ b/tests/unit/internal/keyless-pepper.test.ts
@@ -12,7 +12,7 @@ import { createMockClient, expectRequest } from "../../helpers/mockClient.js";
 import { Network } from "../../../src/utils/apiEndpoints.js";
 import { EphemeralKeyPair } from "../../../src/account/EphemeralKeyPair.js";
 import { Ed25519PrivateKey } from "../../../src/core/crypto/ed25519.js";
-import { getPepper, getProof } from "../../../src/internal/keyless.js";
+import { getPepper, getPepperBase, getProof } from "../../../src/internal/keyless.js";
 
 function makeEphemeral(): EphemeralKeyPair {
   const sk = new Ed25519PrivateKey(new Uint8Array(32).fill(0x33));
@@ -70,6 +70,58 @@ describe("internal/keyless.getPepper", () => {
     mock.enqueue({ data: { pepper: `0x${"00".repeat(31)}` } });
 
     await getPepper({
+      aptosConfig: mock.config,
+      jwt: "x",
+      ephemeralKeyPair: makeEphemeral(),
+      uidKey: "email",
+      derivationPath: "m/44'/637'/0'/0'",
+    });
+
+    const body = mock.requests[0]?.body as { uid_key: string; derivation_path: string };
+    expect(body.uid_key).toBe("email");
+    expect(body.derivation_path).toBe("m/44'/637'/0'/0'");
+  });
+});
+
+describe("internal/keyless.getPepperBase", () => {
+  const mockOpts = { network: Network.DEVNET as const, pepper: "https://pepper.example/v0" };
+
+  it("POSTs to the `signature` endpoint and returns the 48-byte pepper_base", async () => {
+    const mock = createMockClient(mockOpts);
+    // 48-byte pepper_base (compressed BLS12-381 G1 point length).
+    const signatureHex = `0x${"cd".repeat(48)}`;
+    mock.enqueue({ data: { signature: signatureHex } });
+
+    const pepperBase = await getPepperBase({
+      aptosConfig: mock.config,
+      jwt: "ignored-here-because-no-decoding-happens",
+      ephemeralKeyPair: makeEphemeral(),
+    });
+
+    expect(pepperBase).toBeInstanceOf(Uint8Array);
+    expect(pepperBase.length).toBe(48);
+
+    const body = mock.requests[0]?.body as {
+      jwt_b64: string;
+      epk: string;
+      exp_date_secs: number;
+      epk_blinder: string;
+      uid_key: string;
+      derivation_path: undefined | string;
+    };
+    expect(body.jwt_b64).toBe("ignored-here-because-no-decoding-happens");
+    expect(body.uid_key).toBe("sub"); // default
+    expect(body.epk).toMatch(/^[0-9a-f]+$/i);
+    expect(typeof body.exp_date_secs).toBe("number");
+
+    expectRequest(mock.requests[0], { method: "POST", originMethod: "getPepperBase", urlIncludes: "signature" });
+  });
+
+  it("forwards a custom uidKey and derivationPath", async () => {
+    const mock = createMockClient(mockOpts);
+    mock.enqueue({ data: { signature: `0x${"00".repeat(48)}` } });
+
+    await getPepperBase({
       aptosConfig: mock.config,
       jwt: "x",
       ephemeralKeyPair: makeEphemeral(),


### PR DESCRIPTION
### Description

Adds `aptos.keyless.getPepperBase(...)` — fetches a keyless account's 48-byte `pepper_base` (the VUF signature / compressed BLS12-381 G1 point from which the final pepper is derived) from the pepper service's existing `signature` endpoint. It complements `getPepper`, which returns the 31-byte derived pepper.

Unlike the final pepper, `pepper_base` is independent of the ephemeral key and the derivation path, so it's a stable per-identity seed. It is the seed for the confidential-asset keyless decryption-key (DK) derivation (`@aptos-labs/confidential-asset`'s `TwistedEd25519PrivateKey.fromPepperBase`). Deriving the DK from `pepper_base` rather than the final pepper (a one-way hash of it) ensures a leaked pepper cannot recover the DK.

No server/aptos-core change is required — the `/v0/signature` endpoint already exists; this only adds the SDK client for it:
- `SignatureFetchResponse` type (`src/types/keyless.ts`)
- internal `getPepperBase` posting to `path: "signature"` (`src/internal/keyless.ts`)
- public `Keyless.getPepperBase` (`src/api/keyless.ts`)

### Test Plan

- Unit tests in `tests/unit/internal/keyless-pepper.test.ts` (mirroring `getPepper`): assert `getPepperBase` POSTs to the `signature` endpoint, returns a 48-byte value, and forwards `uidKey`/`derivationPath`.
- Manually validated against the live **devnet and mainnet** pepper services with the `test.oidc.provider` fixture: `getPepperBase` returns a real 48-byte `pepper_base`, and the same request's `getPepper` returns the known test-issuer pepper (`0x7727…56c`).
- `pnpm build` and `pnpm check` pass.

### Related Links

- Consumer: `@aptos-labs/confidential-asset` `TwistedEd25519PrivateKey.fromPepperBase` (keyless DK derivation).
- aptos-core confidential-assets keyless integration (PR #19458).

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
