### PR TITLE
fix(account): avoid owned-object timeouts during account discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - Add offline/mocked-client unit tests raising coverage of previously-untested modules: `internal/faucet.ts` (`fundAccount`), `client/get.ts` pagination helpers (`getAptosFullNode`, `getAptosPepperService`, `paginateWithCursor`, `paginateWithObfuscatedCursor`, `getPageWithObfuscatedCursor`), `core/crypto/abstraction.ts` (`AbstractPublicKey`/`AbstractSignature`), `account/AbstractedAccount.ts`, `account/keylessSigner.ts` (`isKeylessSigner`), `api/account/abstraction.ts` (`AccountAbstraction`), `api/transactionSubmission/sign.ts` (`Sign`), `api/utils.ts` (`waitForIndexerOnVersion`), and `SimpleTransaction` BCS round trips in `transactions/instances`.
 
+## Fixed
+
+- Avoid failing account discovery for standard accounts when the owned-objects indexer query times out by only querying owned objects when the account resource is absent. Resource-less light-account detection continues to use the owned-objects fallback.
+
 # 7.2.0 (2026-07-06)
 
 ## Added

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -951,26 +951,25 @@ async function doesAccountExistAtAddress(args: {
 }): Promise<boolean> {
   const { aptosConfig, accountAddress, options } = args;
   try {
-    // Get the account resources and the balance of the account.  We need to check both because
-    // an account resource can exist with 0 balance and a balance can exist without an account resource (light accounts).
-    const [accountResource, ownedObjects] = await Promise.all([
-      getResourceFallible<{ authentication_key: string }>({
-        aptosConfig,
-        accountAddress,
-        resourceType: "0x1::account::Account",
-      }),
-      getAccountOwnedObjects({
+    const accountResource = await getResourceFallible<{ authentication_key: string }>({
+      aptosConfig,
+      accountAddress,
+      resourceType: "0x1::account::Account",
+    });
+
+    // An account resource is sufficient to prove that the account exists. Only query owned objects
+    // when the resource is absent, because light accounts can exist without an account resource.
+    if (!accountResource) {
+      const ownedObjects = await getAccountOwnedObjects({
         aptosConfig,
         accountAddress,
         options: {
           limit: 1,
         },
-      }),
-    ]);
-
-    // If the account resource is not found and the balance is 0, then the account does not exist.
-    if (!accountResource && ownedObjects.length === 0) {
-      return false;
+      });
+      if (ownedObjects.length === 0) {
+        return false;
+      }
     }
 
     // If no auth key is provided as an argument, return true.

--- a/tests/unit/internal/account-getAccounts.test.ts
+++ b/tests/unit/internal/account-getAccounts.test.ts
@@ -5,8 +5,110 @@ import { describe, expect, it } from "vitest";
 import { createMockClient } from "../../helpers/mockClient.js";
 import { Account } from "../../../src/account/Account.js";
 import { getAccountsForPublicKey } from "../../../src/internal/account.js";
+import { SigningSchemeInput } from "../../../src/types/index.js";
 
 describe("internal/account.getAccountsForPublicKey", () => {
+  it("does not query owned objects when the account resource exists", async () => {
+    const mock = createMockClient();
+    const account = Account.generate({ scheme: SigningSchemeInput.Secp256k1Ecdsa });
+    const authKeyHex = account.accountAddress.toString();
+
+    mock.setResponder((req) => {
+      if (req.method === "GET" && req.url?.includes("/transactions")) {
+        return { data: [] };
+      }
+      if (req.method === "GET" && req.url?.includes("/resource/0x1::account::Account")) {
+        return {
+          data: {
+            type: "0x1::account::Account",
+            data: { sequence_number: "0", authentication_key: authKeyHex },
+          },
+        };
+      }
+      if (req.method === "POST" && req.body && typeof req.body === "object" && "query" in req.body) {
+        const body = req.body as { query?: string };
+        if (body.query?.includes("current_objects")) {
+          return {
+            data: {
+              errors: [
+                {
+                  message: "Request Timed Out: Upstream took longer than 10000ms to respond",
+                  extensions: { code: "408" },
+                },
+              ],
+            },
+          };
+        }
+        if (body.query?.includes("public_key_auth_keys")) {
+          return { data: { data: { public_key_auth_keys: [] } } };
+        }
+        if (body.query?.includes("auth_key_account_addresses")) {
+          return { data: { data: { auth_key_account_addresses: [] } } };
+        }
+      }
+      return { data: {} };
+    });
+
+    const result = await getAccountsForPublicKey({
+      aptosConfig: mock.config,
+      publicKey: account.publicKey,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].accountAddress.toString()).toBe(account.accountAddress.toString());
+    expect(
+      mock.requests.some((req) => req.body !== undefined && JSON.stringify(req.body).includes("current_objects")),
+    ).toBe(false);
+  });
+
+  it("queries owned objects to detect a light account when the account resource is absent", async () => {
+    const mock = createMockClient();
+    const account = Account.generate({ scheme: SigningSchemeInput.Secp256k1Ecdsa });
+
+    mock.setResponder((req) => {
+      if (req.method === "GET" && req.url?.includes("/transactions")) {
+        return { data: [] };
+      }
+      if (req.method === "GET" && req.url?.includes("/resource/0x1::account::Account")) {
+        return {
+          status: 404,
+          statusText: "Not Found",
+          data: { message: "resource not found", error_code: "resource_not_found" },
+        };
+      }
+      if (req.method === "POST" && req.body && typeof req.body === "object" && "query" in req.body) {
+        const body = req.body as { query?: string };
+        if (body.query?.includes("current_objects")) {
+          return {
+            data: {
+              data: {
+                current_objects: [{ object_address: "0x1" }],
+              },
+            },
+          };
+        }
+        if (body.query?.includes("public_key_auth_keys")) {
+          return { data: { data: { public_key_auth_keys: [] } } };
+        }
+        if (body.query?.includes("auth_key_account_addresses")) {
+          return { data: { data: { auth_key_account_addresses: [] } } };
+        }
+      }
+      return { data: {} };
+    });
+
+    const result = await getAccountsForPublicKey({
+      aptosConfig: mock.config,
+      publicKey: account.publicKey,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].accountAddress.toString()).toBe(account.accountAddress.toString());
+    expect(
+      mock.requests.some((req) => req.body !== undefined && JSON.stringify(req.body).includes("current_objects")),
+    ).toBe(true);
+  });
+
   it("returns the default account when the auth-key address exists on-chain", async () => {
     const mock = createMockClient();
     const account = Account.generate();


### PR DESCRIPTION
### Description

**Problem**

`doesAccountExistAtAddress` queried the account resource and owned objects concurrently in a `Promise.all`. For standard accounts the account resource alone is enough to prove the account exists, but if the unnecessary `current_objects` indexer query timed out (`Request Timed Out: Upstream took longer than 10000ms to respond`), the whole discovery call failed even though the resource was available.

This could prevent wallets such as Petra from importing accounts with a large history.

**Solution**

- Query the `0x1::account::Account` resource first.
- Skip the owned-object query when the resource exists.
- Only query owned objects when the resource is absent, so light accounts without a resource are still detected.
- Auth key validation and error propagation behave the same as before.
- Added regression tests for both the standard and light account paths.

> [!NOTE]
> Standard accounts no longer depend on the object indexer during existence detection. Light accounts keep the owned-object fallback, which now runs after the resource check instead of in parallel (about one extra REST round trip, only for addresses without an account resource).

### Test Plan

**Automated verification**

- [x] Regression test: a standard account succeeds without issuing `current_objects`, even when the mocked `current_objects` response is a 408 timeout.
- [x] Regression test: a light account without a resource still queries owned objects and is discovered.
- [x] Ran the new regression test against the previous implementation: it fails with the exact production error, so it does catch the original bug.
- [x] Full unit suite: 128 files, 1,696 tests passed.
- [x] `pnpm check`
- [x] `pnpm build`

**Live QA (read-only, public APIs)**

Built the SDK locally and called `getAccountsForPublicKey` with an instrumented client for the public key of
`0xbf40935e0e6f0515cddf3e884ea7ebf1488f1292e0313f080c88102d8e0564f4` (no private key involved):

- Returned the expected address on both mainnet and testnet, and the on-chain `authentication_key` matches the address (not rotated).
- No `current_objects` request was issued for the target address. The only `current_objects` query was for the secondary `AnyPublicKey` candidate, which has no account resource, so the light account fallback kicked in as expected.

### Related Links

- [Mainnet account used for live QA](https://explorer.aptoslabs.com/account/0xbf40935e0e6f0515cddf3e884ea7ebf1488f1292e0313f080c88102d8e0564f4/transactions?network=mainnet)
- [Testnet account used for live QA](https://explorer.aptoslabs.com/account/0xbf40935e0e6f0515cddf3e884ea7ebf1488f1292e0313f080c88102d8e0564f4/transactions?network=testnet)

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?
