### PR TITLE
[bcs] Reject non-canonical uleb128 u32 length prefixes

### DIFF
--- a/src/bcs/deserializer.ts
+++ b/src/bcs/deserializer.ts
@@ -527,9 +527,11 @@ export class Deserializer {
     // Maximum 5 bytes for uleb128-encoded u32 (7 bits per byte, 5*7=35 bits > 32 bits needed)
     const MAX_ULEB128_BYTES = 5;
     let bytesRead = 0;
+    let lastByte = 0;
 
     while (bytesRead < MAX_ULEB128_BYTES) {
       const byte = this.deserializeU8();
+      lastByte = byte;
       bytesRead += 1;
 
       value |= BigInt(byte & 0x7f) << BigInt(shift);
@@ -546,9 +548,11 @@ export class Deserializer {
       shift += 7;
     }
 
-    // If we read MAX_ULEB128_BYTES and the last byte had continuation bit set, it's malformed
-    if (bytesRead === MAX_ULEB128_BYTES && value > MAX_U32_NUMBER) {
-      throw new Error("Overflow while parsing uleb128-encoded uint32 value");
+    // If we read MAX_ULEB128_BYTES and the last byte still had its continuation
+    // bit set, another byte is signaled that a u32 cannot hold, so the encoding
+    // is malformed. This also rejects non-canonical zero-padded encodings.
+    if (bytesRead === MAX_ULEB128_BYTES && (lastByte & 0x80) !== 0) {
+      throw new Error("Malformed uleb128 encoding for uint32 value");
     }
 
     return Number(value);

--- a/tests/unit/deserializer.test.ts
+++ b/tests/unit/deserializer.test.ts
@@ -116,6 +116,22 @@ describe("BCS Deserializer", () => {
     }).toThrow("Overflow while parsing uleb128-encoded uint32 value");
   });
 
+  it("throws when deserializing a non-canonical uleb128 whose fifth byte keeps the continuation bit set", () => {
+    // Fifth byte 0x8f signals a sixth byte that a u32 cannot hold. The value it
+    // accumulates to (4294967295) has a canonical encoding ending in 0x0f, so
+    // accepting this would let two byte strings decode to the same u32.
+    expect(() => {
+      const deserializer = new Deserializer(new Uint8Array([0xff, 0xff, 0xff, 0xff, 0x8f]));
+      deserializer.deserializeUleb128AsU32();
+    }).toThrow("Malformed uleb128 encoding for uint32 value");
+
+    // Five continuation-flagged zero bytes is a non-canonical encoding of 0.
+    expect(() => {
+      const deserializer = new Deserializer(new Uint8Array([0x80, 0x80, 0x80, 0x80, 0x80]));
+      deserializer.deserializeUleb128AsU32();
+    }).toThrow("Malformed uleb128 encoding for uint32 value");
+  });
+
   it("throws when deserializing against buffer that has been drained", () => {
     expect(() => {
       const deserializer = new Deserializer(


### PR DESCRIPTION
## What

`Deserializer.deserializeUleb128AsU32` accepts non-canonical uleb128 encodings. The malformed-input guard at the end of the loop does not do what its comment says, so two different byte strings can decode to the same u32.

## Why

The comment already states the intent:

```ts
// If we read MAX_ULEB128_BYTES and the last byte had continuation bit set, it's malformed
if (bytesRead === MAX_ULEB128_BYTES && value > MAX_U32_NUMBER) {
```

but the condition checks the value range, not the continuation bit. The value range is already enforced inside the loop (it throws on `value > MAX_U32_NUMBER` every iteration), so this post-loop check can never be true and the continuation bit on the fifth byte is never inspected.

As a result the reader accepts encodings the reference BCS reader rejects:

- `[0xff, 0xff, 0xff, 0xff, 0x8f]` decodes to `4294967295`, even though the fifth byte signals a sixth byte. The canonical encoding of that value ends in `0x0f`, so both byte strings decode to the same u32 (length-prefix and enum-tag malleability).
- `[0x80, 0x80, 0x80, 0x80, 0x80]` decodes to `0` instead of being rejected as a non-canonical zero.

## Change

Track the last byte read and reject a set continuation bit on the fifth byte, which is what the comment intended. Honest, canonical encodings are unaffected. Added unit tests for both non-canonical cases.
