### PR TITLE
docs: `TransactionSubmitter` example uses field names that do not exist

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -487,8 +487,8 @@ export type PluginSettings = Omit<PluginConfig, "IGNORE_TRANSACTION_SUBMITTER">;
  * const myGasStationClient = new MyGasStationClient(network);
  * const config = new AptosConfig({
  *   network,
- *   pluginConfig: {
- *     transactionSubmitter: myGasStationClient,
+ *   pluginSettings: {
+ *     TRANSACTION_SUBMITTER: myGasStationClient,
  *   },
  * });
  * const aptos = new Aptos(config);


### PR DESCRIPTION
## Problem

The `@example` block on the `TransactionSubmitter` interface (`src/types/types.ts:490`) shows how to register a custom submitter:

```ts
const config = new AptosConfig({
  network,
  pluginConfig: {
    transactionSubmitter: myGasStationClient,
  },
});
```

Both names are wrong:

- the field on `AptosSettings` is **`pluginSettings`** (`src/types/types.ts:348`), not `pluginConfig`
- the key inside is **`TRANSACTION_SUBMITTER`** (`src/types/types.ts:461`), not `transactionSubmitter` — `PluginSettings` is `Omit<PluginConfig, "IGNORE_TRANSACTION_SUBMITTER">` (line 469), and `PluginConfig` declares the upper-case key

The failure is silent. `AptosSettings` is a plain object type, so an extra `pluginConfig` property is simply ignored — no compile error, no runtime warning. A developer following this example to wire up a gas station gets a config that quietly never installs their submitter, and transactions keep going through the default path.

## Fix

```diff
- *   pluginConfig: {
- *     transactionSubmitter: myGasStationClient,
+ *   pluginSettings: {
+ *     TRANSACTION_SUBMITTER: myGasStationClient,
```

Comment-only change; no runtime code is touched.

## Note on overlap

Open PRs #802 and #631 also edit `types.ts`, but their hunks are at lines 156-205, 1512-1599 and 1716-1789 — nowhere near line 490.