### PR TITLE
[client] Retry pruned reads against the archival endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 - Remove usage of Buffer.from and replace with TextEncoder or js-base64 for greater compatibility
 - Update dependencies for examples, gas station, and confidential assets packages
 
+## Added
+
+- Retry reads of pruned history against the archival endpoint the node advertises in its `410 Gone` response, so
+  historical Node API reads keep working as fullnodes move to a rolling history window. Enabled by default; opt out
+  with `new AptosConfig({ ..., archivalFallback: false })`. Credentials are only forwarded to the archival endpoint
+  when it is on the same site as the configured node.
+
 ## Fixed
 
 - Fix `@noble/curves` v2.x import in `external_signing` example (use `.js` extension for subpath exports)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ const modules = await aptos.getAccountModules({ accountAddress: "0x123" });
 const tokens = await aptos.getAccountOwnedTokens({ accountAddress: "0x123" });
 ```
 
+#### Reading pruned history
+
+Public fullnodes only retain a rolling window of recent history. Reads outside that window fail with `410 Gone` and an
+`archival_endpoint` naming a node that still holds the data. The SDK retries those reads against that endpoint and
+returns the result transparently, so historical queries keep working without any code change.
+
+Credentials are only sent to the archival endpoint when it is on the same site as the node you configured, since that
+endpoint is chosen by the node rather than by you. To disable the retry:
+
+```ts
+const aptos = new Aptos(new AptosConfig({ network: Network.TESTNET, archivalFallback: false }));
+```
+
+> Note: `getTransactionByHash` is not covered. A pruned node cannot tell a pruned transaction from one that never
+> existed, so it answers `404` with no archival hint. Use `getTransactionByVersion` for historical lookups, or point
+> `fullnode` at an archival endpoint directly.
+
 ### Account management (default to Ed25519)
 
 > Note: We introduce a Single Sender authentication (as introduced in [AIP-55](https://github.com/aptos-foundation/AIPs/pull/263)). Generating an account defaults to Legacy Ed25519 authentication with the option to use the Single Sender unified authentication.

--- a/src/api/aptosConfig.ts
+++ b/src/api/aptosConfig.ts
@@ -125,6 +125,17 @@ export class AptosConfig {
   private pluginConfig?: PluginConfig;
 
   /**
+   * Whether reads of pruned history are retried against the archival endpoint the node advertises in its
+   * `410 Gone` response. Defaults to `true`.
+   *
+   * The retry happens once, only for requests that would otherwise throw. Credentials are sent to the
+   * archival endpoint only when it is on the same site as the node, since the node chooses that URL.
+   *
+   * @group Client
+   */
+  readonly archivalFallback: boolean;
+
+  /**
    * Initializes an instance of the Aptos client with the specified settings.
    * This allows users to configure various aspects of the client, such as network and endpoints.
    *
@@ -140,6 +151,8 @@ export class AptosConfig {
    * @param settings.fullnodeConfig - Additional configuration for the fullnode.
    * @param settings.indexerConfig - Additional configuration for the indexer.
    * @param settings.faucetConfig - Additional configuration for the faucet.
+   * @param settings.archivalFallback - Whether to retry pruned reads against the node's archival endpoint,
+   * defaults to `true`.
    *
    * @example
    * ```typescript
@@ -188,6 +201,7 @@ export class AptosConfig {
     this.indexerConfig = settings?.indexerConfig ?? {};
     this.faucetConfig = settings?.faucetConfig ?? {};
     this.transactionGenerationConfig = settings?.transactionGenerationConfig ?? {};
+    this.archivalFallback = settings?.archivalFallback ?? true;
     this.pluginConfig = settings?.pluginSettings
       ? {
           ...settings.pluginSettings,

--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -59,26 +59,107 @@ export async function request<Req, Res>(options: ClientRequest<Req>, client: Cli
   });
 }
 
+const HTTP_STATUS_GONE = 410;
+
+const CREDENTIAL_HEADERS = new Set(["authorization", "cookie", "x-api-key"]);
+
+const warnedArchivalEndpoints = new Set<string>();
+
+type ArchivalRetryTarget = {
+  url: string;
+  forwardCredentials: boolean;
+};
+
 /**
- * The main function to use when making an API request, returning the response or throwing an AptosApiError on failure.
- *
- * @param aptosRequestOpts - Options for the Aptos request, including the URL and path.
- * @param aptosConfig - The configuration information for the SDK client instance.
- * @param apiType - The type of API being accessed, which determines how the response is handled.
- * @returns The response from the API request or throws an AptosApiError if the request fails.
- * @group Implementation
- * @category Client
+ * Registrable domain, approximated as the last two labels.
+ * Hosts under a multi-part suffix like `co.uk` compare equal.
  */
-export async function aptosRequest<Req extends {}, Res extends {}>(
+function siteOf(hostname: string): string {
+  return hostname.toLowerCase().split(".").slice(-2).join(".");
+}
+
+/**
+ * Validates the archival endpoint advertised in a pruning error, returning undefined if it is unusable.
+ *
+ * The endpoint is chosen by the node rather than the caller, so it must be an absolute http(s) URL that does
+ * not downgrade an https request, and credentials are only forwarded to it when it is same-site.
+ */
+function resolveArchivalRetryTarget(originalUrl: string, responseData: any): ArchivalRetryTarget | undefined {
+  const advertisedEndpoint = responseData?.archival_endpoint;
+  if (typeof advertisedEndpoint !== "string" || advertisedEndpoint.length === 0) {
+    return undefined;
+  }
+
+  let archivalUrl: URL;
+  let originUrl: URL;
+  try {
+    archivalUrl = new URL(advertisedEndpoint);
+    originUrl = new URL(originalUrl);
+  } catch {
+    return undefined;
+  }
+
+  if (archivalUrl.protocol !== "https:" && archivalUrl.protocol !== "http:") {
+    return undefined;
+  }
+  if (originUrl.protocol === "https:" && archivalUrl.protocol !== "https:") {
+    return undefined;
+  }
+
+  return {
+    url: advertisedEndpoint.replace(/\/+$/, ""),
+    forwardCredentials: siteOf(archivalUrl.hostname) === siteOf(originUrl.hostname),
+  };
+}
+
+function hasCredentials(overrides: AptosRequest["overrides"]): boolean {
+  if (!overrides) {
+    return false;
+  }
+  if (overrides.API_KEY || overrides.AUTH_TOKEN) {
+    return true;
+  }
+  return Object.keys(overrides.HEADERS ?? {}).some((name) => CREDENTIAL_HEADERS.has(name.toLowerCase()));
+}
+
+function withoutCredentials(overrides: AptosRequest["overrides"]): AptosRequest["overrides"] {
+  if (!overrides) {
+    return overrides;
+  }
+  const { API_KEY, AUTH_TOKEN, HEADERS, ...rest } = overrides;
+  if (!HEADERS) {
+    return rest;
+  }
+  return {
+    ...rest,
+    HEADERS: Object.fromEntries(
+      Object.entries(HEADERS).filter(([name]) => !CREDENTIAL_HEADERS.has(name.toLowerCase())),
+    ),
+  };
+}
+
+function warnOnceAboutDroppedCredentials(originalUrl: string, archivalUrl: string): void {
+  if (warnedArchivalEndpoints.has(archivalUrl)) {
+    return;
+  }
+  warnedArchivalEndpoints.add(archivalUrl);
+  console.warn(
+    `[Aptos SDK] ${originalUrl} reported pruned data and advertised the archival endpoint ${archivalUrl}. ` +
+      "Retrying there without credentials because it is not on the same site. If that endpoint requires " +
+      "authentication, set it as your `fullnode` URL, or disable this retry with `archivalFallback: false`.",
+  );
+}
+
+/** Sends a request and shapes the client response into an `AptosResponse`, without interpreting the status. */
+async function sendAptosRequest<Req extends {}, Res extends {}>(
   aptosRequestOpts: AptosRequest,
   aptosConfig: AptosConfig,
-  apiType: AptosApiType,
 ): Promise<AptosResponse<Req, Res>> {
   const { url, path } = aptosRequestOpts;
   const fullUrl = path ? `${url}/${path}` : url;
   const clientResponse = await request<Req, Res>({ ...aptosRequestOpts, url: fullUrl }, aptosConfig.client);
 
-  const aptosResponse: AptosResponse<Req, Res> = {
+  return {
     status: clientResponse.status,
     statusText: clientResponse.statusText ?? "No status text provided",
     data: clientResponse.data,
@@ -87,7 +168,14 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
     request: clientResponse.request,
     url: fullUrl,
   };
+}
 
+/** Returns the response on success, or throws an `AptosApiError` describing the failure. */
+function handleAptosResponse<Req extends {}, Res extends {}>(
+  aptosResponse: AptosResponse<Req, Res>,
+  aptosRequestOpts: AptosRequest,
+  apiType: AptosApiType,
+): AptosResponse<Req, Res> {
   // Handle case for `Unauthorized` error (i.e. API_KEY error)
   if (aptosResponse.status === 401) {
     throw new AptosApiError({ apiType, aptosRequest: aptosRequestOpts, aptosResponse });
@@ -119,4 +207,56 @@ export async function aptosRequest<Req extends {}, Res extends {}>(
   // We have to explicitly check for all request types, because if the error is a non-indexer error, but
   // comes from an indexer request (e.g. 404), we'll need to mention it appropriately
   throw new AptosApiError({ apiType, aptosRequest: aptosRequestOpts, aptosResponse });
+}
+
+/**
+ * The main function to use when making an API request, returning the response or throwing an AptosApiError on failure.
+ *
+ * A Node API read of pruned data answers `410 Gone` with an `archival_endpoint`. Such requests are replayed
+ * once against that endpoint and the result returned transparently. Opt out with `archivalFallback: false`.
+ *
+ * @param aptosRequestOpts - Options for the Aptos request, including the URL and path.
+ * @param aptosConfig - The configuration information for the SDK client instance.
+ * @param apiType - The type of API being accessed, which determines how the response is handled.
+ * @returns The response from the API request or throws an AptosApiError if the request fails.
+ * @group Implementation
+ * @category Client
+ */
+export async function aptosRequest<Req extends {}, Res extends {}>(
+  aptosRequestOpts: AptosRequest,
+  aptosConfig: AptosConfig,
+  apiType: AptosApiType,
+): Promise<AptosResponse<Req, Res>> {
+  const aptosResponse = await sendAptosRequest<Req, Res>(aptosRequestOpts, aptosConfig);
+
+  const archivalTarget =
+    apiType === AptosApiType.FULLNODE && aptosResponse.status === HTTP_STATUS_GONE && aptosConfig.archivalFallback
+      ? resolveArchivalRetryTarget(aptosResponse.url, aptosResponse.data)
+      : undefined;
+
+  if (archivalTarget === undefined) {
+    return handleAptosResponse<Req, Res>(aptosResponse, aptosRequestOpts, apiType);
+  }
+
+  if (!archivalTarget.forwardCredentials && hasCredentials(aptosRequestOpts.overrides)) {
+    warnOnceAboutDroppedCredentials(aptosResponse.url, archivalTarget.url);
+  }
+
+  const archivalRequestOpts: AptosRequest = {
+    ...aptosRequestOpts,
+    url: archivalTarget.url,
+    overrides: archivalTarget.forwardCredentials
+      ? aptosRequestOpts.overrides
+      : withoutCredentials(aptosRequestOpts.overrides),
+  };
+
+  let archivalResponse: AptosResponse<Req, Res>;
+  try {
+    archivalResponse = await sendAptosRequest<Req, Res>(archivalRequestOpts, aptosConfig);
+  } catch {
+    // Archival was unreachable, so the pruning error remains the more useful one to surface.
+    throw new AptosApiError({ apiType, aptosRequest: aptosRequestOpts, aptosResponse });
+  }
+
+  return handleAptosResponse<Req, Res>(archivalResponse, archivalRequestOpts, apiType);
 }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -335,6 +335,12 @@ export type AptosSettings = {
   readonly transactionGenerationConfig?: TransactionGenerationConfig;
 
   readonly pluginSettings?: PluginSettings;
+
+  /**
+   * Whether reads of pruned history are retried against the archival endpoint the node advertises.
+   * Defaults to `true`.
+   */
+  readonly archivalFallback?: boolean;
 };
 
 /**

--- a/tests/unit/archivalFallback.test.ts
+++ b/tests/unit/archivalFallback.test.ts
@@ -1,0 +1,230 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+import { type MockInstance, vi } from "vitest";
+import { AptosApiError, AptosConfig, ClientRequest, ClientResponse, Network } from "../../src";
+import { aptosRequest } from "../../src/client/core";
+import { AptosApiType } from "../../src/utils/const";
+
+const NODE_URL = "https://api.testnet.aptoslabs.com/v1";
+const ARCHIVAL_URL = "https://archive.testnet.staging.aptoslabs.com/v1";
+const PATH = "blocks/by_height/1";
+
+const prunedBody = (archivalEndpoint?: string) => ({
+  error_code: "block_pruned",
+  message: "Ledger version(1) has been pruned",
+  hint: "The requested data has been pruned from this node. Retry your request against the archival endpoint to access full history.",
+  oldest_ledger_version: "10255283755",
+  ...(archivalEndpoint === undefined ? {} : { archival_endpoint: archivalEndpoint }),
+});
+
+type RecordedRequest = ClientRequest<any> & { headers: Record<string, any> };
+
+/** A transport stub that answers per request and records what was put on the wire. */
+function stubClient(responder: (request: ClientRequest<any>) => Partial<ClientResponse<any>> | Error) {
+  const requests: RecordedRequest[] = [];
+  const client = {
+    provider: async <Req, Res>(request: ClientRequest<Req>): Promise<ClientResponse<Res>> => {
+      requests.push({ ...request, headers: request.headers ?? {} });
+      const result = responder(request);
+      if (result instanceof Error) {
+        throw result;
+      }
+      return { status: 200, statusText: "OK", data: undefined as Res, headers: {}, ...result } as ClientResponse<Res>;
+    },
+  };
+  return { client, requests };
+}
+
+/** A transport that returns a pruning 410 from the node and the given response from the archival endpoint. */
+function stubPrunedNode(archival: Partial<ClientResponse<any>> | Error, archivalEndpoint = ARCHIVAL_URL) {
+  return stubClient((request) =>
+    request.url.startsWith(NODE_URL)
+      ? { status: 410, statusText: "Gone", data: prunedBody(archivalEndpoint) }
+      : archival,
+  );
+}
+
+function makeRequest(config: AptosConfig, overrides?: ClientRequest<any>["overrides"]) {
+  return aptosRequest<{}, any>(
+    { url: NODE_URL, method: "GET", path: PATH, originMethod: "getBlockByHeight", overrides },
+    config,
+    AptosApiType.FULLNODE,
+  );
+}
+
+describe("archival fallback", () => {
+  let warn: MockInstance<typeof console.warn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it("retries a pruned request against the advertised archival endpoint and returns the result", async () => {
+    const { client, requests } = stubPrunedNode({ status: 200, data: { block_height: "1" } });
+    const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+    const response = await makeRequest(config);
+
+    expect(response.status).toBe(200);
+    expect(response.data).toEqual({ block_height: "1" });
+    expect(response.url).toBe(`${ARCHIVAL_URL}/${PATH}`);
+    expect(requests.map((r) => r.url)).toEqual([`${NODE_URL}/${PATH}`, `${ARCHIVAL_URL}/${PATH}`]);
+  });
+
+  it("preserves method, body, content type, params and headers on the retry", async () => {
+    const { client, requests } = stubPrunedNode({ status: 200, data: [] });
+    const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+    await aptosRequest<{}, any>(
+      {
+        url: NODE_URL,
+        method: "POST",
+        path: "view",
+        body: { function: "0x1::coin::balance" },
+        contentType: "application/json",
+        params: { ledger_version: "1" },
+        overrides: { API_KEY: "secret-key", HEADERS: { "x-custom": "kept" } },
+      },
+      config,
+      AptosApiType.FULLNODE,
+    );
+
+    const [original, retry] = requests;
+    expect(retry.method).toBe("POST");
+    expect(retry.body).toEqual(original.body);
+    expect(retry.params).toEqual(original.params);
+    expect(retry.headers["content-type"]).toBe("application/json");
+    expect(retry.headers["x-custom"]).toBe("kept");
+    expect(retry.headers.Authorization).toBe("Bearer secret-key");
+  });
+
+  it("retries exactly once and never chains when the archival endpoint is also pruned", async () => {
+    const { client, requests } = stubClient(() => ({
+      status: 410,
+      statusText: "Gone",
+      data: prunedBody(ARCHIVAL_URL),
+    }));
+    const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+    await expect(makeRequest(config)).rejects.toThrow(AptosApiError);
+    expect(requests).toHaveLength(2);
+  });
+
+  describe("credential forwarding", () => {
+    it("drops credentials when the archival endpoint is on a different site", async () => {
+      const { client, requests } = stubPrunedNode({ status: 200, data: {} }, "https://archive.example.com/v1");
+      const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+      await makeRequest(config, {
+        API_KEY: "secret-key",
+        AUTH_TOKEN: "secret-token",
+        HEADERS: { Authorization: "Bearer header-key", Cookie: "session=1", "x-custom": "kept" },
+      });
+
+      const retryHeaders = requests[1].headers;
+      expect(retryHeaders.Authorization).toBeUndefined();
+      expect(retryHeaders.Cookie).toBeUndefined();
+      expect(retryHeaders["x-custom"]).toBe("kept");
+      expect(JSON.stringify(retryHeaders)).not.toContain("secret");
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toContain("https://archive.example.com/v1");
+    });
+
+    it("does not warn when there were no credentials to drop", async () => {
+      const { client } = stubPrunedNode({ status: 200, data: {} }, "https://archive.example.com/v1");
+      const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+      await makeRequest(config, { HEADERS: { "x-custom": "kept" } });
+
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("endpoints that are not retried", () => {
+    it.each([
+      ["the field is absent", undefined],
+      ["the endpoint is not a valid absolute URL", "not-a-url"],
+      ["the endpoint is not http(s)", "ftp://archive.testnet.aptoslabs.com/v1"],
+      ["the endpoint downgrades https to plaintext", "http://archive.testnet.aptoslabs.com/v1"],
+    ])("throws the original error when %s", async (_label, archivalEndpoint) => {
+      const { client, requests } = stubClient(() => ({
+        status: 410,
+        statusText: "Gone",
+        data: prunedBody(archivalEndpoint),
+      }));
+      const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+      const error = await makeRequest(config).catch((e) => e);
+
+      expect(error).toBeInstanceOf(AptosApiError);
+      expect(error.status).toBe(410);
+      expect(error.url).toBe(`${NODE_URL}/${PATH}`);
+      expect(requests).toHaveLength(1);
+    });
+
+    it("is not applied to non-fullnode requests", async () => {
+      const { client, requests } = stubPrunedNode({ status: 200, data: {} });
+      const config = new AptosConfig({ network: Network.TESTNET, pepper: NODE_URL, client });
+
+      await expect(
+        aptosRequest<{}, any>({ url: NODE_URL, method: "GET", path: PATH }, config, AptosApiType.PEPPER),
+      ).rejects.toThrow(AptosApiError);
+      expect(requests).toHaveLength(1);
+    });
+
+    it("is not applied when archivalFallback is disabled", async () => {
+      const { client, requests } = stubPrunedNode({ status: 200, data: {} });
+      const config = new AptosConfig({
+        network: Network.TESTNET,
+        fullnode: NODE_URL,
+        client,
+        archivalFallback: false,
+      });
+
+      await expect(makeRequest(config)).rejects.toThrow(AptosApiError);
+      expect(requests).toHaveLength(1);
+    });
+
+    it("is not applied to non-410 failures", async () => {
+      const { client, requests } = stubClient(() => ({
+        status: 404,
+        statusText: "Not Found",
+        data: { error_code: "block_not_found", message: "not found", archival_endpoint: ARCHIVAL_URL },
+      }));
+      const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+      await expect(makeRequest(config)).rejects.toThrow(AptosApiError);
+      expect(requests).toHaveLength(1);
+    });
+  });
+
+  describe("when the retry itself fails", () => {
+    it("surfaces the archival error when the archival endpoint returns a failure", async () => {
+      const { client } = stubPrunedNode({ status: 404, statusText: "Not Found", data: { message: "gone forever" } });
+      const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+      const error = await makeRequest(config).catch((e) => e);
+
+      expect(error).toBeInstanceOf(AptosApiError);
+      expect(error.status).toBe(404);
+      expect(error.url).toBe(`${ARCHIVAL_URL}/${PATH}`);
+    });
+
+    it("surfaces the original pruning error when the archival endpoint is unreachable", async () => {
+      const { client } = stubPrunedNode(new Error("ENOTFOUND"));
+      const config = new AptosConfig({ network: Network.TESTNET, fullnode: NODE_URL, client });
+
+      const error = await makeRequest(config).catch((e) => e);
+
+      expect(error).toBeInstanceOf(AptosApiError);
+      expect(error.status).toBe(410);
+      expect(error.url).toBe(`${NODE_URL}/${PATH}`);
+      expect(error.message).toContain("block_pruned");
+    });
+  });
+});


### PR DESCRIPTION
### Description

Public fullnodes are moving from archival (full history) to a pruned tier that keeps only a rolling ~150M version window. Reads outside that window now fail with `410 Gone`, but the node tells you where to go instead:

```json
{
  "error_code": "version_pruned",
  "message": "Ledger version(1) has been pruned",
  "hint": "The requested data has been pruned from this node. Retry your request against the archival endpoint to access full history.",
  "oldest_ledger_version": "10255283755",
  "archival_endpoint": "https://archive.testnet.staging.aptoslabs.com/v1"
}
```

Today every SDK consumer gets an `AptosApiError` and has to implement the retry themselves. Hardware wallet vendors, staking apps, explorers and indexers are making millions of historical block/transaction reads that will start failing. Handling it in `aptosRequest` — the single chokepoint every Node API call funnels through — means they get the fix by upgrading.

**What it does.** On a fullnode `410` carrying an `archival_endpoint`, the same request is replayed once against that endpoint and the result returned transparently. Method, body, params, content type and headers are preserved.

**Design notes:**

- **Server-driven only.** The target comes solely from the advertised `archival_endpoint`; no archival URLs are hardcoded and the original host is never string-munged. If the field is absent, behaviour is identical to today.
- **Exactly once, never chained.** The retry calls the transport directly, so recursion is structurally impossible rather than flag-guarded.
- **On by default**, opt out with `new AptosConfig({ archivalFallback: false })`. It only executes on responses that already throw today, so no currently working request changes behaviour — and off-by-default would mean nobody gets the fix by upgrading, which is the point.
- **Error contract preserved.** Archival returns non-2xx → `AptosApiError` describing the archival attempt. Archival throws at the transport layer → the original `410` error. Callers never get a swallowed failure or a surprise non-`AptosApiError`.
- **Fullnode only.** Indexer/GraphQL, faucet, pepper and prover paths are untouched.
- **Triggered by the presence of `archival_endpoint`, not an `error_code` allowlist**, so new pruned error codes work without an SDK release. `version_pruned` and `block_pruned` both covered.
- **GET and POST.** `/v1/view?ledger_version=<pruned>` is a POST and a real pruned-read path. A `410` is an unambiguous "did not execute", so the usual non-idempotent-retry concern does not apply.

### Credential handling — worth a careful look

The archival host is chosen entirely by the node that just failed your request. Forwarding `Authorization` unconditionally would let a compromised or MITM'd fullnode name any host and harvest your API key.

Credentials (`API_KEY`, `AUTH_TOKEN`, and any `Authorization`/`Cookie`/`X-Api-Key` header) are therefore forwarded **only when the archival endpoint is on the same site as the configured node**, with a one-time `console.warn` when they are dropped. This mirrors how `curl` and browsers drop `Authorization` across a cross-host redirect.

Same-origin-only was considered and rejected: the real archival endpoint is a different host (`api.testnet.staging` → `archive.testnet.staging`), so that rule would drop the key on exactly the case this is meant to fix.

One known imprecision: the same-site check approximates the registrable domain as the last two labels rather than using the public suffix list, so hosts under a multi-part suffix like `co.uk` compare equal. This is documented at the call site. Reaching that case already requires control of the fullnode you configured, which receives the same credentials on every request anyway. Happy to tighten if reviewers prefer.

### Test Plan

**Unit tests** (`tests/unit/archivalFallback.test.ts`, 14 cases, mocked at the transport layer — no network):

- Retries to the advertised endpoint and returns the result; asserts both URLs in order
- Preserves method, body, params, content type and custom headers on the retry
- Retries exactly once and does not chain when archival is also pruned
- Drops `API_KEY`/`AUTH_TOKEN`/`Authorization`/`Cookie` cross-site, keeps unrelated headers, warns once; does not warn when there were no credentials to drop
- Leaves the original error intact when the field is absent, unparseable, non-http(s), or downgrades https→http
- Not applied to non-fullnode requests, when disabled, or to non-410 failures
- Surfaces the archival error on an archival HTTP failure, and the original pruning error when archival is unreachable

**Verified against staging testnet**, where the pruned/archival split is already deployed (run manually, not committed — the committed suite never hits the network):

| Check | Result |
|---|---|
| `getBlockByHeight(1)` | 410 from `api.testnet.staging` → 200 from `archive.testnet.staging`, returns block 1 |
| `getTransactionByVersion(1)` | Same two-hop, returns the v1 `block_metadata_transaction` |
| `POST /v1/view` at pruned version | 410 → archival 200, returns `["1712407729204830"]` (April 2024, so the archival node genuinely executed at the historical version) |
| `archivalFallback: false` | Throws `AptosApiError`, status 410, `error_code: block_pruned`, one request only |
| Recent data (`getLedgerInfo`) | Single 200, fallback never engages |

`pnpm check` clean, `tsc --noEmit` clean, 460/460 unit tests pass. The e2e suite has 6 pre-existing `MAX_GAS_UNITS_BELOW_MIN_TRANSACTION_GAS_UNITS` failures, confirmed identical on a clean tree at `main`.

### Related Links

Not covered: `/v1/transactions/by_hash/<pruned>` returns `404` with no hint, since a pruned node cannot distinguish a pruned transaction from one that never existed. Being fixed server-side; noted in the README so users reach for `getTransactionByVersion` in the meantime.

I could not find an AIP covering fullnode history retention or this Node API error contract — searched the AIPs repo issue tracker for `archival`, `pruning`, `prune`, `archive` and `fullnode history` with no relevant hits. If there is an internal RFC or rollout doc, happy to link it here.

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?