### PR TITLE
feat: automate TS SDK releases (script + skill + NPM publish workflow)

### DIFF
--- a/.claude/skills/release-ts-sdk/SKILL.md
+++ b/.claude/skills/release-ts-sdk/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: release-ts-sdk
+description: Use when cutting a release of @aptos-labs/ts-sdk or @aptos-labs/confidential-asset. Phase 1 bumps the version, stamps the changelog, and opens the release PR. Phase 2 (after the PR merges to main) cuts the tag and GitHub Release that triggers the NPM publish workflow.
+---
+
+# Releasing the Aptos TypeScript SDK
+
+Two packages release independently:
+
+- `@aptos-labs/ts-sdk` (repo root) — tag prefix `ts-sdk-v`
+- `@aptos-labs/confidential-asset` (`confidential-asset/`) — tag prefix `confidential-asset-v`
+
+All mechanical work is done by `scripts/prepareRelease.mjs`. Publishing to NPM is done by
+`.github/workflows/publish.yaml` when a GitHub Release is published — never publish by hand.
+
+## Preconditions
+
+- Working tree clean, on an up-to-date `main`.
+- The target package's `# Unreleased` changelog section already lists the changes being released.
+  If it is empty, stop and ask the maintainer to fill it in first (the script will refuse otherwise).
+
+## Phase 1 — prepare the release PR
+
+1. Ask which package (`ts-sdk` or `confidential-asset`) unless it is obvious from context.
+2. Ask the bump type: `major`, `minor`, or `patch`. For a **major** bump, remind the maintainer to
+   write an upgrade guide at `upgrade-guides/UPGRADE_GUIDE_X.Y.Z.md` and reference it in the changelog.
+3. Determine the new version without mutating anything yet: read `version` from the package's
+   `package.json` (`.` for ts-sdk, `confidential-asset/` for confidential-asset) and apply the bump.
+4. Create a release branch: `git checkout -b release/<pkg>-v<newVersion>`.
+5. Run the prep script:
+   - `node scripts/prepareRelease.mjs --package <pkg> --bump <type>`
+6. Validate:
+   - `pnpm check`
+   - For `ts-sdk` only: `pnpm check-version`
+7. Review the diff with `git --no-pager diff`. Confirm: `package.json` version bumped, changelog
+   stamped with today's date, and (ts-sdk) `src/version.ts` + `docs/` updated.
+8. Commit: `git commit -am "chore: release <pkg> v<newVersion>"`.
+9. Push and open a PR:
+   - `git push -u origin release/<pkg>-v<newVersion>`
+   - `gh pr create --fill --title "chore: release <pkg> v<newVersion>"`
+10. Tell the maintainer to review + merge, then re-invoke this skill for **Phase 2**.
+
+## Phase 2 — tag + GitHub Release (after the PR merges)
+
+1. `git checkout main && git pull --ff-only`.
+2. Verify the working tree is clean and the merged version is present:
+   `node -p "require('./<pkgPath>/package.json').version"` matches the released version
+   (`<pkgPath>` is `.` for ts-sdk, `confidential-asset` for confidential-asset).
+3. Compute the tag: `<pkg>-v<version>`.
+4. Refuse if the tag already exists: `git tag --list <tag>` must be empty.
+5. Create + push the tag:
+   - `git tag -a <tag> -m "<pkg> v<version>"`
+   - `git push origin <tag>`
+6. Create the GitHub Release (this triggers publishing):
+   - Extract that version's changelog section for the notes.
+   - `gh release create <tag> --title "<pkg> v<version>" --notes-file <notes>`
+7. Report the Actions run URL. Note that publishing waits for approval on the `npm-publish`
+   environment before it pushes to NPM.
+
+## Never do
+
+- Never run `npm publish` / `pnpm publish` locally — CI owns publishing.
+- Never tag from a dirty tree or a branch other than `main`.
+- Never release with an empty `# Unreleased` section.

--- a/.cursor/rules/release-ts-sdk.mdc
+++ b/.cursor/rules/release-ts-sdk.mdc
@@ -1,0 +1,33 @@
+---
+description: Release @aptos-labs/ts-sdk or @aptos-labs/confidential-asset — version bump, changelog stamp, release PR, then tag + GitHub Release that triggers NPM publish.
+alwaysApply: false
+---
+
+# Releasing the Aptos TypeScript SDK
+
+Follow the same procedure as the Claude skill in @.claude/skills/release-ts-sdk/SKILL.md.
+All mechanical work is delegated to @scripts/prepareRelease.mjs; publishing is done by CI
+(@.github/workflows/publish.yaml) on GitHub Release — never publish by hand.
+
+Packages (independent versions):
+- `@aptos-labs/ts-sdk` (root) — tag prefix `ts-sdk-v`
+- `@aptos-labs/confidential-asset` (`confidential-asset/`) — tag prefix `confidential-asset-v`
+
+## Phase 1 — release PR
+1. Confirm package + bump type (`major`/`minor`/`patch`) with the maintainer.
+2. Ensure the target `# Unreleased` changelog section is populated (the script refuses if empty).
+3. `git checkout -b release/<pkg>-v<newVersion>`
+4. `node scripts/prepareRelease.mjs --package <pkg> --bump <type>`
+5. `pnpm check` (and `pnpm check-version` for ts-sdk); review `git diff`.
+6. `git commit -am "chore: release <pkg> v<newVersion>"`, push, `gh pr create --fill`.
+7. Ask the maintainer to review + merge, then re-run for Phase 2.
+
+## Phase 2 — tag + release (after merge)
+1. `git checkout main && git pull --ff-only`; confirm clean tree + version present.
+2. `git tag -a <pkg>-v<version> -m "<pkg> v<version>"` (refuse if it already exists).
+3. `git push origin <pkg>-v<version>`
+4. `gh release create <pkg>-v<version> --title "<pkg> v<version>" --notes-file <notes>`
+   using that version's changelog section as the notes.
+5. Report the Actions run URL; publishing waits on the `npm-publish` environment approval.
+
+Never run `npm publish` / `pnpm publish` locally. Never tag a dirty tree or non-`main` branch.

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -6,8 +6,16 @@ on:
 permissions:
   contents: read
 
+# Serialize publishes for the same release tag so two runs can't race on the
+# same version; never cancel an in-flight publish (killing it mid-push is worse
+# than letting it finish). Different package tags still publish independently.
+concurrency:
+  group: publish-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
 jobs:
   publish:
+    name: Publish package to NPM
     runs-on: ubuntu-latest
     environment: npm-publish
     permissions:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,58 @@
+name: "Publish to NPM"
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      id-token: write # OIDC trusted publishing + provenance
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Resolve package and verify version matches tag
+        id: resolve
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG" == ts-sdk-v* ]]; then
+            dir="."
+            version="${TAG#ts-sdk-v}"
+          elif [[ "$TAG" == confidential-asset-v* ]]; then
+            dir="confidential-asset"
+            version="${TAG#confidential-asset-v}"
+          else
+            echo "Tag '$TAG' is not a package release tag; skipping publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pkg_version="$(node -p "require('./${dir}/package.json').version")"
+          if [[ "$version" != "$pkg_version" ]]; then
+            echo "Tag version ($version) != ${dir}/package.json version ($pkg_version)" >&2
+            exit 1
+          fi
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies
+        if: steps.resolve.outputs.publish == 'true'
+        run: pnpm install --frozen-lockfile
+      # OIDC trusted publishing requires a one-time Trusted Publisher config on
+      # npmjs.com for each package (repo aptos-labs/aptos-ts-sdk, workflow
+      # publish.yaml, environment npm-publish). See CONTRIBUTING.md. No NPM_TOKEN
+      # secret is used. If the first release fails auth, verify the pinned pnpm
+      # performs OIDC trusted publishing; otherwise fall back to the npm CLI
+      # (npm i -g npm@latest && npm publish --provenance --access public).
+      - name: Publish to NPM (OIDC trusted publishing + provenance)
+        if: steps.resolve.outputs.publish == 'true'
+        working-directory: ${{ steps.resolve.outputs.dir }}
+        run: pnpm publish --provenance --no-git-checks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Added
+
+- Automated release tooling: `scripts/prepareRelease.mjs` bumps a package's version and stamps its changelog, a two-phase release skill/Cursor rule (`.claude/skills/release-ts-sdk/`, `.cursor/rules/release-ts-sdk.mdc`) drives the version-bump PR and the tag + GitHub Release, and `.github/workflows/publish.yaml` publishes `@aptos-labs/ts-sdk` and `@aptos-labs/confidential-asset` to NPM with provenance via OIDC trusted publishing when a GitHub Release is published. See `CONTRIBUTING.md` and `docs/superpowers/specs/2026-07-06-automated-ts-sdk-releases-design.md`.
+
 # 7.2.0 (2026-07-06)
 
 ## Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -151,35 +151,61 @@ necessary information and instructions to reproduce your issue.
 
 ## Releasing a new version
 
-### Create a release PR
+Releases are automated. The mechanical work is done by `scripts/prepareRelease.mjs`, and publishing
+to NPM is done by `.github/workflows/publish.yaml` when a GitHub Release is published. **Do not run
+`npm publish` by hand.**
 
-Simply update the version in `package.json` and `pnpm update-version` will take care of the rest. This will create a new
-version everywhere in the code, and generate documentation accordingly. Ensure you check out a new branch before running
-these commands.
+Agents can drive the whole flow via the release skill (`.claude/skills/release-ts-sdk/SKILL.md`, or
+the Cursor rule `.cursor/rules/release-ts-sdk.mdc`). To do it manually, follow the steps below.
 
-```bash
-git checkout "bump_version"
-// update version in `package.json`
-// update CHANGELOG.md
-pnpm update-version
-```
+Two packages release independently, each with its own version, changelog, and tag prefix:
 
-Then push the branch and create a new PR. Once the PR is approved, merge it into the main branch and pull locally.
+- `@aptos-labs/ts-sdk` (repo root) — tags `ts-sdk-vX.Y.Z`
+- `@aptos-labs/confidential-asset` (`confidential-asset/`) — tags `confidential-asset-vX.Y.Z`
 
-### Publish to NPM
+### 1. Prepare the release PR
 
-After you pulled latest main, it is recommended to first do a dry-run to make sure we are publishing only the files we need to. To do that run:
+First make sure the target changelog's `# Unreleased` section lists the changes being released
+(the prep script refuses an empty section). Then:
 
 ```bash
-npm publish --dry-run
+git checkout -b release/ts-sdk-v7.3.0
+# Bumps package.json, stamps the changelog with today's date, and (ts-sdk only)
+# syncs src/version.ts + regenerates docs:
+node scripts/prepareRelease.mjs --package ts-sdk --bump minor   # or --bump major|patch
+pnpm check
+pnpm check-version    # ts-sdk only
+git commit -am "chore: release ts-sdk v7.3.0"
+git push -u origin release/ts-sdk-v7.3.0
+gh pr create --fill
 ```
 
-This command gives us a preview of what we will be releasing to NPM, make sure it does not include hidden files or anything we dont want to publish. Also, compare the package size and the total files with what is on [npm](https://www.npmjs.com/package/@aptos-labs/ts-sdk) and validate it is reasonable.
+For `confidential-asset`, pass `--package confidential-asset` (it has no `src/version.ts` or docs,
+so only its `package.json` and `CHANGELOG.md` change). For a **major** release, also add an upgrade
+guide (`upgrade-guides/UPGRADE_GUIDE_X.Y.Z.md`) and reference it in the changelog. Get the PR
+approved and merge it into `main`.
 
-Then, when we are ready to publish to NPM, simply run:
+### 2. Tag and release
+
+After the PR is on `main` and you have pulled latest:
 
 ```bash
-npm publish
+git checkout main && git pull --ff-only
+git tag -a ts-sdk-v7.3.0 -m "ts-sdk v7.3.0"
+git push origin ts-sdk-v7.3.0
+gh release create ts-sdk-v7.3.0 --title "ts-sdk v7.3.0" --notes "<changelog section>"
 ```
 
-This command will build the SDK and publish it to NPM registry
+Publishing the GitHub Release triggers `publish.yaml`, which verifies the tag version matches
+`package.json`, then publishes to NPM with provenance. The publish waits for a one-click approval on
+the protected `npm-publish` environment.
+
+### One-time setup (repo admin)
+
+Before the first automated release, an admin must configure:
+
+1. **npmjs.com → each package → Settings → Trusted Publisher:** provider GitHub Actions, repository
+   `aptos-labs/aptos-ts-sdk`, workflow `publish.yaml`, environment `npm-publish`. Do this for both
+   `@aptos-labs/ts-sdk` and `@aptos-labs/confidential-asset`.
+2. **GitHub → repo Settings → Environments → `npm-publish`:** add required reviewers so publishing
+   pauses for approval.

--- a/docs/superpowers/plans/2026-07-06-automated-ts-sdk-releases.md
+++ b/docs/superpowers/plans/2026-07-06-automated-ts-sdk-releases.md
@@ -1,0 +1,830 @@
+# Automated TS SDK Releases Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automate releasing `@aptos-labs/ts-sdk` and `@aptos-labs/confidential-asset` via a deterministic prep script, a two-phase agent skill (Claude + Cursor), and a GitHub Actions workflow that publishes to NPM on GitHub Release.
+
+**Architecture:** Three layers. (A) `scripts/prepareRelease.mjs` — a pure-function-based Node script that bumps `package.json`, stamps the changelog, and (for ts-sdk) runs `pnpm update-version`. (B) A thin skill in `.claude/skills/` + a Cursor rule in `.cursor/rules/` that orchestrate git/PR/tag around the script. (C) `.github/workflows/publish.yaml` fires on `release: published`, routes by tag prefix, and runs `pnpm publish --provenance` via OIDC trusted publishing into a protected environment.
+
+**Tech Stack:** Node ≥ 22 (ESM), pnpm 10.30.3, Vitest (unit config, no Docker), GitHub Actions, npm OIDC trusted publishing.
+
+## Global Constraints
+
+- **Node:** `>= 22` (`.node-version` = `v22.12.0`); scripts run under Node ESM (`"type": "module"`).
+- **Package manager:** `pnpm@10.30.3` (pinned in `package.json#packageManager`).
+- **GitHub Actions pinning:** every `uses:` must pin a full commit SHA with a trailing `# pin@vX.Y.Z` comment (repo convention — see existing workflows).
+- **Formatting:** run `pnpm check` / `pnpm fmt` (Biome) before committing.
+- **Changelog:** tooling changes to ts-sdk go under `# Unreleased` in the root `CHANGELOG.md`.
+- **Two packages, asymmetric:** `ts-sdk` (root) has `src/version.ts` + versioned `docs/` + `update-version`; `confidential-asset/` has neither — bump `package.json` + changelog only.
+- **Tag scheme:** `ts-sdk-vX.Y.Z` and `confidential-asset-vX.Y.Z`. Legacy `vX.Y.Z` tags are left as-is and must never trigger a publish.
+- **Unit tests:** live in `tests/unit/**/*.test.ts`, run with `vitest run --config vitest.config.unit.ts` (no Docker/localnet).
+
+## File Structure
+
+**New files:**
+
+| File | Responsibility |
+|------|----------------|
+| `scripts/prepareRelease.mjs` | Deterministic version bump + changelog stamp; exports pure helpers + a CLI `main()`. |
+| `tests/unit/prepareRelease.test.ts` | Vitest unit tests for the pure helpers. |
+| `.github/workflows/publish.yaml` | Publish-to-NPM workflow (release-triggered, OIDC, protected env). |
+| `.claude/skills/release-ts-sdk/SKILL.md` | Claude-facing release skill (Phase 1 + Phase 2). |
+| `.cursor/rules/release-ts-sdk.mdc` | Cursor-facing rule mirroring the skill. |
+
+**Modified files:**
+
+| File | Change |
+|------|--------|
+| `CONTRIBUTING.md` | Rewrite "Releasing a new version" for the new flow + one-time setup. |
+| `CHANGELOG.md` | Add an `# Unreleased` entry describing the release automation. |
+
+---
+
+### Task 1: `prepareRelease.mjs` pure helpers (TDD)
+
+The mechanical core, as small pure functions so they are hermetically testable without touching the real repo files.
+
+**Files:**
+- Create: `scripts/prepareRelease.mjs`
+- Test: `tests/unit/prepareRelease.test.ts`
+
+**Interfaces:**
+- Produces (all named ESM exports from `scripts/prepareRelease.mjs`):
+  - `computeNextVersion(current: string, bump: "major"|"minor"|"patch"): string`
+  - `isStrictlyGreater(next: string, current: string): boolean`
+  - `getUnreleasedSection(changelogText: string): string`
+  - `hasUnreleasedContent(changelogText: string): boolean`
+  - `stampChangelog(changelogText: string, version: string, dateStr: string): string`
+  - `setPackageVersion(pkgJsonText: string, version: string): string`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/prepareRelease.test.ts`:
+
+```ts
+import { describe, expect, it } from "vitest";
+import {
+  computeNextVersion,
+  getUnreleasedSection,
+  hasUnreleasedContent,
+  isStrictlyGreater,
+  setPackageVersion,
+  stampChangelog,
+} from "../../scripts/prepareRelease.mjs";
+
+describe("computeNextVersion", () => {
+  it("bumps patch", () => expect(computeNextVersion("7.2.0", "patch")).toBe("7.2.1"));
+  it("bumps minor and zeroes patch", () => expect(computeNextVersion("7.2.3", "minor")).toBe("7.3.0"));
+  it("bumps major and zeroes minor+patch", () => expect(computeNextVersion("7.2.3", "major")).toBe("8.0.0"));
+  it("rejects non-plain-semver current", () =>
+    expect(() => computeNextVersion("7.2.0-beta.1", "patch")).toThrow());
+  it("rejects unknown bump", () =>
+    // @ts-expect-error deliberately invalid bump
+    expect(() => computeNextVersion("7.2.0", "nope")).toThrow());
+});
+
+describe("isStrictlyGreater", () => {
+  it("true when greater", () => expect(isStrictlyGreater("7.3.0", "7.2.9")).toBe(true));
+  it("false when equal", () => expect(isStrictlyGreater("7.2.0", "7.2.0")).toBe(false));
+  it("false when lower", () => expect(isStrictlyGreater("7.1.0", "7.2.0")).toBe(false));
+});
+
+const CHANGELOG_EMPTY = `# Changelog
+
+Intro paragraph.
+
+# Unreleased
+
+# 7.2.0 (2026-07-06)
+
+## Added
+
+- something old
+`;
+
+const CHANGELOG_FULL = `# Changelog
+
+Intro paragraph.
+
+# Unreleased
+
+## Added
+
+- a brand new feature
+
+## Fixed
+
+- a bug
+
+# 2.0.0 (2026-01-01)
+
+## Added
+
+- older
+`;
+
+describe("getUnreleasedSection / hasUnreleasedContent", () => {
+  it("empty Unreleased has no content", () => {
+    expect(hasUnreleasedContent(CHANGELOG_EMPTY)).toBe(false);
+  });
+  it("populated Unreleased has content", () => {
+    expect(hasUnreleasedContent(CHANGELOG_FULL)).toBe(true);
+  });
+  it("section stops at next top-level heading", () => {
+    const section = getUnreleasedSection(CHANGELOG_FULL);
+    expect(section).toContain("a brand new feature");
+    expect(section).not.toContain("older");
+  });
+  it("throws when no Unreleased heading", () => {
+    expect(() => getUnreleasedSection("# Changelog\n\n# 1.0.0\n")).toThrow();
+  });
+});
+
+describe("stampChangelog", () => {
+  it("renames Unreleased and inserts a fresh empty Unreleased on top", () => {
+    const out = stampChangelog(CHANGELOG_FULL, "2.1.0", "2026-07-06");
+    // fresh empty Unreleased still present
+    expect(out).toContain("# Unreleased\n\n# 2.1.0 (2026-07-06)");
+    // the previous entries now sit under the stamped version
+    const stampedIdx = out.indexOf("# 2.1.0 (2026-07-06)");
+    const featureIdx = out.indexOf("a brand new feature");
+    const olderIdx = out.indexOf("# 2.0.0 (2026-01-01)");
+    expect(stampedIdx).toBeLessThan(featureIdx);
+    expect(featureIdx).toBeLessThan(olderIdx);
+  });
+  it("throws when no Unreleased heading", () => {
+    expect(() => stampChangelog("# Changelog\n", "1.0.0", "2026-07-06")).toThrow();
+  });
+});
+
+describe("setPackageVersion", () => {
+  it("replaces only the top-level version, preserving formatting", () => {
+    const pkg = `{\n  "name": "@aptos-labs/ts-sdk",\n  "dependencies": {\n    "x": "1.2.3"\n  },\n  "version": "7.2.0"\n}\n`;
+    const out = setPackageVersion(pkg, "7.3.0");
+    expect(out).toContain(`"version": "7.3.0"`);
+    expect(out).toContain(`"x": "1.2.3"`); // dependency version untouched
+  });
+  it("throws when no version field", () => {
+    expect(() => setPackageVersion(`{\n  "name": "x"\n}\n`, "1.0.0")).toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run --config vitest.config.unit.ts prepareRelease`
+Expected: FAIL — cannot resolve `../../scripts/prepareRelease.mjs` (module does not exist).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `scripts/prepareRelease.mjs` (helpers only for now — CLI added in Task 2):
+
+```js
+// Prepare a release: bump package.json version + stamp the changelog.
+// Pure helpers are exported for unit testing; the CLI entry point is at the bottom.
+
+/**
+ * Compute the next semver from a plain `X.Y.Z` current version.
+ * @param {string} current
+ * @param {"major"|"minor"|"patch"} bump
+ * @returns {string}
+ */
+export function computeNextVersion(current, bump) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(current);
+  if (!m) throw new Error(`current version is not plain semver X.Y.Z: ${current}`);
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = Number(m[3]);
+  switch (bump) {
+    case "major":
+      return `${major + 1}.0.0`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "patch":
+      return `${major}.${minor}.${patch + 1}`;
+    default:
+      throw new Error(`unknown bump type: ${bump} (expected major|minor|patch)`);
+  }
+}
+
+/**
+ * True iff `next` is strictly greater than `current` (both plain `X.Y.Z`).
+ * @param {string} next
+ * @param {string} current
+ * @returns {boolean}
+ */
+export function isStrictlyGreater(next, current) {
+  const a = next.split(".").map(Number);
+  const b = current.split(".").map(Number);
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return false;
+}
+
+/**
+ * Return the text between the `# Unreleased` heading and the next top-level
+ * `# ` heading (exclusive). Throws if there is no `# Unreleased` heading.
+ * @param {string} changelogText
+ * @returns {string}
+ */
+export function getUnreleasedSection(changelogText) {
+  const lines = changelogText.split("\n");
+  const start = lines.findIndex((l) => /^# Unreleased\s*$/.test(l));
+  if (start === -1) throw new Error("no `# Unreleased` heading found in changelog");
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^# /.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start + 1, end).join("\n");
+}
+
+/**
+ * True iff the `# Unreleased` section contains at least one changelog bullet.
+ * @param {string} changelogText
+ * @returns {boolean}
+ */
+export function hasUnreleasedContent(changelogText) {
+  return /^\s*-\s+\S/m.test(getUnreleasedSection(changelogText));
+}
+
+/**
+ * Rename `# Unreleased` to `# <version> (<dateStr>)`, leaving a fresh empty
+ * `# Unreleased` heading above it. Throws if there is no `# Unreleased` heading.
+ * @param {string} changelogText
+ * @param {string} version
+ * @param {string} dateStr  ISO `YYYY-MM-DD`
+ * @returns {string}
+ */
+export function stampChangelog(changelogText, version, dateStr) {
+  if (!/^# Unreleased[ \t]*$/m.test(changelogText)) {
+    throw new Error("no `# Unreleased` heading found in changelog");
+  }
+  return changelogText.replace(
+    /^# Unreleased[ \t]*$/m,
+    `# Unreleased\n\n# ${version} (${dateStr})`,
+  );
+}
+
+/**
+ * Replace the top-level `"version"` string in a package.json's raw text,
+ * preserving all other formatting. Throws if no version field is present.
+ * @param {string} pkgJsonText
+ * @param {string} version
+ * @returns {string}
+ */
+export function setPackageVersion(pkgJsonText, version) {
+  const re = /("version":\s*")[^"]*(")/;
+  if (!re.test(pkgJsonText)) throw new Error("no `version` field found in package.json");
+  return pkgJsonText.replace(re, `$1${version}$2`);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run --config vitest.config.unit.ts prepareRelease`
+Expected: PASS (all cases green).
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+pnpm fmt
+git add scripts/prepareRelease.mjs tests/unit/prepareRelease.test.ts
+git commit -m "feat(release): add prepareRelease version/changelog helpers"
+```
+
+---
+
+### Task 2: `prepareRelease.mjs` CLI entry point
+
+Wire the pure helpers into a CLI that mutates the real files and (for ts-sdk) runs `pnpm update-version`.
+
+**Files:**
+- Modify: `scripts/prepareRelease.mjs` (append CLI: `PACKAGES`, `parseArgs`, `main`)
+
+**Interfaces:**
+- Consumes: all helpers from Task 1.
+- Produces: CLI usage `node scripts/prepareRelease.mjs --package <ts-sdk|confidential-asset> --bump <major|minor|patch>` (or `--version X.Y.Z`). Prints the new version and the tag name `<pkg>-v<version>`.
+
+- [ ] **Step 1: Add the CLI to `scripts/prepareRelease.mjs`**
+
+Append below the helpers:
+
+```js
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { dirname, join } from "node:path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Per-package release configuration.
+ * `runsUpdateVersion` is true only for ts-sdk (it owns src/version.ts + docs).
+ */
+const PACKAGES = {
+  "ts-sdk": {
+    tagPrefix: "ts-sdk",
+    pkgJsonPath: join(REPO_ROOT, "package.json"),
+    changelogPath: join(REPO_ROOT, "CHANGELOG.md"),
+    runsUpdateVersion: true,
+  },
+  "confidential-asset": {
+    tagPrefix: "confidential-asset",
+    pkgJsonPath: join(REPO_ROOT, "confidential-asset", "package.json"),
+    changelogPath: join(REPO_ROOT, "confidential-asset", "CHANGELOG.md"),
+    runsUpdateVersion: false,
+  },
+};
+
+/**
+ * Parse `--package`, and exactly one of `--bump` / `--version`.
+ * @param {string[]} argv
+ * @returns {{ pkg: string, bump?: string, version?: string }}
+ */
+export function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--package") out.pkg = argv[(i += 1)];
+    else if (arg === "--bump") out.bump = argv[(i += 1)];
+    else if (arg === "--version") out.version = argv[(i += 1)];
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!out.pkg || !PACKAGES[out.pkg]) {
+    throw new Error("--package must be one of: ts-sdk, confidential-asset");
+  }
+  if (!!out.bump === !!out.version) {
+    throw new Error("provide exactly one of --bump or --version");
+  }
+  return out;
+}
+
+function main() {
+  const { pkg, bump, version } = parseArgs(process.argv.slice(2));
+  const cfg = PACKAGES[pkg];
+
+  const pkgJsonText = readFileSync(cfg.pkgJsonPath, "utf8");
+  const current = JSON.parse(pkgJsonText).version;
+  const next = version ?? computeNextVersion(current, bump);
+
+  if (!isStrictlyGreater(next, current)) {
+    throw new Error(`new version ${next} is not greater than current ${current}`);
+  }
+
+  const changelogText = readFileSync(cfg.changelogPath, "utf8");
+  if (!hasUnreleasedContent(changelogText)) {
+    throw new Error(
+      `\`# Unreleased\` section of ${cfg.changelogPath} is empty; ` +
+        "add changelog entries before preparing a release",
+    );
+  }
+
+  // UTC date so releases are reproducible regardless of the runner's timezone.
+  const dateStr = new Date().toISOString().slice(0, 10);
+
+  writeFileSync(cfg.pkgJsonPath, setPackageVersion(pkgJsonText, next));
+  writeFileSync(cfg.changelogPath, stampChangelog(changelogText, next, dateStr));
+
+  if (cfg.runsUpdateVersion) {
+    // `pnpm update-version` re-reads package.json, so $npm_package_version is
+    // the version we just wrote; it syncs src/version.ts and regenerates docs.
+    execSync("pnpm update-version", { cwd: REPO_ROOT, stdio: "inherit" });
+  }
+
+  const tag = `${cfg.tagPrefix}-v${next}`;
+  console.log(`\nPrepared ${pkg} release: ${current} -> ${next}`);
+  console.log(`Changelog stamped with date ${dateStr}`);
+  console.log(`Phase 2 tag will be: ${tag}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`prepareRelease failed: ${err.message}`);
+    process.exit(1);
+  }
+}
+```
+
+- [ ] **Step 2: Add a `parseArgs` test and run the existing suite**
+
+Append to `tests/unit/prepareRelease.test.ts`:
+
+```ts
+import { parseArgs } from "../../scripts/prepareRelease.mjs";
+
+describe("parseArgs", () => {
+  it("parses package + bump", () => {
+    expect(parseArgs(["--package", "ts-sdk", "--bump", "minor"])).toEqual({
+      pkg: "ts-sdk",
+      bump: "minor",
+    });
+  });
+  it("parses package + explicit version", () => {
+    expect(parseArgs(["--package", "confidential-asset", "--version", "2.1.0"])).toEqual({
+      pkg: "confidential-asset",
+      version: "2.1.0",
+    });
+  });
+  it("rejects unknown package", () =>
+    expect(() => parseArgs(["--package", "nope", "--bump", "patch"])).toThrow());
+  it("rejects both bump and version", () =>
+    expect(() => parseArgs(["--package", "ts-sdk", "--bump", "patch", "--version", "1.0.0"])).toThrow());
+  it("rejects neither bump nor version", () =>
+    expect(() => parseArgs(["--package", "ts-sdk"])).toThrow());
+});
+```
+
+Run: `pnpm exec vitest run --config vitest.config.unit.ts prepareRelease`
+Expected: PASS (Task 1 cases + the new `parseArgs` cases).
+
+- [ ] **Step 3: Live smoke test against confidential-asset, then revert**
+
+`confidential-asset` has a populated `# Unreleased` section, so this exercises the changelog stamp + package.json bump without the ts-sdk docs regeneration:
+
+```bash
+node scripts/prepareRelease.mjs --package confidential-asset --bump minor
+git --no-pager diff -- confidential-asset/package.json confidential-asset/CHANGELOG.md
+```
+
+Expected: `confidential-asset/package.json` version `2.0.0 -> 2.1.0`; `confidential-asset/CHANGELOG.md` shows a fresh empty `# Unreleased` above a new `# 2.1.0 (<today>)` heading that now holds the previously-unreleased entries. Then revert the smoke test:
+
+```bash
+git checkout -- confidential-asset/package.json confidential-asset/CHANGELOG.md
+```
+
+- [ ] **Step 4: Guard test — empty Unreleased is refused**
+
+The root `CHANGELOG.md` currently has an empty `# Unreleased`, so this must fail cleanly and mutate nothing:
+
+```bash
+node scripts/prepareRelease.mjs --package ts-sdk --bump patch; echo "exit=$?"
+git status --porcelain
+```
+
+Expected: prints `prepareRelease failed: \`# Unreleased\` section of .../CHANGELOG.md is empty; ...`, `exit=1`, and `git status --porcelain` shows **no** changes. (If Task 5's changelog entry is already committed, this guard will instead succeed — run this step before Task 5, or temporarily clear the entry to verify.)
+
+- [ ] **Step 5: Format + commit**
+
+```bash
+pnpm fmt
+git add scripts/prepareRelease.mjs tests/unit/prepareRelease.test.ts
+git commit -m "feat(release): add prepareRelease CLI entry point"
+```
+
+---
+
+### Task 3: NPM publish workflow
+
+**Files:**
+- Create: `.github/workflows/publish.yaml`
+
+**Interfaces:**
+- Consumes: `github.event.release.tag_name` (`ts-sdk-vX.Y.Z` or `confidential-asset-vX.Y.Z`); the `setup-node-pnpm` composite action; a repo Environment named `npm-publish`.
+- Produces: an `@aptos-labs/*` package published to NPM with provenance.
+
+- [ ] **Step 1: Create the workflow**
+
+Create `.github/workflows/publish.yaml`:
+
+```yaml
+name: "Publish to NPM"
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      id-token: write # OIDC trusted publishing + provenance
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # pin@v7.0.0
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-node-pnpm
+      - name: Resolve package and verify version matches tag
+        id: resolve
+        shell: bash
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          if [[ "$TAG" == ts-sdk-v* ]]; then
+            dir="."
+            version="${TAG#ts-sdk-v}"
+          elif [[ "$TAG" == confidential-asset-v* ]]; then
+            dir="confidential-asset"
+            version="${TAG#confidential-asset-v}"
+          else
+            echo "Tag '$TAG' is not a package release tag; skipping publish."
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          pkg_version="$(node -p "require('./${dir}/package.json').version")"
+          if [[ "$version" != "$pkg_version" ]]; then
+            echo "Tag version ($version) != ${dir}/package.json version ($pkg_version)" >&2
+            exit 1
+          fi
+          echo "dir=$dir" >> "$GITHUB_OUTPUT"
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+      - name: Install dependencies
+        if: steps.resolve.outputs.publish == 'true'
+        run: pnpm install --frozen-lockfile
+      - name: Publish to NPM (OIDC trusted publishing + provenance)
+        if: steps.resolve.outputs.publish == 'true'
+        working-directory: ${{ steps.resolve.outputs.dir }}
+        run: pnpm publish --provenance --no-git-checks
+```
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `pnpm exec actionlint .github/workflows/publish.yaml` (or, if `actionlint` is not installed locally, `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color .github/workflows/publish.yaml`).
+Expected: no errors.
+
+- [ ] **Step 3: Verify OIDC trusted-publishing readiness (manual check, document risk)**
+
+The `setup-node-pnpm` composite runs `actions/setup-node` with `registry-url`, which writes an `.npmrc` line referencing `NODE_AUTH_TOKEN`. With no token set, confirm this does **not** shadow OIDC trusted publishing. Verify by reading npm/pnpm trusted-publishing docs for the pinned pnpm (`10.30.3`). If the empty-token `.npmrc` line interferes, the fix (applied in this step) is to add, before the publish step, a shell step that strips the token line:
+
+```yaml
+      - name: Remove token line so OIDC trusted publishing is used
+        if: steps.resolve.outputs.publish == 'true'
+        run: |
+          npmrc="${HOME}/.npmrc"
+          [ -f "$npmrc" ] && sed -i '/_authToken/d' "$npmrc" || true
+```
+
+Only add this step if verification shows it is needed. Record the outcome in the commit message.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/publish.yaml
+git commit -m "ci(release): add NPM publish workflow (OIDC, protected env)"
+```
+
+---
+
+### Task 4: Release skill (Claude) + Cursor rule
+
+**Files:**
+- Create: `.claude/skills/release-ts-sdk/SKILL.md`
+- Create: `.cursor/rules/release-ts-sdk.mdc`
+
+**Interfaces:**
+- Consumes: `scripts/prepareRelease.mjs`, `gh` CLI, the tag scheme, `publish.yaml`.
+- Produces: a documented two-phase agent procedure usable from Claude Code and Cursor.
+
+- [ ] **Step 1: Create the Claude skill**
+
+Create `.claude/skills/release-ts-sdk/SKILL.md`:
+
+```markdown
+---
+name: release-ts-sdk
+description: Use when cutting a release of @aptos-labs/ts-sdk or @aptos-labs/confidential-asset. Phase 1 bumps the version, stamps the changelog, and opens the release PR. Phase 2 (after the PR merges to main) cuts the tag and GitHub Release that triggers the NPM publish workflow.
+---
+
+# Releasing the Aptos TypeScript SDK
+
+Two packages release independently:
+
+- `@aptos-labs/ts-sdk` (repo root) — tag prefix `ts-sdk-v`
+- `@aptos-labs/confidential-asset` (`confidential-asset/`) — tag prefix `confidential-asset-v`
+
+All mechanical work is done by `scripts/prepareRelease.mjs`. Publishing to NPM is done by
+`.github/workflows/publish.yaml` when a GitHub Release is published — never publish by hand.
+
+## Preconditions
+
+- Working tree clean, on an up-to-date `main`.
+- The target package's `# Unreleased` changelog section already lists the changes being released.
+  If it is empty, stop and ask the maintainer to fill it in first (the script will refuse otherwise).
+
+## Phase 1 — prepare the release PR
+
+1. Ask which package (`ts-sdk` or `confidential-asset`) unless it is obvious from context.
+2. Ask the bump type: `major`, `minor`, or `patch`. For a **major** bump, remind the maintainer to
+   write an upgrade guide at `upgrade-guides/UPGRADE_GUIDE_X.Y.Z.md` and reference it in the changelog.
+3. Determine the new version without mutating anything yet:
+   - Current version: read `version` from the package's `package.json`.
+4. Create a release branch: `git checkout -b release/<pkg>-v<newVersion>`.
+5. Run the prep script:
+   - `node scripts/prepareRelease.mjs --package <pkg> --bump <type>`
+6. Validate:
+   - `pnpm check`
+   - For `ts-sdk` only: `pnpm check-version`
+7. Review the diff with `git --no-pager diff`. Confirm: `package.json` version bumped, changelog
+   stamped with today's date, and (ts-sdk) `src/version.ts` + `docs/` updated.
+8. Commit: `git commit -am "chore: release <pkg> v<newVersion>"`.
+9. Push and open a PR:
+   - `git push -u origin release/<pkg>-v<newVersion>`
+   - `gh pr create --fill --title "chore: release <pkg> v<newVersion>"`
+10. Tell the maintainer to review + merge, then re-invoke this skill for **Phase 2**.
+
+## Phase 2 — tag + GitHub Release (after the PR merges)
+
+1. `git checkout main && git pull --ff-only`.
+2. Verify the working tree is clean and the merged version is present:
+   `node -p "require('./<pkgPath>/package.json').version"` matches the released version
+   (`<pkgPath>` is `.` for ts-sdk, `confidential-asset` for confidential-asset).
+3. Compute the tag: `<pkg>-v<version>`.
+4. Refuse if the tag already exists: `git tag --list <tag>` must be empty.
+5. Create + push the tag:
+   - `git tag -a <tag> -m "<pkg> v<version>"`
+   - `git push origin <tag>`
+6. Create the GitHub Release (this triggers publishing):
+   - Extract that version's changelog section for the notes.
+   - `gh release create <tag> --title "<pkg> v<version>" --notes-file <notes>`
+7. Report the Actions run URL. Note that publishing waits for approval on the `npm-publish`
+   environment before it pushes to NPM.
+
+## Never do
+
+- Never run `npm publish` / `pnpm publish` locally — CI owns publishing.
+- Never tag from a dirty tree or a branch other than `main`.
+- Never release with an empty `# Unreleased` section.
+```
+
+- [ ] **Step 2: Create the Cursor rule**
+
+Create `.cursor/rules/release-ts-sdk.mdc`:
+
+```markdown
+---
+description: Release @aptos-labs/ts-sdk or @aptos-labs/confidential-asset — version bump, changelog stamp, release PR, then tag + GitHub Release that triggers NPM publish.
+alwaysApply: false
+---
+
+# Releasing the Aptos TypeScript SDK
+
+Follow the same procedure as the Claude skill in @.claude/skills/release-ts-sdk/SKILL.md.
+All mechanical work is delegated to @scripts/prepareRelease.mjs; publishing is done by CI
+(@.github/workflows/publish.yaml) on GitHub Release — never publish by hand.
+
+Packages (independent versions):
+- `@aptos-labs/ts-sdk` (root) — tag prefix `ts-sdk-v`
+- `@aptos-labs/confidential-asset` (`confidential-asset/`) — tag prefix `confidential-asset-v`
+
+## Phase 1 — release PR
+1. Confirm package + bump type (`major`/`minor`/`patch`) with the maintainer.
+2. Ensure the target `# Unreleased` changelog section is populated (the script refuses if empty).
+3. `git checkout -b release/<pkg>-v<newVersion>`
+4. `node scripts/prepareRelease.mjs --package <pkg> --bump <type>`
+5. `pnpm check` (and `pnpm check-version` for ts-sdk); review `git diff`.
+6. `git commit -am "chore: release <pkg> v<newVersion>"`, push, `gh pr create --fill`.
+7. Ask the maintainer to review + merge, then re-run for Phase 2.
+
+## Phase 2 — tag + release (after merge)
+1. `git checkout main && git pull --ff-only`; confirm clean tree + version present.
+2. `git tag -a <pkg>-v<version> -m "<pkg> v<version>"` (refuse if it already exists).
+3. `git push origin <pkg>-v<version>`
+4. `gh release create <pkg>-v<version> --title "<pkg> v<version>" --notes-file <notes>`
+   using that version's changelog section as the notes.
+5. Report the Actions run URL; publishing waits on the `npm-publish` environment approval.
+
+Never run `npm publish` / `pnpm publish` locally. Never tag a dirty tree or non-`main` branch.
+```
+
+- [ ] **Step 3: Sanity-check the skill loads (Claude)**
+
+Confirm the skill is discoverable: the file exists at `.claude/skills/release-ts-sdk/SKILL.md` with valid frontmatter (`name`, `description`). (Discovery is automatic for project skills; no command needed.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .claude/skills/release-ts-sdk/SKILL.md .cursor/rules/release-ts-sdk.mdc
+git commit -m "docs(release): add release skill (Claude) and Cursor rule"
+```
+
+---
+
+### Task 5: Docs — CONTRIBUTING + CHANGELOG
+
+**Files:**
+- Modify: `CONTRIBUTING.md` (replace the "Releasing a new version" section)
+- Modify: `CHANGELOG.md` (add an `# Unreleased` entry)
+
+- [ ] **Step 1: Rewrite the CONTRIBUTING release section**
+
+Replace the current "## Releasing a new version" section (through the end of the "Publish to NPM"
+subsection) in `CONTRIBUTING.md` with:
+
+````markdown
+## Releasing a new version
+
+Releases are automated. The mechanical work is done by `scripts/prepareRelease.mjs`, and publishing
+to NPM is done by `.github/workflows/publish.yaml` when a GitHub Release is published. **Do not run
+`npm publish` by hand.**
+
+Agents can drive the whole flow via the release skill (`.claude/skills/release-ts-sdk/SKILL.md`, or
+the Cursor rule `.cursor/rules/release-ts-sdk.mdc`). To do it manually:
+
+Two packages release independently, each with its own version, changelog, and tag prefix:
+
+- `@aptos-labs/ts-sdk` (repo root) — tags `ts-sdk-vX.Y.Z`
+- `@aptos-labs/confidential-asset` (`confidential-asset/`) — tags `confidential-asset-vX.Y.Z`
+
+### 1. Prepare the release PR
+
+First make sure the target changelog's `# Unreleased` section lists the changes being released
+(the prep script refuses an empty section). Then:
+
+```bash
+git checkout -b release/ts-sdk-v7.3.0
+# Bumps package.json, stamps the changelog with today's date, and (ts-sdk only)
+# syncs src/version.ts + regenerates docs:
+node scripts/prepareRelease.mjs --package ts-sdk --bump minor   # or --bump major|patch
+pnpm check
+pnpm check-version    # ts-sdk only
+git commit -am "chore: release ts-sdk v7.3.0"
+git push -u origin release/ts-sdk-v7.3.0
+gh pr create --fill
+```
+
+For a **major** release, also add an upgrade guide (`upgrade-guides/UPGRADE_GUIDE_X.Y.Z.md`) and
+reference it in the changelog. Get the PR approved and merge it into `main`.
+
+### 2. Tag and release
+
+After the PR is on `main` and you have pulled latest:
+
+```bash
+git checkout main && git pull --ff-only
+git tag -a ts-sdk-v7.3.0 -m "ts-sdk v7.3.0"
+git push origin ts-sdk-v7.3.0
+gh release create ts-sdk-v7.3.0 --title "ts-sdk v7.3.0" --notes "<changelog section>"
+```
+
+Publishing the GitHub Release triggers `publish.yaml`, which verifies the tag version matches
+`package.json`, then publishes to NPM with provenance. The publish waits for a one-click approval on
+the protected `npm-publish` environment.
+
+### One-time setup (repo admin)
+
+Before the first automated release, an admin must configure:
+
+1. **npmjs.com → each package → Settings → Trusted Publisher:** provider GitHub Actions, repository
+   `aptos-labs/aptos-ts-sdk`, workflow `publish.yaml`, environment `npm-publish`. Do this for both
+   `@aptos-labs/ts-sdk` and `@aptos-labs/confidential-asset`.
+2. **GitHub → repo Settings → Environments → `npm-publish`:** add required reviewers so publishing
+   pauses for approval.
+````
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+In `CHANGELOG.md`, under `# Unreleased`, add:
+
+```markdown
+# Unreleased
+
+## Added
+
+- Automated release tooling: `scripts/prepareRelease.mjs` bumps a package's version and stamps its changelog, a two-phase release skill/Cursor rule (`.claude/skills/release-ts-sdk/`, `.cursor/rules/release-ts-sdk.mdc`) drives the version-bump PR and the tag + GitHub Release, and `.github/workflows/publish.yaml` publishes `@aptos-labs/ts-sdk` and `@aptos-labs/confidential-asset` to NPM with provenance via OIDC trusted publishing when a GitHub Release is published. See `CONTRIBUTING.md` and `docs/superpowers/specs/2026-07-06-automated-ts-sdk-releases-design.md`.
+```
+
+- [ ] **Step 3: Format + validate + commit**
+
+```bash
+pnpm fmt
+pnpm check
+git add CONTRIBUTING.md CHANGELOG.md
+git commit -m "docs(release): document automated release flow and one-time setup"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Layer A (script) → Tasks 1–2. Layer B (skill/Cursor) → Task 4. Layer C (workflow) → Task 3.
+- Both packages + asymmetry (ts-sdk docs vs confidential-asset) → `PACKAGES` map (Task 2) + skill/CONTRIBUTING notes.
+- OIDC + provenance + protected env → Task 3 workflow. pnpm publish w/ npm fallback → Task 3 Step 3 note.
+- Tag scheme + legacy tags don't trigger → Task 3 routing (release-triggered, prefix match, else no-op).
+- Empty-Unreleased guard + non-increasing-version guard → Task 1/2 + Task 2 Step 4.
+- Cross-tool packaging → Task 4 (both wrappers reference the script). One-time setup → Task 5.
+- Testing/validation → Task 1/2 unit tests + smoke tests, Task 3 actionlint.
+
+**Placeholder scan:** No TBD/TODO; all steps carry concrete code or commands. `<pkg>`/`<version>`
+in the skill are runtime template values, not plan gaps.
+
+**Type consistency:** Helper names (`computeNextVersion`, `isStrictlyGreater`, `getUnreleasedSection`,
+`hasUnreleasedContent`, `stampChangelog`, `setPackageVersion`, `parseArgs`) are used identically in
+the implementation and the tests. `PACKAGES` keys (`ts-sdk`, `confidential-asset`) match the CLI
+`--package` values, the skill, and the workflow tag prefixes.
+
+**Note / known risk:** Task 3 Step 3 — OIDC trusted publishing vs the `.npmrc` token line written by
+`setup-node-pnpm` — is the one item that cannot be fully verified without a real (or dry-run) publish;
+the step documents the check and the conditional fix.
+```

--- a/docs/superpowers/specs/2026-07-06-automated-ts-sdk-releases-design.md
+++ b/docs/superpowers/specs/2026-07-06-automated-ts-sdk-releases-design.md
@@ -141,25 +141,33 @@ jobs:
     steps:
       - uses: actions/checkout@<pinned>
       - uses: ./.github/actions/setup-node-pnpm
-      - run: npm install -g npm@latest      # ensure npm >= 11.5.1 for OIDC trusted publishing
       - name: Route by tag + guard version
         # Parse github.event.release.tag_name:
         #   ts-sdk-vX.Y.Z             -> dir = .                (package @aptos-labs/ts-sdk)
         #   confidential-asset-vX.Y.Z -> dir = confidential-asset
         # Assert the X.Y.Z in the tag === version in that dir's package.json; fail on mismatch.
+        # Any other tag prefix (e.g. legacy `vX.Y.Z`) -> exit 0 without publishing.
       - run: pnpm install --frozen-lockfile
       - name: Publish
-        run: npm publish --provenance --access public   # in the routed dir
+        run: pnpm publish --provenance --no-git-checks   # in the routed dir
 ```
 
 **Routing:** a single job inspects `github.event.release.tag_name`. Prefix `confidential-asset-v`
 → publish from `confidential-asset/`; prefix `ts-sdk-v` → publish from repo root. Any other tag
-prefix → the job no-ops (not a package release).
+prefix (including the **legacy `vX.Y.Z` tags**) → the job no-ops (not a package release). Because
+the workflow triggers only on `release: published` (never on tag push) and routes solely on these
+two prefixes, the existing `v7.0.0`-style tags cannot trigger a publish.
 
-**Publish tooling:** the actual publish uses the **npm CLI** (`npm publish`), not `pnpm publish`,
-to guarantee OIDC trusted-publishing support (needs npm ≥ 11.5.1). Install and build still use
-pnpm via the existing `setup-node-pnpm` action. `prepublishOnly` (build + check-license) runs
-automatically on `npm publish`.
+**Publish tooling:** the publish uses **pnpm** (`pnpm publish --provenance --no-git-checks`) to
+match the rest of the repo's tooling. This requires a pnpm version that supports OIDC trusted
+publishing (pnpm ≥ 10.13; repo pins `pnpm@10.30.3`, which satisfies this — the implementation must
+verify OIDC trusted publishing actually works with the pinned pnpm; if it does not, first try
+pinning a newer pnpm in the workflow, and only if pnpm still cannot do OIDC trusted publishing fall
+back to the **npm CLI** (`npm install -g npm@latest && npm publish --provenance --access public`)
+for the publish step alone — install/build stay on pnpm).
+`--no-git-checks` is needed because the tag checkout is a detached HEAD. Install and build use pnpm
+via the existing `setup-node-pnpm` action. `prepublishOnly` (build + check-license) runs
+automatically on `pnpm publish`.
 
 **Version guard:** the workflow refuses to publish if the tag version does not match the target
 `package.json` version — prevents publishing a mismatched or stale tree.

--- a/docs/superpowers/specs/2026-07-06-automated-ts-sdk-releases-design.md
+++ b/docs/superpowers/specs/2026-07-06-automated-ts-sdk-releases-design.md
@@ -1,0 +1,226 @@
+# Automated TS SDK Releases — Design
+
+**Date:** 2026-07-06
+**Status:** Approved (pending spec review)
+**Author:** Greg Nazario (with Claude)
+
+## Goal
+
+Automate releasing the Aptos TypeScript SDK packages so that a maintainer (human, Claude, or
+Cursor) can cut a release with minimal manual, error-prone steps. Replace the current
+manual `npm publish`-from-a-laptop flow with a repeatable script + agent skill + CI workflow
+that publishes to NPM via a GitHub Action.
+
+Covers **two packages**, versioned independently:
+
+- `@aptos-labs/ts-sdk` (repo root)
+- `@aptos-labs/confidential-asset` (`confidential-asset/`)
+
+## Current process (baseline)
+
+From `CONTRIBUTING.md` and `scripts/`:
+
+1. Branch off `main`; manually bump `version` in `package.json`; manually edit `CHANGELOG.md`
+   (move `# Unreleased` content under a new `# X.Y.Z (date)` heading).
+2. `pnpm update-version` → `scripts/updateVersion.sh` syncs `src/version.ts` and `pnpm doc`
+   regenerates TypeDoc into `docs/@aptos-labs/ts-sdk-X.Y.Z`, inserts a line into `docs/index.md`,
+   and updates the `-latest` redirect.
+3. Push branch → PR → approve → merge → pull `main`.
+4. **Manually** run `npm publish` from a laptop (runs `prepublishOnly`: build + check-license).
+   No git tag, no GitHub Release, no CI publish today.
+
+Asymmetry between the packages:
+
+- **`ts-sdk`**: has `src/version.ts`, versioned `docs/`, `update-version` + `check-version` scripts.
+- **`confidential-asset`**: **no** `src/version.ts`, **no** `docs/`, **no** `update-version`/`check-version`.
+  Its bump = edit `confidential-asset/package.json` version + stamp `confidential-asset/CHANGELOG.md` only.
+
+Both changelogs use the same shape: a `# Unreleased` heading with `## Added` / `## Changed` /
+`## Fixed` / `## Breaking` subsections.
+
+## Decisions (locked)
+
+| Decision | Choice |
+|----------|--------|
+| NPM auth | **Trusted Publishing (OIDC)** + `--provenance`, no long-lived token |
+| Publish trigger | **GitHub Release `published`** |
+| Scope | **Both packages** (independent versioning) |
+| Publish gate | **Protected `npm-publish` environment** with required reviewers |
+| Tag scheme | **`ts-sdk-vX.Y.Z`** and **`confidential-asset-vX.Y.Z`** (explicit prefix on both) |
+| Phase 2 (tag + release) | **Separate skill invocation** after the PR merges |
+
+## Architecture — three layers
+
+### Layer A — deterministic script: `scripts/prepareRelease.mjs`
+
+Single source of truth for the mechanical bump so a human, Claude, and Cursor all produce
+byte-identical results. Node ESM script (repo is Node ≥ 22, `"type": "module"`).
+
+**Invocation:**
+
+```bash
+node scripts/prepareRelease.mjs --package <ts-sdk|confidential-asset> --bump <major|minor|patch>
+# or an explicit version:
+node scripts/prepareRelease.mjs --package ts-sdk --version 7.3.0
+```
+
+**Behavior (common):**
+
+1. Resolve the target `package.json` (root or `confidential-asset/`).
+2. Compute the new semver from `--bump` (or accept explicit `--version`); reject a version
+   that is not strictly greater than current.
+3. **Guard:** verify the target changelog's `# Unreleased` section is **non-empty** (has at least
+   one bullet under a subsection). Abort with a clear error if empty — no silent empty releases.
+4. Write the new `version` into the target `package.json`.
+5. Stamp the changelog: rename `# Unreleased` → `# X.Y.Z (YYYY-MM-DD)` and insert a fresh empty
+   `# Unreleased` heading above it. Date is the current UTC date.
+6. Print the new version, the tag name that Phase 2 will use, and the list of touched files.
+
+**Behavior (package-specific):**
+
+- `ts-sdk`: after bumping `package.json`, run `pnpm update-version` (syncs `src/version.ts`,
+  regenerates docs, updates `docs/index.md` + `-latest` redirect). Note: `update-version` reads
+  `$npm_package_version`, so it is invoked such that the freshly written version is in effect
+  (e.g. via `pnpm update-version` after the package.json write, which re-reads package.json).
+- `confidential-asset`: no `src/version.ts`, no docs — steps 4–5 only, scoped to
+  `confidential-asset/package.json` and `confidential-asset/CHANGELOG.md`.
+
+The script does **not** commit, branch, push, tag, or publish. It only mutates files and prints a
+summary. Git/PR/tag orchestration is the skill's job; this keeps the script pure and testable.
+
+Date injection: the script reads the date from the environment/Node at run time. (Agents running
+the skill pass no date; the script owns "today".)
+
+### Layer B — agent skill (two phases, thin wrapper around Layer A)
+
+Content source of truth is Layer A + `CONTRIBUTING.md`. The skill only orchestrates.
+
+**Phase 1 — prepare release PR:**
+
+1. Ask which package (`ts-sdk` | `confidential-asset`) if not obvious from context.
+2. Ask the bump type (`major` | `minor` | `patch`), explaining semver implications. For a `major`
+   bump, remind the maintainer to author an upgrade guide (`upgrade-guides/UPGRADE_GUIDE_X.Y.Z.md`,
+   per CLAUDE.md) and reference it in the changelog.
+3. Confirm the `# Unreleased` changelog section is populated; if not, stop and ask the maintainer
+   to fill it in first.
+4. Create a release branch (e.g. `release/ts-sdk-vX.Y.Z`).
+5. Run `node scripts/prepareRelease.mjs --package <pkg> --bump <type>`.
+6. Run `pnpm check` + `pnpm check-version` (for `ts-sdk`) to validate consistency.
+7. Show the diff; commit with a `chore: release <pkg> vX.Y.Z` message.
+8. Push and open a PR via `gh pr create` with a summary of the changelog delta.
+9. Tell the maintainer: review + merge, then re-invoke the skill for Phase 2.
+
+**Phase 2 — tag + GitHub Release (after PR merges):**
+
+1. Verify: on `main`, up to date with `origin/main`, working tree clean, and the release commit
+   is present (`package.json` version matches the intended release).
+2. Compute the tag: `<pkg>-vX.Y.Z`.
+3. Create the annotated tag and push it.
+4. Create the GitHub Release via `gh release create <tag>` with notes extracted from that version's
+   changelog section. This fires `publish.yaml`.
+5. Report the Actions run URL and note that the publish waits on the `npm-publish` environment
+   approval.
+
+**Skill safety rails:** refuse Phase 2 if the tree is dirty, not on `main`, or the version/tag
+already exists; never publish directly from the skill (CI owns publishing).
+
+### Layer C — CI workflow: `.github/workflows/publish.yaml`
+
+```yaml
+name: Publish to NPM
+on:
+  release:
+    types: [published]
+permissions:
+  id-token: write   # OIDC for trusted publishing + provenance
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: npm-publish        # required-reviewer gate
+    steps:
+      - uses: actions/checkout@<pinned>
+      - uses: ./.github/actions/setup-node-pnpm
+      - run: npm install -g npm@latest      # ensure npm >= 11.5.1 for OIDC trusted publishing
+      - name: Route by tag + guard version
+        # Parse github.event.release.tag_name:
+        #   ts-sdk-vX.Y.Z             -> dir = .                (package @aptos-labs/ts-sdk)
+        #   confidential-asset-vX.Y.Z -> dir = confidential-asset
+        # Assert the X.Y.Z in the tag === version in that dir's package.json; fail on mismatch.
+      - run: pnpm install --frozen-lockfile
+      - name: Publish
+        run: npm publish --provenance --access public   # in the routed dir
+```
+
+**Routing:** a single job inspects `github.event.release.tag_name`. Prefix `confidential-asset-v`
+→ publish from `confidential-asset/`; prefix `ts-sdk-v` → publish from repo root. Any other tag
+prefix → the job no-ops (not a package release).
+
+**Publish tooling:** the actual publish uses the **npm CLI** (`npm publish`), not `pnpm publish`,
+to guarantee OIDC trusted-publishing support (needs npm ≥ 11.5.1). Install and build still use
+pnpm via the existing `setup-node-pnpm` action. `prepublishOnly` (build + check-license) runs
+automatically on `npm publish`.
+
+**Version guard:** the workflow refuses to publish if the tag version does not match the target
+`package.json` version — prevents publishing a mismatched or stale tree.
+
+## Cross-tool skill packaging (Claude + Cursor)
+
+All real logic is in `scripts/prepareRelease.mjs` and the expanded `CONTRIBUTING.md` "Releasing"
+section (the human runbook). Two **thin** wrappers reference them so there is no forked logic to
+drift:
+
+- `.claude/skills/release-ts-sdk/SKILL.md` — Claude Code auto-discovers project skills under
+  `.claude/skills/`. Frontmatter `name` + `description`; body = the Phase 1 / Phase 2 steps above,
+  delegating mechanics to the script.
+- `.cursor/rules/release-ts-sdk.mdc` — Cursor rule (frontmatter `description`, `alwaysApply: false`)
+  that `@`-references `SKILL.md` and `scripts/prepareRelease.mjs` and restates the same phased steps.
+
+Rejected alternative: a single fully self-contained skill duplicated in both locations → high drift
+risk. Script-as-source-of-truth keeps both wrappers minimal.
+
+## One-time manual setup (documented in CONTRIBUTING.md)
+
+These cannot be done in code and must be done once by a repo admin:
+
+1. **npmjs.com → Trusted Publisher** for each package (`@aptos-labs/ts-sdk` and
+   `@aptos-labs/confidential-asset`): provider GitHub Actions, repo `aptos-labs/aptos-ts-sdk`,
+   workflow `publish.yaml`, environment `npm-publish`.
+2. **GitHub repo settings → Environments → `npm-publish`**: add required reviewers so publishing
+   pauses for a one-click approval.
+
+## Testing / validation
+
+- **Script unit tests** (`scripts/__tests__/prepareRelease.test.ts` or a Vitest file): given
+  fixture `package.json` + `CHANGELOG.md`, assert version math (major/minor/patch), changelog
+  stamping (heading rename + fresh `# Unreleased`), the empty-Unreleased guard, and the
+  reject-non-increasing-version guard. Package-specific branches (ts-sdk vs confidential-asset)
+  covered by not requiring `src/version.ts` for the latter.
+- **Workflow lint:** `publish.yaml` passes `actionlint` (already wired in `.github/actionlint.yaml`)
+  and follows the repo's action-pinning convention (pinned SHAs with `# pin@vX` comments).
+- **Dry-run rehearsal:** first real run can be validated by publishing a prerelease / using
+  `npm publish --dry-run` locally against the built tree before trusting CI end-to-end.
+- **check-version CI** continues to guard `ts-sdk` version consistency on PRs.
+
+## Out of scope
+
+- Auto-generating changelog entries from commits (changelogs remain hand-written, per repo policy).
+- Automating the npmjs.com trusted-publisher and GitHub environment setup (manual, one-time).
+- Changing the confidential-asset `zeta` prerelease flow (`publish-zeta`) — left as-is.
+- Canary/nightly publishing.
+
+## Files touched
+
+**New:**
+
+- `scripts/prepareRelease.mjs`
+- `scripts/__tests__/prepareRelease.test.ts` (or colocated Vitest file)
+- `.github/workflows/publish.yaml`
+- `.claude/skills/release-ts-sdk/SKILL.md`
+- `.cursor/rules/release-ts-sdk.mdc`
+
+**Modified:**
+
+- `CONTRIBUTING.md` — rewrite the "Releasing a new version" section for the new flow + one-time setup.
+- `CHANGELOG.md` — add an entry under `# Unreleased` describing the release automation.
+```

--- a/scripts/prepareRelease.mjs
+++ b/scripts/prepareRelease.mjs
@@ -1,0 +1,196 @@
+// Prepare a release: bump package.json version + stamp the changelog.
+// Pure helpers are exported for unit testing; the CLI entry point is at the bottom.
+
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+/**
+ * Compute the next semver from a plain `X.Y.Z` current version.
+ * @param {string} current
+ * @param {"major"|"minor"|"patch"} bump
+ * @returns {string}
+ */
+export function computeNextVersion(current, bump) {
+  const m = /^(\d+)\.(\d+)\.(\d+)$/.exec(current);
+  if (!m) throw new Error(`current version is not plain semver X.Y.Z: ${current}`);
+  const major = Number(m[1]);
+  const minor = Number(m[2]);
+  const patch = Number(m[3]);
+  switch (bump) {
+    case "major":
+      return `${major + 1}.0.0`;
+    case "minor":
+      return `${major}.${minor + 1}.0`;
+    case "patch":
+      return `${major}.${minor}.${patch + 1}`;
+    default:
+      throw new Error(`unknown bump type: ${bump} (expected major|minor|patch)`);
+  }
+}
+
+/**
+ * True iff `next` is strictly greater than `current` (both plain `X.Y.Z`).
+ * @param {string} next
+ * @param {string} current
+ * @returns {boolean}
+ */
+export function isStrictlyGreater(next, current) {
+  const a = next.split(".").map(Number);
+  const b = current.split(".").map(Number);
+  for (let i = 0; i < 3; i += 1) {
+    if (a[i] > b[i]) return true;
+    if (a[i] < b[i]) return false;
+  }
+  return false;
+}
+
+/**
+ * Return the text between the `# Unreleased` heading and the next top-level
+ * `# ` heading (exclusive). Throws if there is no `# Unreleased` heading.
+ * @param {string} changelogText
+ * @returns {string}
+ */
+export function getUnreleasedSection(changelogText) {
+  const lines = changelogText.split("\n");
+  const start = lines.findIndex((l) => /^# Unreleased\s*$/.test(l));
+  if (start === -1) throw new Error("no `# Unreleased` heading found in changelog");
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i += 1) {
+    if (/^# /.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start + 1, end).join("\n");
+}
+
+/**
+ * True iff the `# Unreleased` section contains at least one changelog bullet.
+ * @param {string} changelogText
+ * @returns {boolean}
+ */
+export function hasUnreleasedContent(changelogText) {
+  return /^\s*-\s+\S/m.test(getUnreleasedSection(changelogText));
+}
+
+/**
+ * Rename `# Unreleased` to `# <version> (<dateStr>)`, leaving a fresh empty
+ * `# Unreleased` heading above it. Throws if there is no `# Unreleased` heading.
+ * @param {string} changelogText
+ * @param {string} version
+ * @param {string} dateStr  ISO `YYYY-MM-DD`
+ * @returns {string}
+ */
+export function stampChangelog(changelogText, version, dateStr) {
+  if (!/^# Unreleased[ \t]*$/m.test(changelogText)) {
+    throw new Error("no `# Unreleased` heading found in changelog");
+  }
+  return changelogText.replace(/^# Unreleased[ \t]*$/m, `# Unreleased\n\n# ${version} (${dateStr})`);
+}
+
+/**
+ * Replace the top-level `"version"` string in a package.json's raw text,
+ * preserving all other formatting. Throws if no version field is present.
+ * @param {string} pkgJsonText
+ * @param {string} version
+ * @returns {string}
+ */
+export function setPackageVersion(pkgJsonText, version) {
+  const re = /("version":\s*")[^"]*(")/;
+  if (!re.test(pkgJsonText)) throw new Error("no `version` field found in package.json");
+  return pkgJsonText.replace(re, `$1${version}$2`);
+}
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+/**
+ * Per-package release configuration.
+ * `runsUpdateVersion` is true only for ts-sdk (it owns src/version.ts + docs).
+ */
+const PACKAGES = {
+  "ts-sdk": {
+    tagPrefix: "ts-sdk",
+    pkgJsonPath: join(REPO_ROOT, "package.json"),
+    changelogPath: join(REPO_ROOT, "CHANGELOG.md"),
+    runsUpdateVersion: true,
+  },
+  "confidential-asset": {
+    tagPrefix: "confidential-asset",
+    pkgJsonPath: join(REPO_ROOT, "confidential-asset", "package.json"),
+    changelogPath: join(REPO_ROOT, "confidential-asset", "CHANGELOG.md"),
+    runsUpdateVersion: false,
+  },
+};
+
+/**
+ * Parse `--package`, and exactly one of `--bump` / `--version`.
+ * @param {string[]} argv
+ * @returns {{ pkg: string, bump?: string, version?: string }}
+ */
+export function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 2) {
+    const flag = argv[i];
+    const value = argv[i + 1];
+    if (flag === "--package") out.pkg = value;
+    else if (flag === "--bump") out.bump = value;
+    else if (flag === "--version") out.version = value;
+    else throw new Error(`unknown argument: ${flag}`);
+  }
+  if (!out.pkg || !PACKAGES[out.pkg]) {
+    throw new Error("--package must be one of: ts-sdk, confidential-asset");
+  }
+  if (!!out.bump === !!out.version) {
+    throw new Error("provide exactly one of --bump or --version");
+  }
+  return out;
+}
+
+function main() {
+  const { pkg, bump, version } = parseArgs(process.argv.slice(2));
+  const cfg = PACKAGES[pkg];
+
+  const pkgJsonText = readFileSync(cfg.pkgJsonPath, "utf8");
+  const current = JSON.parse(pkgJsonText).version;
+  const next = version ?? computeNextVersion(current, bump);
+
+  if (!isStrictlyGreater(next, current)) {
+    throw new Error(`new version ${next} is not greater than current ${current}`);
+  }
+
+  const changelogText = readFileSync(cfg.changelogPath, "utf8");
+  if (!hasUnreleasedContent(changelogText)) {
+    throw new Error(
+      `\`# Unreleased\` section of ${cfg.changelogPath} is empty; ` +
+        "add changelog entries before preparing a release",
+    );
+  }
+
+  // UTC date so releases are reproducible regardless of the runner's timezone.
+  const dateStr = new Date().toISOString().slice(0, 10);
+
+  writeFileSync(cfg.pkgJsonPath, setPackageVersion(pkgJsonText, next));
+  writeFileSync(cfg.changelogPath, stampChangelog(changelogText, next, dateStr));
+
+  if (cfg.runsUpdateVersion) {
+    // `pnpm update-version` re-reads package.json, so $npm_package_version is
+    // the version we just wrote; it syncs src/version.ts and regenerates docs.
+    execSync("pnpm update-version", { cwd: REPO_ROOT, stdio: "inherit" });
+  }
+
+  const tag = `${cfg.tagPrefix}-v${next}`;
+  console.log(`\nPrepared ${pkg} release: ${current} -> ${next}`);
+  console.log(`Changelog stamped with date ${dateStr}`);
+  console.log(`Phase 2 tag will be: ${tag}`);
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (err) {
+    console.error(`prepareRelease failed: ${err.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/prepareRelease.mjs
+++ b/scripts/prepareRelease.mjs
@@ -7,6 +7,15 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 /**
+ * True iff `version` is a plain `X.Y.Z` semver (no prerelease/build suffix).
+ * @param {string} version
+ * @returns {boolean}
+ */
+export function isPlainSemver(version) {
+  return /^\d+\.\d+\.\d+$/.test(version);
+}
+
+/**
  * Compute the next semver from a plain `X.Y.Z` current version.
  * @param {string} current
  * @param {"major"|"minor"|"patch"} bump
@@ -155,6 +164,13 @@ function main() {
   const pkgJsonText = readFileSync(cfg.pkgJsonPath, "utf8");
   const current = JSON.parse(pkgJsonText).version;
   const next = version ?? computeNextVersion(current, bump);
+
+  // `computeNextVersion` always returns plain semver, but an explicit
+  // `--version` is unchecked until here — reject a malformed value before it is
+  // written into package.json / the changelog.
+  if (!isPlainSemver(next)) {
+    throw new Error(`--version must be plain semver X.Y.Z: ${next}`);
+  }
 
   if (!isStrictlyGreater(next, current)) {
     throw new Error(`new version ${next} is not greater than current ${current}`);

--- a/tests/unit/prepareRelease.test.ts
+++ b/tests/unit/prepareRelease.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeNextVersion,
+  getUnreleasedSection,
+  hasUnreleasedContent,
+  isStrictlyGreater,
+  parseArgs,
+  setPackageVersion,
+  stampChangelog,
+} from "../../scripts/prepareRelease.mjs";
+
+describe("computeNextVersion", () => {
+  it("bumps patch", () => expect(computeNextVersion("7.2.0", "patch")).toBe("7.2.1"));
+  it("bumps minor and zeroes patch", () => expect(computeNextVersion("7.2.3", "minor")).toBe("7.3.0"));
+  it("bumps major and zeroes minor+patch", () => expect(computeNextVersion("7.2.3", "major")).toBe("8.0.0"));
+  it("rejects non-plain-semver current", () => expect(() => computeNextVersion("7.2.0-beta.1", "patch")).toThrow());
+  it("rejects unknown bump", () =>
+    // @ts-expect-error deliberately invalid bump
+    expect(() => computeNextVersion("7.2.0", "nope")).toThrow());
+});
+
+describe("isStrictlyGreater", () => {
+  it("true when greater", () => expect(isStrictlyGreater("7.3.0", "7.2.9")).toBe(true));
+  it("false when equal", () => expect(isStrictlyGreater("7.2.0", "7.2.0")).toBe(false));
+  it("false when lower", () => expect(isStrictlyGreater("7.1.0", "7.2.0")).toBe(false));
+});
+
+const CHANGELOG_EMPTY = `# Changelog
+
+Intro paragraph.
+
+# Unreleased
+
+# 7.2.0 (2026-07-06)
+
+## Added
+
+- something old
+`;
+
+const CHANGELOG_FULL = `# Changelog
+
+Intro paragraph.
+
+# Unreleased
+
+## Added
+
+- a brand new feature
+
+## Fixed
+
+- a bug
+
+# 2.0.0 (2026-01-01)
+
+## Added
+
+- older
+`;
+
+describe("getUnreleasedSection / hasUnreleasedContent", () => {
+  it("empty Unreleased has no content", () => {
+    expect(hasUnreleasedContent(CHANGELOG_EMPTY)).toBe(false);
+  });
+  it("populated Unreleased has content", () => {
+    expect(hasUnreleasedContent(CHANGELOG_FULL)).toBe(true);
+  });
+  it("section stops at next top-level heading", () => {
+    const section = getUnreleasedSection(CHANGELOG_FULL);
+    expect(section).toContain("a brand new feature");
+    expect(section).not.toContain("older");
+  });
+  it("throws when no Unreleased heading", () => {
+    expect(() => getUnreleasedSection("# Changelog\n\n# 1.0.0\n")).toThrow();
+  });
+});
+
+describe("stampChangelog", () => {
+  it("renames Unreleased and inserts a fresh empty Unreleased on top", () => {
+    const out = stampChangelog(CHANGELOG_FULL, "2.1.0", "2026-07-06");
+    // fresh empty Unreleased still present
+    expect(out).toContain("# Unreleased\n\n# 2.1.0 (2026-07-06)");
+    // the previous entries now sit under the stamped version
+    const stampedIdx = out.indexOf("# 2.1.0 (2026-07-06)");
+    const featureIdx = out.indexOf("a brand new feature");
+    const olderIdx = out.indexOf("# 2.0.0 (2026-01-01)");
+    expect(stampedIdx).toBeLessThan(featureIdx);
+    expect(featureIdx).toBeLessThan(olderIdx);
+  });
+  it("throws when no Unreleased heading", () => {
+    expect(() => stampChangelog("# Changelog\n", "1.0.0", "2026-07-06")).toThrow();
+  });
+});
+
+describe("setPackageVersion", () => {
+  it("replaces only the top-level version, preserving formatting", () => {
+    const pkg = `{\n  "name": "@aptos-labs/ts-sdk",\n  "dependencies": {\n    "x": "1.2.3"\n  },\n  "version": "7.2.0"\n}\n`;
+    const out = setPackageVersion(pkg, "7.3.0");
+    expect(out).toContain(`"version": "7.3.0"`);
+    expect(out).toContain(`"x": "1.2.3"`); // dependency version untouched
+  });
+  it("throws when no version field", () => {
+    expect(() => setPackageVersion(`{\n  "name": "x"\n}\n`, "1.0.0")).toThrow();
+  });
+});
+
+describe("parseArgs", () => {
+  it("parses package + bump", () => {
+    expect(parseArgs(["--package", "ts-sdk", "--bump", "minor"])).toEqual({
+      pkg: "ts-sdk",
+      bump: "minor",
+    });
+  });
+  it("parses package + explicit version", () => {
+    expect(parseArgs(["--package", "confidential-asset", "--version", "2.1.0"])).toEqual({
+      pkg: "confidential-asset",
+      version: "2.1.0",
+    });
+  });
+  it("rejects unknown package", () => expect(() => parseArgs(["--package", "nope", "--bump", "patch"])).toThrow());
+  it("rejects both bump and version", () =>
+    expect(() => parseArgs(["--package", "ts-sdk", "--bump", "patch", "--version", "1.0.0"])).toThrow());
+  it("rejects neither bump nor version", () => expect(() => parseArgs(["--package", "ts-sdk"])).toThrow());
+});

--- a/tests/unit/prepareRelease.test.ts
+++ b/tests/unit/prepareRelease.test.ts
@@ -3,11 +3,19 @@ import {
   computeNextVersion,
   getUnreleasedSection,
   hasUnreleasedContent,
+  isPlainSemver,
   isStrictlyGreater,
   parseArgs,
   setPackageVersion,
   stampChangelog,
 } from "../../scripts/prepareRelease.mjs";
+
+describe("isPlainSemver", () => {
+  it("accepts plain X.Y.Z", () => expect(isPlainSemver("7.3.0")).toBe(true));
+  it("rejects two-part version", () => expect(isPlainSemver("7.3")).toBe(false));
+  it("rejects prerelease suffix", () => expect(isPlainSemver("7.3.0-beta.1")).toBe(false));
+  it("rejects non-numeric", () => expect(isPlainSemver("v7.3.0")).toBe(false));
+});
 
 describe("computeNextVersion", () => {
   it("bumps patch", () => expect(computeNextVersion("7.2.0", "patch")).toBe("7.2.1"));


### PR DESCRIPTION
## Summary

Automates releasing both `@aptos-labs/ts-sdk` and `@aptos-labs/confidential-asset`, replacing the manual `npm publish`-from-a-laptop flow with a deterministic prep script, a cross-tool release skill, and a GitHub Actions workflow that publishes to NPM via OIDC trusted publishing.

Design: `docs/superpowers/specs/2026-07-06-automated-ts-sdk-releases-design.md`
Plan: `docs/superpowers/plans/2026-07-06-automated-ts-sdk-releases.md`

## What's included

**1. `scripts/prepareRelease.mjs`** (+ 21 unit tests in `tests/unit/prepareRelease.test.ts`)
```
node scripts/prepareRelease.mjs --package <ts-sdk|confidential-asset> --bump <major|minor|patch>
```
- Bumps `package.json`, stamps the changelog (`# Unreleased` → `# X.Y.Z (date)` + a fresh empty `# Unreleased`).
- For **ts-sdk**, additionally runs `pnpm update-version` (syncs `src/version.ts`, regenerates docs). **confidential-asset** skips version.ts/docs (it has neither).
- Refuses an empty `# Unreleased` section or a non-increasing version.

**2. Cross-tool release skill** (two phases)
- `.claude/skills/release-ts-sdk/SKILL.md` — Claude Code project skill.
- `.cursor/rules/release-ts-sdk.mdc` — Cursor rule referencing the skill + script.
- Phase 1: ask major/minor/patch → run the script → open the release PR. Phase 2 (after merge): cut the tag + GitHub Release.

**3. `.github/workflows/publish.yaml`**
- Triggers on GitHub Release `published`; routes by tag prefix (`ts-sdk-v*` / `confidential-asset-v*`).
- Guards that the tag version matches `package.json`.
- `pnpm publish --provenance` via **OIDC trusted publishing** (no long-lived token) into the required-reviewer-gated `npm-publish` environment.
- Legacy `vX.Y.Z` tags cannot trigger it.

**4. Docs**
- Rewrote the `CONTRIBUTING.md` "Releasing a new version" section for the new flow + one-time setup.
- Added a root `CHANGELOG.md` entry.

## Tag scheme
`ts-sdk-vX.Y.Z` and `confidential-asset-vX.Y.Z`. Existing `vX.Y.Z` tags are left as-is and won't trigger CI.

## Verification
- `vitest run --config vitest.config.unit.ts prepareRelease` → 21/21 pass.
- `biome check` clean; `actionlint` clean on the workflow.
- Smoke-tested both packages end-to-end (`pnpm check-version` passed on the ts-sdk dry run); reverted.

## Note for reviewers
The one thing not verifiable without a real publish: whether the empty `NODE_AUTH_TOKEN` line that `setup-node-pnpm` writes to `.npmrc` interferes with pnpm's OIDC. There's an inline comment in the workflow with the fallback (strip the token line, or use the npm CLI with `--provenance`) if the first release fails auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)