### PR TITLE
test: harden flaky e2e tests against indexer lag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,7 +197,3 @@ Docker is pre-installed and the daemon is running. The Docker socket at `/var/ru
 ### Build Before Testing Examples
 
 Examples under `examples/` link to the root SDK via `link:../..`. Always run `pnpm build` in the repo root before working with examples.
-
-### Known Flaky Test
-
-`tests/e2e/api/account.test.ts` — the "it doesn't return default account if it is rotated" test can fail intermittently due to timing on the local testnet. This is a pre-existing issue, not an environment problem.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 # Unreleased
 
+## Fixed
+
+- **Indexer sync timeout**: Increased the default `waitForIndexer` timeout from 3s to 10s (`DEFAULT_INDEXER_SYNC_TIMEOUT_SEC`) so brief processor lag on localnet and public networks no longer throws `waitForLastSuccessIndexerVersionSync timeout`. The error now includes the current and target versions, and callers can pass `timeoutMilliseconds` for a custom budget.
+- **Account discovery**: `doesAccountExistAtAddress` now checks the `0x1::account::Account` resource first and skips the indexer `current_objects` query when the resource exists. A slow or timed-out owned-object query no longer fails discovery for standard accounts (light accounts without a resource still use the owned-object fallback).
+- **E2E reliability**: Account derivation and indexer-backed account queries now wait on `minimumLedgerVersion` after the relevant transaction. Transaction worker tests use isolated accounts, await `push`, and poll for the committed sequence number instead of a fixed sleep.
+
 ## Changed
 
 - Upgrade repository package-manager pins to pnpm `11.21.0` and update dependency overrides for patched `brace-expansion`, `immutable`, `js-yaml`, `linkify-it`, `nanoid`, and `postcss` releases, eliminating known audit vulnerabilities.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to the Aptos TypeScript SDK will be captured in this file. T
 
 - **Indexer sync timeout**: Increased the default `waitForIndexer` timeout from 3s to 10s (`DEFAULT_INDEXER_SYNC_TIMEOUT_SEC`) so brief processor lag on localnet and public networks no longer throws `waitForLastSuccessIndexerVersionSync timeout`. The error now includes the current and target versions, and callers can pass `timeoutMilliseconds` for a custom budget.
 - **Account discovery**: `doesAccountExistAtAddress` now checks the `0x1::account::Account` resource first and skips the indexer `current_objects` query when the resource exists. A slow or timed-out owned-object query no longer fails discovery for standard accounts (light accounts without a resource still use the owned-object fallback).
-- **E2E reliability**: Account derivation and indexer-backed account queries now wait on `minimumLedgerVersion` after the relevant transaction. Transaction worker tests use isolated accounts, await `push`, and poll for the committed sequence number instead of a fixed sleep.
+- **E2E reliability**: Account derivation and indexer-backed account queries now wait on `minimumLedgerVersion` after the relevant transaction. Transaction worker tests use isolated accounts, await `push`, and poll for the committed sequence number instead of a fixed sleep. Keyless e2e installs the federated test JWK from a local fixture instead of fetching GitHub on every test.
 
 ## Changed
 

--- a/src/internal/account.ts
+++ b/src/internal/account.ts
@@ -951,48 +951,41 @@ async function doesAccountExistAtAddress(args: {
 }): Promise<boolean> {
   const { aptosConfig, accountAddress, options } = args;
   try {
-    // Get the account resources and the balance of the account.  We need to check both because
-    // an account resource can exist with 0 balance and a balance can exist without an account resource (light accounts).
-    const [accountResource, ownedObjects] = await Promise.all([
-      getResourceFallible<{ authentication_key: string }>({
-        aptosConfig,
-        accountAddress,
-        resourceType: "0x1::account::Account",
-      }),
-      getAccountOwnedObjects({
-        aptosConfig,
-        accountAddress,
-        options: {
-          limit: 1,
-        },
-      }),
-    ]);
+    // Check the account resource first. For standard accounts this is sufficient proof of
+    // existence, and querying owned objects in parallel used to fail the whole check when
+    // the indexer `current_objects` query timed out.
+    const accountResource = await getResourceFallible<{ authentication_key: string }>({
+      aptosConfig,
+      accountAddress,
+      resourceType: "0x1::account::Account",
+    });
 
-    // If the account resource is not found and the balance is 0, then the account does not exist.
-    if (!accountResource && ownedObjects.length === 0) {
+    if (accountResource) {
+      if (!options?.withAuthKey) {
+        return true;
+      }
+      return accountResource.authentication_key === options.withAuthKey.toString();
+    }
+
+    // No account resource: still treat light accounts (objects but no resource) as existing.
+    const ownedObjects = await getAccountOwnedObjects({
+      aptosConfig,
+      accountAddress,
+      options: {
+        limit: 1,
+      },
+    });
+
+    if (ownedObjects.length === 0) {
       return false;
     }
 
-    // If no auth key is provided as an argument, return true.
     if (!options?.withAuthKey) {
       return true;
     }
 
-    // Get the auth key from the account resource if it exists. If the account resource does not exist,
-    // then the auth key is the account address by default.
-    let authKey;
-    if (accountResource) {
-      authKey = accountResource.authentication_key;
-    } else {
-      authKey = accountAddress.toStringLong();
-    }
-
-    if (authKey !== options.withAuthKey.toString()) {
-      return false;
-    }
-
-    // Else the account exists and the auth key matches.
-    return true;
+    // Light accounts have no resource, so the auth key is the account address by convention.
+    return accountAddress.toStringLong() === options.withAuthKey.toString();
   } catch (error: any) {
     throw new Error(`Error while checking if account exists at ${accountAddress.toString()}: ${error}`);
   }

--- a/src/internal/transaction.ts
+++ b/src/internal/transaction.ts
@@ -23,7 +23,7 @@ import {
   CommittedTransactionResponse,
   Block,
 } from "../types/index.js";
-import { DEFAULT_TXN_TIMEOUT_SEC, ProcessorType } from "../utils/const.js";
+import { DEFAULT_INDEXER_SYNC_TIMEOUT_SEC, DEFAULT_TXN_TIMEOUT_SEC, ProcessorType } from "../utils/const.js";
 import { sleep } from "../utils/helpers.js";
 import { memoizeAsync } from "../utils/memoize.js";
 import { getIndexerLastSuccessVersion, getProcessorStatus } from "./general.js";
@@ -313,29 +313,34 @@ export async function waitForTransaction(args: {
 }
 
 /**
- * Waits for the indexer to sync up to the specified ledger version. The timeout is 3 seconds.
+ * Waits for the indexer to sync up to the specified ledger version.
  *
  * @param args - The arguments for the function.
  * @param args.aptosConfig - The configuration object for Aptos.
  * @param args.minimumLedgerVersion - The minimum ledger version that the indexer should sync to.
  * @param args.processorType - (Optional) The type of processor to check the last success version from.
+ * @param args.timeoutMilliseconds - (Optional) How long to wait before throwing. Defaults to 10 seconds.
  * @group Implementation
  */
 export async function waitForIndexer(args: {
   aptosConfig: AptosConfig;
   minimumLedgerVersion: AnyNumber;
   processorType?: ProcessorType;
+  timeoutMilliseconds?: number;
 }): Promise<void> {
   const { aptosConfig, processorType } = args;
   const minimumLedgerVersion = BigInt(args.minimumLedgerVersion);
-  const timeoutMilliseconds = 3000; // 3 seconds
+  const timeoutMilliseconds = args.timeoutMilliseconds ?? DEFAULT_INDEXER_SYNC_TIMEOUT_SEC * 1000;
   const startTime = Date.now();
   let indexerVersion = BigInt(-1);
 
   while (indexerVersion < minimumLedgerVersion) {
     // check for timeout
     if (Date.now() - startTime > timeoutMilliseconds) {
-      throw new Error("waitForLastSuccessIndexerVersionSync timeout");
+      throw new Error(
+        `waitForLastSuccessIndexerVersionSync timeout after ${timeoutMilliseconds}ms: indexer at version ${indexerVersion}, needed ${minimumLedgerVersion}. ` +
+          `If this is a faucet/fundAccount call, you can skip the wait with { waitForIndexer: false }.`,
+      );
     }
 
     if (processorType === undefined) {

--- a/src/utils/const.ts
+++ b/src/utils/const.ts
@@ -68,6 +68,18 @@ export const DEFAULT_TXN_EXP_SEC_FROM_NOW = 20;
 export const DEFAULT_TXN_TIMEOUT_SEC = 20;
 
 /**
+ * The default number of seconds to wait for an indexer processor to catch up
+ * to a requested ledger version.
+ *
+ * Public networks and a busy local testnet can lag several seconds behind the
+ * fullnode. Callers that need a different budget can pass `timeoutMilliseconds`
+ * to `waitForIndexer`.
+ * @group Implementation
+ * @category Utils
+ */
+export const DEFAULT_INDEXER_SYNC_TIMEOUT_SEC = 10;
+
+/**
  * The default gas currency for the network.
  * @group Implementation
  * @category Utils

--- a/tests/e2e/api/account.test.ts
+++ b/tests/e2e/api/account.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../../src/index.js";
 import { getAptosClient } from "../helper.js";
 import { simpleCoinTransactionHeler } from "../transaction/helper.js";
+import { longTestTimeout } from "../../unit/helper.js";
 
 describe("account api", () => {
   const FUND_AMOUNT = 1_000_000_000;
@@ -229,6 +230,7 @@ describe("account api", () => {
       await aptos.waitForTransaction({ transactionHash: response.hash });
       const accountTransactionsCount = await aptos.getAccountTransactionsCount({
         accountAddress: senderAccount.accountAddress,
+        minimumLedgerVersion: BigInt(response.version),
       });
       expect(accountTransactionsCount).toBe(1);
     });
@@ -245,6 +247,7 @@ describe("account api", () => {
       await aptos.waitForTransaction({ transactionHash: fundTxn.hash });
       const accountCoinData = await aptos.getAccountCoinsData({
         accountAddress: senderAccount.accountAddress,
+        minimumLedgerVersion: BigInt(fundTxn.version),
       });
       expect(accountCoinData[0].amount).toBe(FUND_AMOUNT);
       expect(accountCoinData[0].asset_type).toBe("0x1::aptos_coin::AptosCoin");
@@ -262,6 +265,7 @@ describe("account api", () => {
       await aptos.waitForTransaction({ transactionHash: fundTxn.hash });
       const accountCoinsCount = await aptos.getAccountCoinsCount({
         accountAddress: senderAccount.accountAddress,
+        minimumLedgerVersion: BigInt(fundTxn.version),
       });
       expect(accountCoinsCount).toBe(1);
     });
@@ -417,27 +421,48 @@ describe("account api", () => {
       });
       const aptos = new Aptos(config);
 
-      test("single sender ed25519", async () => {
-        const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: false });
-        await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100 });
+      test(
+        "single sender ed25519",
+        async () => {
+          const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: false });
+          const fundTxn = await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100 });
 
-        const derivedAccount = await aptos.deriveAccountFromPrivateKey({ privateKey: account.privateKey });
-        expect(derivedAccount.accountAddress.equals(account.accountAddress)).toEqual(true);
-      }, 15000);
-      test("single sender secp256k1", async () => {
-        const account = Account.generate({ scheme: SigningSchemeInput.Secp256k1Ecdsa });
-        await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100 });
+          const derivedAccount = await aptos.deriveAccountFromPrivateKey({
+            privateKey: account.privateKey,
+            minimumLedgerVersion: BigInt(fundTxn.version),
+          });
+          expect(derivedAccount.accountAddress.equals(account.accountAddress)).toEqual(true);
+        },
+        longTestTimeout,
+      );
+      test(
+        "single sender secp256k1",
+        async () => {
+          const account = Account.generate({ scheme: SigningSchemeInput.Secp256k1Ecdsa });
+          const fundTxn = await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100 });
 
-        const derivedAccount = await aptos.deriveAccountFromPrivateKey({ privateKey: account.privateKey });
-        expect(derivedAccount).toStrictEqual(account);
-      });
-      test("legacy ed25519", async () => {
-        const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-        await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100 });
+          const derivedAccount = await aptos.deriveAccountFromPrivateKey({
+            privateKey: account.privateKey,
+            minimumLedgerVersion: BigInt(fundTxn.version),
+          });
+          expect(derivedAccount).toStrictEqual(account);
+        },
+        longTestTimeout,
+      );
+      test(
+        "legacy ed25519",
+        async () => {
+          const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+          const fundTxn = await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 100 });
 
-        const derivedAccount = await aptos.deriveAccountFromPrivateKey({ privateKey: account.privateKey });
-        expect(derivedAccount).toStrictEqual(account);
-      });
+          const derivedAccount = await aptos.deriveAccountFromPrivateKey({
+            privateKey: account.privateKey,
+            minimumLedgerVersion: BigInt(fundTxn.version),
+          });
+          expect(derivedAccount).toStrictEqual(account);
+        },
+        longTestTimeout,
+      );
       test("fails when account not created/funded and throwIfNoAccountFound is true", async () => {
         const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
 
@@ -460,146 +485,162 @@ describe("account api", () => {
   });
 
   describe("Key Rotation", () => {
-    test("it should rotate ed25519 to ed25519 auth key correctly", async () => {
-      const config = new AptosConfig({ network: Network.LOCAL });
-      const aptos = new Aptos(config);
+    test(
+      "it should rotate ed25519 to ed25519 auth key correctly",
+      async () => {
+        const config = new AptosConfig({ network: Network.LOCAL });
+        const aptos = new Aptos(config);
 
-      // Current Account
-      const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 1_000_000_000 });
+        // Current Account
+        const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 1_000_000_000 });
 
-      // account that holds the new key
-      const rotateToPrivateKey = Ed25519PrivateKey.generate();
+        // account that holds the new key
+        const rotateToPrivateKey = Ed25519PrivateKey.generate();
 
-      // Rotate the key
-      const txn = await aptos.rotateAuthKey({ fromAccount: account, toNewPrivateKey: rotateToPrivateKey });
-      const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
-      const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
+        // Rotate the key
+        const txn = await aptos.rotateAuthKey({ fromAccount: account, toNewPrivateKey: rotateToPrivateKey });
+        const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
+        const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
 
-      // lookup original account address
-      const lookupAccountAddress = await aptos.lookupOriginalAccountAddress({
-        authenticationKey: rotateToPrivateKey.publicKey().authKey().derivedAddress(),
-        minimumLedgerVersion: BigInt(response.version),
-      });
+        // lookup original account address
+        const lookupAccountAddress = await aptos.lookupOriginalAccountAddress({
+          authenticationKey: rotateToPrivateKey.publicKey().authKey().derivedAddress(),
+          minimumLedgerVersion: BigInt(response.version),
+        });
 
-      // Check if the lookup account address is the same as the original account address
-      expect(lookupAccountAddress).toStrictEqual(account.accountAddress);
+        // Check if the lookup account address is the same as the original account address
+        expect(lookupAccountAddress).toStrictEqual(account.accountAddress);
 
-      const rotatedAccount = Account.fromPrivateKey({
-        privateKey: rotateToPrivateKey,
-        address: account.accountAddress,
-      });
-      await simpleCoinTransactionHeler(aptos, rotatedAccount, Account.generate());
-    }, 10000);
+        const rotatedAccount = Account.fromPrivateKey({
+          privateKey: rotateToPrivateKey,
+          address: account.accountAddress,
+        });
+        await simpleCoinTransactionHeler(aptos, rotatedAccount, Account.generate());
+      },
+      longTestTimeout,
+    );
 
-    test("it should rotate ed25519 to multi-ed25519 auth key correctly", async () => {
-      const config = new AptosConfig({ network: Network.LOCAL });
-      const aptos = new Aptos(config);
+    test(
+      "it should rotate ed25519 to multi-ed25519 auth key correctly",
+      async () => {
+        const config = new AptosConfig({ network: Network.LOCAL });
+        const aptos = new Aptos(config);
 
-      // Current Account
-      const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 1_000_000_000 });
+        // Current Account
+        const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 1_000_000_000 });
 
-      const mk1 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const mk2 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const multiEdAccount = new MultiEd25519Account({
-        publicKey: new MultiEd25519PublicKey({
+        const mk1 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const mk2 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const multiEdAccount = new MultiEd25519Account({
+          publicKey: new MultiEd25519PublicKey({
+            publicKeys: [mk1.publicKey, mk2.publicKey],
+            threshold: 1,
+          }),
+          signers: [mk1.privateKey],
+        });
+
+        // Rotate the key
+        const txn = await aptos.rotateAuthKey({ fromAccount: account, toAccount: multiEdAccount });
+        const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
+        await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
+
+        const accountInfo = await aptos.account.getAccountInfo({
+          accountAddress: account.accountAddress,
+        });
+        expect(accountInfo.authentication_key).toEqual(multiEdAccount.publicKey.authKey().toString());
+
+        const rotatedAccount = new MultiEd25519Account({
+          publicKey: new MultiEd25519PublicKey({
+            publicKeys: [mk1.publicKey, mk2.publicKey],
+            threshold: 1,
+          }),
+          signers: [mk1.privateKey],
+          address: account.accountAddress,
+        });
+        await simpleCoinTransactionHeler(aptos, rotatedAccount, Account.generate());
+      },
+      longTestTimeout,
+    );
+
+    test(
+      "it should rotate ed25519 to multikey auth key correctly",
+      async () => {
+        const config = new AptosConfig({ network: Network.LOCAL });
+        const aptos = new Aptos(config);
+
+        // Current Account
+        const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 1_000_000_000 });
+
+        const mk1 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const mk2 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const multiKeyAccount = MultiKeyAccount.fromPublicKeysAndSigners({
           publicKeys: [mk1.publicKey, mk2.publicKey],
-          threshold: 1,
-        }),
-        signers: [mk1.privateKey],
-      });
+          signaturesRequired: 1,
+          signers: [mk1],
+        });
 
-      // Rotate the key
-      const txn = await aptos.rotateAuthKey({ fromAccount: account, toAccount: multiEdAccount });
-      const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
-      await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
+        // Rotate the key
+        const txn = await aptos.rotateAuthKeyUnverified({
+          fromAccount: account,
+          toNewPublicKey: multiKeyAccount.publicKey,
+        });
+        const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
+        await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
 
-      const accountInfo = await aptos.account.getAccountInfo({
-        accountAddress: account.accountAddress,
-      });
-      expect(accountInfo.authentication_key).toEqual(multiEdAccount.publicKey.authKey().toString());
+        const accountInfo = await aptos.account.getAccountInfo({
+          accountAddress: account.accountAddress,
+        });
+        expect(accountInfo.authentication_key).toEqual(multiKeyAccount.publicKey.authKey().toString());
 
-      const rotatedAccount = new MultiEd25519Account({
-        publicKey: new MultiEd25519PublicKey({
+        const rotatedAccount = MultiKeyAccount.fromPublicKeysAndSigners({
+          address: account.accountAddress,
           publicKeys: [mk1.publicKey, mk2.publicKey],
-          threshold: 1,
-        }),
-        signers: [mk1.privateKey],
-        address: account.accountAddress,
-      });
-      await simpleCoinTransactionHeler(aptos, rotatedAccount, Account.generate());
-    }, 10000);
+          signaturesRequired: 1,
+          signers: [mk1],
+        });
+        await simpleCoinTransactionHeler(aptos, rotatedAccount, Account.generate());
+      },
+      longTestTimeout,
+    );
 
-    test("it should rotate ed25519 to multikey auth key correctly", async () => {
-      const config = new AptosConfig({ network: Network.LOCAL });
-      const aptos = new Aptos(config);
+    test(
+      "it should rotate ed25519 to unverified auth key correctly",
+      async () => {
+        const config = new AptosConfig({ network: Network.LOCAL });
+        const aptos = new Aptos(config);
 
-      // Current Account
-      const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 1_000_000_000 });
+        // Current Account
+        const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 1_000_000_000 });
 
-      const mk1 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const mk2 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const multiKeyAccount = MultiKeyAccount.fromPublicKeysAndSigners({
-        publicKeys: [mk1.publicKey, mk2.publicKey],
-        signaturesRequired: 1,
-        signers: [mk1],
-      });
+        // account that holds the new key
+        const newAccount = Account.generate();
+        const newAuthKey = newAccount.publicKey.authKey();
 
-      // Rotate the key
-      const txn = await aptos.rotateAuthKeyUnverified({
-        fromAccount: account,
-        toNewPublicKey: multiKeyAccount.publicKey,
-      });
-      const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
-      await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
+        // Rotate the key
+        const txn = await aptos.rotateAuthKeyUnverified({
+          fromAccount: account,
+          toNewPublicKey: newAccount.publicKey,
+        });
+        const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
+        await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
 
-      const accountInfo = await aptos.account.getAccountInfo({
-        accountAddress: account.accountAddress,
-      });
-      expect(accountInfo.authentication_key).toEqual(multiKeyAccount.publicKey.authKey().toString());
+        const accountInfo = await aptos.account.getAccountInfo({
+          accountAddress: account.accountAddress,
+        });
+        expect(accountInfo.authentication_key).toEqual(newAuthKey.toString());
 
-      const rotatedAccount = MultiKeyAccount.fromPublicKeysAndSigners({
-        address: account.accountAddress,
-        publicKeys: [mk1.publicKey, mk2.publicKey],
-        signaturesRequired: 1,
-        signers: [mk1],
-      });
-      await simpleCoinTransactionHeler(aptos, rotatedAccount, Account.generate());
-    }, 10000);
-
-    test("it should rotate ed25519 to unverified auth key correctly", async () => {
-      const config = new AptosConfig({ network: Network.LOCAL });
-      const aptos = new Aptos(config);
-
-      // Current Account
-      const account = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      await aptos.fundAccount({ accountAddress: account.accountAddress, amount: 1_000_000_000 });
-
-      // account that holds the new key
-      const newAccount = Account.generate();
-      const newAuthKey = newAccount.publicKey.authKey();
-
-      // Rotate the key
-      const txn = await aptos.rotateAuthKeyUnverified({
-        fromAccount: account,
-        toNewPublicKey: newAccount.publicKey,
-      });
-      const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account, transaction: txn });
-      await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
-
-      const accountInfo = await aptos.account.getAccountInfo({
-        accountAddress: account.accountAddress,
-      });
-      expect(accountInfo.authentication_key).toEqual(newAuthKey.toString());
-
-      const rotatedAccount = Account.fromPrivateKey({
-        privateKey: newAccount.privateKey,
-        address: newAccount.accountAddress,
-      });
-      await simpleCoinTransactionHeler(aptos, rotatedAccount, Account.generate());
-    }, 10000);
+        const rotatedAccount = Account.fromPrivateKey({
+          privateKey: newAccount.privateKey,
+          address: newAccount.accountAddress,
+        });
+        await simpleCoinTransactionHeler(aptos, rotatedAccount, Account.generate());
+      },
+      longTestTimeout,
+    );
   });
 
   describe("Account Derivation APIs", () => {
@@ -613,7 +654,7 @@ describe("account api", () => {
         accountAddress: minterAccount.accountAddress,
         amount: FUND_AMOUNT * 100,
       });
-    }, 10000);
+    }, longTestTimeout);
 
     const checkAccountsMatch = (
       accounts: { accountAddress: AccountAddress }[],
@@ -645,209 +686,257 @@ describe("account api", () => {
       return await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
     }
 
-    test("it derives accounts correctly", async () => {
-      const account1 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const account2 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const account3 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const multiKeyAccount = MultiKeyAccount.fromPublicKeysAndSigners({
-        publicKeys: [account1.publicKey, account2.publicKey, account3.publicKey],
-        signaturesRequired: 1,
-        signers: [account3],
-      });
-      const multiEdAccount = new MultiEd25519Account({
-        publicKey: new MultiEd25519PublicKey({
-          publicKeys: [account3.publicKey, account1.publicKey],
-          threshold: 1,
-        }),
-        signers: [account3.privateKey],
-      });
-      const multiEdAccountTwoSigners = new MultiEd25519Account({
-        publicKey: new MultiEd25519PublicKey({
+    test(
+      "it derives accounts correctly",
+      async () => {
+        const account1 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const account2 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const account3 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const multiKeyAccount = MultiKeyAccount.fromPublicKeysAndSigners({
           publicKeys: [account1.publicKey, account2.publicKey, account3.publicKey],
-          threshold: 2,
-        }),
-        signers: [account1.privateKey, account2.privateKey],
-      });
-      for (const account of [account1, account2, account3, multiKeyAccount, multiEdAccount, multiEdAccountTwoSigners]) {
-        await createAccount(account);
-      }
-      // Rotate account2 to account1's auth key, skipping verification.
-      const rotateTxn = await aptos.rotateAuthKeyUnverified({
-        fromAccount: account2,
-        toNewPublicKey: account1.publicKey,
-      });
-      const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account2, transaction: rotateTxn });
-      await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
+          signaturesRequired: 1,
+          signers: [account3],
+        });
+        const multiEdAccount = new MultiEd25519Account({
+          publicKey: new MultiEd25519PublicKey({
+            publicKeys: [account3.publicKey, account1.publicKey],
+            threshold: 1,
+          }),
+          signers: [account3.privateKey],
+        });
+        const multiEdAccountTwoSigners = new MultiEd25519Account({
+          publicKey: new MultiEd25519PublicKey({
+            publicKeys: [account1.publicKey, account2.publicKey, account3.publicKey],
+            threshold: 2,
+          }),
+          signers: [account1.privateKey, account2.privateKey],
+        });
+        let lastTxn: CommittedTransactionResponse | undefined;
+        for (const account of [
+          account1,
+          account2,
+          account3,
+          multiKeyAccount,
+          multiEdAccount,
+          multiEdAccountTwoSigners,
+        ]) {
+          lastTxn = await createAccount(account);
+        }
+        // Rotate account2 to account1's auth key, skipping verification.
+        const rotateTxn = await aptos.rotateAuthKeyUnverified({
+          fromAccount: account2,
+          toNewPublicKey: account1.publicKey,
+        });
+        const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account2, transaction: rotateTxn });
+        lastTxn = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
 
-      // Send noop txns for the multikey accounts with account3 as the signer. These accounts
-      // are not verified as owned by account1.
-      await sendNoopTxn(multiKeyAccount);
-      await sendNoopTxn(multiEdAccount);
-      await sendNoopTxn(multiEdAccountTwoSigners);
-      let accounts = await aptos.deriveOwnedAccountsFromSigner({ signer: account1 });
-      expect(accounts.length).toBe(1);
-      expect(accounts[0].accountAddress.equals(account1.accountAddress)).toEqual(true);
+        // Send noop txns for the multikey accounts with account3 as the signer. These accounts
+        // are not verified as owned by account1.
+        await sendNoopTxn(multiKeyAccount);
+        await sendNoopTxn(multiEdAccount);
+        lastTxn = await sendNoopTxn(multiEdAccountTwoSigners);
+        let accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(lastTxn.version),
+        });
+        expect(accounts.length).toBe(1);
+        expect(accounts[0].accountAddress.equals(account1.accountAddress)).toEqual(true);
 
-      // Include unverified accounts.
-      accounts = await aptos.deriveOwnedAccountsFromSigner({
-        signer: account1,
-        options: {
-          includeUnverified: true,
-        },
-      });
-      checkAccountsMatch(accounts, [multiEdAccount, multiKeyAccount, account2, account1]);
+        // Include unverified accounts.
+        accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(lastTxn.version),
+          options: {
+            includeUnverified: true,
+          },
+        });
+        checkAccountsMatch(accounts, [multiEdAccount, multiKeyAccount, account2, account1]);
 
-      // Send txn with multiKeyAccount and account2 from the derived accounts. This will mark them as verified and
-      // be returned even when includeUnverified is false (default).
-      await sendNoopTxn(accounts[1]);
-      const { version } = await sendNoopTxn(accounts[2]);
+        // Send txn with multiKeyAccount and account2 from the derived accounts. This will mark them as verified and
+        // be returned even when includeUnverified is false (default).
+        await sendNoopTxn(accounts[1]);
+        lastTxn = await sendNoopTxn(accounts[2]);
 
-      accounts = await aptos.deriveOwnedAccountsFromSigner({
-        signer: account1,
-        minimumLedgerVersion: BigInt(version),
-        options: {
-          includeUnverified: false,
-        },
-      });
-      checkAccountsMatch(accounts, [account2, multiKeyAccount, account1]);
+        accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(lastTxn.version),
+          options: {
+            includeUnverified: false,
+          },
+        });
+        checkAccountsMatch(accounts, [account2, multiKeyAccount, account1]);
 
-      // Send txn with account1 which will change the ordering
-      await sendNoopTxn(account1);
+        // Send txn with account1 which will change the ordering
+        lastTxn = await sendNoopTxn(account1);
 
-      accounts = await aptos.deriveOwnedAccountsFromSigner({ signer: account1 });
-      checkAccountsMatch(accounts, [account1, account2, multiKeyAccount]);
+        accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(lastTxn.version),
+        });
+        checkAccountsMatch(accounts, [account1, account2, multiKeyAccount]);
 
-      // Check the noMultiKey works.
-      accounts = await aptos.deriveOwnedAccountsFromSigner({ signer: account1, options: { noMultiKey: true } });
-      checkAccountsMatch(accounts, [account1, account2]);
-    }, 20000);
+        // Check the noMultiKey works.
+        accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(lastTxn.version),
+          options: { noMultiKey: true },
+        });
+        checkAccountsMatch(accounts, [account1, account2]);
+      },
+      longTestTimeout,
+    );
 
-    test("it derives account that has been rotated", async () => {
-      const account1 = Account.generate({ scheme: SigningSchemeInput.Ed25519 });
-      const account2 = Account.generate({ scheme: SigningSchemeInput.Ed25519 });
+    test(
+      "it derives account that has been rotated",
+      async () => {
+        const account1 = Account.generate({ scheme: SigningSchemeInput.Ed25519 });
+        const account2 = Account.generate({ scheme: SigningSchemeInput.Ed25519 });
 
-      for (const account of [account1, account2]) {
-        await createAccount(account);
-      }
+        let lastTxn: CommittedTransactionResponse | undefined;
+        for (const account of [account1, account2]) {
+          lastTxn = await createAccount(account);
+        }
 
-      let accounts = await aptos.deriveOwnedAccountsFromSigner({ signer: account1 });
-      expect(accounts.length).toBe(1);
-      expect(accounts[0].accountAddress.equals(account1.accountAddress)).toEqual(true);
+        let accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(lastTxn!.version),
+        });
+        expect(accounts.length).toBe(1);
+        expect(accounts[0].accountAddress.equals(account1.accountAddress)).toEqual(true);
 
-      // Verified rotation. Should be derivable immediately.
-      const rotateTxn = await aptos.rotateAuthKey({
-        fromAccount: account2,
-        toNewPrivateKey: account1.privateKey,
-      });
-      const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account2, transaction: rotateTxn });
-      const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
+        // Verified rotation. Should be derivable immediately.
+        const rotateTxn = await aptos.rotateAuthKey({
+          fromAccount: account2,
+          toNewPrivateKey: account1.privateKey,
+        });
+        const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account2, transaction: rotateTxn });
+        const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
 
-      accounts = await aptos.deriveOwnedAccountsFromSigner({
-        signer: account1,
-        minimumLedgerVersion: BigInt(response.version),
-      });
-      expect(accounts.length).toBe(2);
-      expect(accounts[0].accountAddress.equals(account2.accountAddress)).toEqual(true);
-      expect(accounts[1].accountAddress.equals(account1.accountAddress)).toEqual(true);
-    }, 20000);
+        accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(response.version),
+        });
+        expect(accounts.length).toBe(2);
+        expect(accounts[0].accountAddress.equals(account2.accountAddress)).toEqual(true);
+        expect(accounts[1].accountAddress.equals(account1.accountAddress)).toEqual(true);
+      },
+      longTestTimeout,
+    );
 
-    test("it returns both legacy and single-signer accounts by default for ed25519", async () => {
-      const key = Ed25519PrivateKey.generate();
-      const legacyAccount = Account.fromPrivateKey({
-        privateKey: key,
-        legacy: true,
-      });
-      const singleSignerAccount = Account.fromPrivateKey({
-        privateKey: key,
-        legacy: false,
-      });
-      let txn: CommittedTransactionResponse;
-      const defaultAccounts = [legacyAccount, singleSignerAccount];
-      for (const account of [legacyAccount, singleSignerAccount]) {
-        txn = await createAccount(account);
-      }
+    test(
+      "it returns both legacy and single-signer accounts by default for ed25519",
+      async () => {
+        const key = Ed25519PrivateKey.generate();
+        const legacyAccount = Account.fromPrivateKey({
+          privateKey: key,
+          legacy: true,
+        });
+        const singleSignerAccount = Account.fromPrivateKey({
+          privateKey: key,
+          legacy: false,
+        });
+        let txn: CommittedTransactionResponse;
+        const defaultAccounts = [legacyAccount, singleSignerAccount];
+        for (const account of [legacyAccount, singleSignerAccount]) {
+          txn = await createAccount(account);
+        }
 
-      const accounts = await aptos.deriveOwnedAccountsFromSigner({
-        signer: key,
-        minimumLedgerVersion: Number(txn!.version),
-      });
-      checkAccountsMatch(accounts, defaultAccounts.reverse());
-    }, 20000);
+        const accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: key,
+          minimumLedgerVersion: BigInt(txn!.version),
+        });
+        checkAccountsMatch(accounts, defaultAccounts.reverse());
+      },
+      longTestTimeout,
+    );
 
-    test("it doesn't return default account if it is rotated", async () => {
-      const account1 = Account.generate({ scheme: SigningSchemeInput.Ed25519 });
-      const account2 = Account.generate({ scheme: SigningSchemeInput.Ed25519 });
+    test(
+      "it doesn't return default account if it is rotated",
+      async () => {
+        const account1 = Account.generate({ scheme: SigningSchemeInput.Ed25519 });
+        const account2 = Account.generate({ scheme: SigningSchemeInput.Ed25519 });
 
-      for (const account of [account1, account2]) {
-        await createAccount(account);
-      }
+        let lastTxn: CommittedTransactionResponse | undefined;
+        for (const account of [account1, account2]) {
+          lastTxn = await createAccount(account);
+        }
 
-      let accounts = await aptos.deriveOwnedAccountsFromSigner({ signer: account1 });
-      expect(accounts.length).toBe(1);
-      expect(accounts[0].accountAddress.equals(account1.accountAddress)).toEqual(true);
+        let accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(lastTxn!.version),
+        });
+        expect(accounts.length).toBe(1);
+        expect(accounts[0].accountAddress.equals(account1.accountAddress)).toEqual(true);
 
-      // Verified rotation. Should be derivable immediately.
-      const rotateTxn = await aptos.rotateAuthKey({
-        fromAccount: account1,
-        toNewPrivateKey: Ed25519PrivateKey.generate(),
-      });
-      const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account1, transaction: rotateTxn });
-      const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
+        // Verified rotation. Should be derivable immediately.
+        const rotateTxn = await aptos.rotateAuthKey({
+          fromAccount: account1,
+          toNewPrivateKey: Ed25519PrivateKey.generate(),
+        });
+        const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account1, transaction: rotateTxn });
+        const response = await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
 
-      accounts = await aptos.deriveOwnedAccountsFromSigner({
-        signer: account1,
-        minimumLedgerVersion: BigInt(response.version),
-      });
-      expect(accounts.length).toBe(0);
-    }, 20000);
+        accounts = await aptos.deriveOwnedAccountsFromSigner({
+          signer: account1,
+          minimumLedgerVersion: BigInt(response.version),
+        });
+        expect(accounts.length).toBe(0);
+      },
+      longTestTimeout,
+    );
 
-    test("getAccountsFromPublicKey returns accounts", async () => {
-      const account1 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const account2 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const account3 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
-      const multiKeyAccount = MultiKeyAccount.fromPublicKeysAndSigners({
-        publicKeys: [account1.publicKey, account2.publicKey, account3.publicKey],
-        signaturesRequired: 2,
-        signers: [account3, account2],
-      });
-      const multiEdAccount = new MultiEd25519Account({
-        publicKey: new MultiEd25519PublicKey({
-          publicKeys: [account3.publicKey, account1.publicKey],
-          threshold: 2,
-        }),
-        signers: [account3.privateKey, account1.privateKey],
-      });
-      for (const account of [account1, account2, account3, multiKeyAccount, multiEdAccount]) {
-        await createAccount(account);
-      }
-      // Rotate account2 to account1's auth key, skipping verification.
-      const rotateTxn = await aptos.rotateAuthKeyUnverified({
-        fromAccount: account2,
-        toNewPublicKey: account1.publicKey,
-      });
-      const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account2, transaction: rotateTxn });
-      await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
+    test(
+      "getAccountsFromPublicKey returns accounts",
+      async () => {
+        const account1 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const account2 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const account3 = Account.generate({ scheme: SigningSchemeInput.Ed25519, legacy: true });
+        const multiKeyAccount = MultiKeyAccount.fromPublicKeysAndSigners({
+          publicKeys: [account1.publicKey, account2.publicKey, account3.publicKey],
+          signaturesRequired: 2,
+          signers: [account3, account2],
+        });
+        const multiEdAccount = new MultiEd25519Account({
+          publicKey: new MultiEd25519PublicKey({
+            publicKeys: [account3.publicKey, account1.publicKey],
+            threshold: 2,
+          }),
+          signers: [account3.privateKey, account1.privateKey],
+        });
+        for (const account of [account1, account2, account3, multiKeyAccount, multiEdAccount]) {
+          await createAccount(account);
+        }
+        // Rotate account2 to account1's auth key, skipping verification.
+        const rotateTxn = await aptos.rotateAuthKeyUnverified({
+          fromAccount: account2,
+          toNewPublicKey: account1.publicKey,
+        });
+        const pendingTxn = await aptos.signAndSubmitTransaction({ signer: account2, transaction: rotateTxn });
+        await aptos.waitForTransaction({ transactionHash: pendingTxn.hash });
 
-      // Send noop txns for the multikey accounts
-      // The multiEdAccount has account1 as a signer.
-      await sendNoopTxn(multiKeyAccount);
-      const { version } = await sendNoopTxn(multiEdAccount);
+        // Send noop txns for the multikey accounts
+        // The multiEdAccount has account1 as a signer.
+        await sendNoopTxn(multiKeyAccount);
+        const { version } = await sendNoopTxn(multiEdAccount);
 
-      let accounts = await aptos.getAccountsForPublicKey({
-        publicKey: account1.publicKey,
-        minimumLedgerVersion: BigInt(version),
-      });
-      expect(accounts.length).toBe(2);
-      checkAccountsMatch(accounts, [multiEdAccount, account1]);
+        let accounts = await aptos.getAccountsForPublicKey({
+          publicKey: account1.publicKey,
+          minimumLedgerVersion: BigInt(version),
+        });
+        expect(accounts.length).toBe(2);
+        checkAccountsMatch(accounts, [multiEdAccount, account1]);
 
-      // Check that the multiKeyAccount is not included.
-      accounts = await aptos.getAccountsForPublicKey({
-        publicKey: account1.publicKey,
-        options: {
-          includeUnverified: true,
-        },
-      });
-      checkAccountsMatch(accounts, [multiEdAccount, multiKeyAccount, account2, account1]);
-    }, 20000);
+        // Check that the multiKeyAccount is not included.
+        accounts = await aptos.getAccountsForPublicKey({
+          publicKey: account1.publicKey,
+          minimumLedgerVersion: BigInt(version),
+          options: {
+            includeUnverified: true,
+          },
+        });
+        checkAccountsMatch(accounts, [multiEdAccount, multiKeyAccount, account2, account1]);
+      },
+      longTestTimeout,
+    );
   });
 });

--- a/tests/e2e/api/keyless.test.ts
+++ b/tests/e2e/api/keyless.test.ts
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-import { Account, ProofFetchStatus, ZkpVariant } from "../../../src/index.js";
+import { Account, ProofFetchStatus, ZkpVariant, MoveVector } from "../../../src/index.js";
 import { KeylessAccount } from "../../../src/account/KeylessAccount.js";
 import { FederatedKeylessAccount } from "../../../src/account/FederatedKeylessAccount.js";
 import { Groth16Zkp, ZeroKnowledgeSig, ZkProof } from "../../../src/core/crypto/keyless.js";
@@ -60,12 +60,43 @@ export const TEST_FEDERATED_JWT_TOKENS = [
   "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InRlc3QtcnNhIn0.eyJpc3MiOiJ0ZXN0LmZlZGVyYXRlZC5vaWRjLnByb3ZpZGVyIiwiYXVkIjoidGVzdC1rZXlsZXNzLWRhcHAiLCJzdWIiOiJ0ZXN0LXVzZXItMTkiLCJlbWFpbCI6InRlc3RAYXB0b3NsYWJzLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjp0cnVlLCJpYXQiOjk4NzY1NDMyMDksImV4cCI6OTg3NjU0MzIxMCwibm9uY2UiOiIxOTY0MzY5ODg2MTI2NTU2NzgwNDkwOTkxMzEzMDUwNzI0NzgxNDUyNjkxMzU3MDIyODMxNjQxNzM3Nzk2NTEwNTY4MTc5NjE3MzA5OCJ9.xYHVyi1BCZB5szBOS4xbDtORAreaTiDmYfR8l3mmApQgLuAzkv4fPGuClLEitD9rrh1hVQ1tgYqk05cXKA_al6vEa8maxduPd-Q41Yp4Ji3-CU-MgQYqtZNyWPxv9dvMxCat_BCs8z1tZ9g1d7fLGs2G5-IgDhlNhmsmCanLxUUDijPtjvA6xZfRqR4lzS2MtyzPO7dMS7YZFV47O2Rl4CHhDOBPHqplJ1I_T26zurvuZWxT3vOy4qm863dPqRli4UNMTAxGfUB2xn8j36SyhqYzfYuOXjHnTgHsxP3yHY2vg6ttnscoU-Ue4HN6ICeAgnUUXdDpoaPan4qO1OLunA",
 ];
 
-const KEYLESS_TEST_TIMEOUT = 12000;
+const KEYLESS_TEST_TIMEOUT = 60_000;
+
+/** Aptos core `secure_test_jwk.json` — installed on-chain without fetching GitHub. */
+const SECURE_TEST_RSA_JWK = {
+  kid: "test-rsa",
+  alg: "RS256",
+  e: "AQAB",
+  n: "y5Efs1ZzisLLKCARSvTztgWj5JFP3778dZWt-od78fmOZFxem3a_aYbOXSJToRp862do0PxJ4PDMpmqwV5f7KplFI6NswQV-WPufQH8IaHXZtuPdCjPOcHybcDiLkO12d0dG6iZQUzypjAJf63APcadio-4JDNWlGC5_Ow_XQ9lIY71kTMiT9lkCCd0ZxqEifGtnJe5xSoZoaMRKrvlOw-R6iVjLUtPAk5hyUX95LDKxwAR-oshnj7gmATejga2EvH9ozdn3M8Go11PSDa04OQxPcA25OoDTfxLvT28LRpSXrbmUWZ-O_lGtDl3ZAtjIguYGEobTk4N11eRssC95Cw",
+};
 
 describe("keyless api", () => {
   const ephemeralKeyPair = EPHEMERAL_KEY_PAIR;
   const { aptos } = getAptosClient();
   const jwkAccount = Account.generate();
+
+  async function installFederatedJwks(args: {
+    sender: Account;
+    iss: string;
+    keys: Array<{ kid: string; alg: string; e: string; n: string }>;
+  }) {
+    const { sender, iss, keys } = args;
+    const jwkTransaction = await aptos.transaction.build.simple({
+      sender: sender.accountAddress,
+      data: {
+        function: "0x1::jwks::update_federated_jwk_set",
+        functionArguments: [
+          iss,
+          MoveVector.MoveString(keys.map((key) => key.kid)),
+          MoveVector.MoveString(keys.map((key) => key.alg)),
+          MoveVector.MoveString(keys.map((key) => key.e)),
+          MoveVector.MoveString(keys.map((key) => key.n)),
+        ],
+      },
+    });
+    const committedJwkTxn = await aptos.signAndSubmitTransaction({ signer: sender, transaction: jwkTransaction });
+    await aptos.waitForTransaction({ transactionHash: committedJwkTxn.hash });
+  }
 
   beforeEach(async () => {
     // Clear the memoize cache to ensure fresh JWK lookups after installing new JWKs
@@ -74,13 +105,11 @@ describe("keyless api", () => {
       accountAddress: jwkAccount.accountAddress,
       amount: FUND_AMOUNT,
     });
-    const jwkTransaction = await aptos.updateFederatedKeylessJwkSetTransaction({
+    await installFederatedJwks({
       sender: jwkAccount,
       iss: "test.federated.oidc.provider",
-      jwksUrl: "https://github.com/aptos-labs/aptos-core/raw/main/types/src/jwks/rsa/secure_test_jwk.json",
+      keys: [SECURE_TEST_RSA_JWK],
     });
-    const committedJwkTxn = await aptos.signAndSubmitTransaction({ signer: jwkAccount, transaction: jwkTransaction });
-    await aptos.waitForTransaction({ transactionHash: committedJwkTxn.hash });
   });
 
   test(
@@ -156,14 +185,12 @@ describe("keyless api", () => {
       });
       const recipient = Account.generate();
 
-      // Now rotate the JWKs
-      const jwkTransaction = await aptos.updateFederatedKeylessJwkSetTransaction({
+      // Now rotate the JWKs to a different kid so the original JWT's kid is no longer installed.
+      await installFederatedJwks({
         sender: jwkAccount,
         iss: "test.federated.oidc.provider",
-        jwksUrl: "https://dev-qtdgjv22jh0v1k7g.us.auth0.com/.well-known/jwks.json",
+        keys: [{ ...SECURE_TEST_RSA_JWK, kid: "test-rsa-rotated" }],
       });
-      const committedJwkTxn = await aptos.signAndSubmitTransaction({ signer: jwkAccount, transaction: jwkTransaction });
-      await aptos.waitForTransaction({ transactionHash: committedJwkTxn.hash });
 
       await expect(simpleCoinTransactionHelper(aptos, account, recipient)).rejects.toThrow(
         "JWK with kid 'test-rsa' for issuer 'test.federated.oidc.provider' not found",

--- a/tests/e2e/helper.ts
+++ b/tests/e2e/helper.ts
@@ -1,4 +1,5 @@
 import { Aptos, AptosConfig, AptosSettings, Network, NetworkToNetworkName } from "../../src/index.js";
+import { sleep } from "../../src/utils/helpers.js";
 
 /**
  * Use this function whenever you want an Aptos client.
@@ -29,4 +30,24 @@ export function getAptosClient(additionalConfig?: AptosSettings): { aptos: Aptos
   });
   const aptos = new Aptos(config);
   return { aptos, config };
+}
+
+/**
+ * Polls until `predicate` returns true or `timeoutMs` elapses.
+ * Prefer this over a fixed `setTimeout` in e2e tests so assertions wait for
+ * on-chain/indexer state instead of racing a wall-clock delay.
+ */
+export async function waitUntil(
+  predicate: () => Promise<boolean>,
+  options?: { timeoutMs?: number; intervalMs?: number; timeoutMessage?: string },
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 60_000;
+  const intervalMs = options?.intervalMs ?? 250;
+  const start = Date.now();
+  while (!(await predicate())) {
+    if (Date.now() - start >= timeoutMs) {
+      throw new Error(options?.timeoutMessage ?? `Condition not met within ${timeoutMs}ms`);
+    }
+    await sleep(intervalMs);
+  }
 }

--- a/tests/e2e/transactionManagement/transactionWorker.test.ts
+++ b/tests/e2e/transactionManagement/transactionWorker.test.ts
@@ -3,23 +3,34 @@ import { Account } from "../../../src/account/index.js";
 import { InputGenerateTransactionPayloadData } from "../../../src/transactions/types.js";
 import { TransactionWorker } from "../../../src/transactions/management/transactionWorker.js";
 import { TransactionResponseType, TypeTagAddress, TypeTagU64 } from "../../../src/index.js";
-import { getAptosClient } from "../helper.js";
+import { getAptosClient, waitUntil } from "../helper.js";
 
 const { aptos, config: aptosConfig } = getAptosClient();
 
-const sender = Account.generate();
 const recipient = Account.generate();
 
 describe("transactionWorker", () => {
-  beforeAll(async () => {
-    await aptos.fundAccount({ accountAddress: sender.accountAddress, amount: 1000000000 });
+  const workers: TransactionWorker[] = [];
+
+  afterEach(() => {
+    for (const worker of workers) {
+      if (worker.started) {
+        worker.stop();
+      }
+    }
+    workers.length = 0;
   });
+
+  function createWorker(account: Account): TransactionWorker {
+    const worker = new TransactionWorker(aptosConfig, account);
+    workers.push(worker);
+    return worker;
+  }
 
   test(
     "throws when starting an already started worker",
     async () => {
-      // start transactions worker
-      const transactionWorker = new TransactionWorker(aptosConfig, sender);
+      const transactionWorker = createWorker(Account.generate());
       transactionWorker.start();
       await expect(async () => {
         transactionWorker.start();
@@ -31,8 +42,7 @@ describe("transactionWorker", () => {
   test(
     "throws when stopping an already stopped worker",
     async () => {
-      // start transactions worker
-      const transactionWorker = new TransactionWorker(aptosConfig, sender);
+      const transactionWorker = createWorker(Account.generate());
       transactionWorker.start();
       transactionWorker.stop();
       await expect(async () => {
@@ -45,16 +55,14 @@ describe("transactionWorker", () => {
   test(
     "adds transaction into the transactionsQueue",
     async () => {
-      const transactionWorker = new TransactionWorker(aptosConfig, sender);
-      transactionWorker.start();
+      // Push before start so the worker cannot dequeue the payload before we assert.
+      const transactionWorker = createWorker(Account.generate());
       const txn: InputGenerateTransactionPayloadData = {
         function: "0x1::aptos_account::transfer",
         functionArguments: [recipient.accountAddress, 1],
       };
-      transactionWorker.push(txn).then(() => {
-        transactionWorker.stop();
-        expect(transactionWorker.transactionsQueue.queue).toHaveLength(1);
-      });
+      await transactionWorker.push(txn);
+      expect(transactionWorker.transactionsQueue.queue).toHaveLength(1);
     },
     longTestTimeout,
   );
@@ -62,12 +70,13 @@ describe("transactionWorker", () => {
   test(
     "submits 5 transactions to chain for a single account",
     async () => {
-      // create 5 transactions
+      const sender = Account.generate();
+      await aptos.fundAccount({ accountAddress: sender.accountAddress, amount: 1_000_000_000 });
+
       const txn: InputGenerateTransactionPayloadData = {
         function: "0x1::aptos_account::transfer",
         functionArguments: [recipient.accountAddress, 1],
       };
-      // create 5 transactions with ABI
       const txnWithAbi: InputGenerateTransactionPayloadData = {
         function: "0x1::aptos_account::transfer",
         functionArguments: [recipient.accountAddress, 1],
@@ -75,32 +84,33 @@ describe("transactionWorker", () => {
       };
       const payloads = [...new Array(5).fill(txn), ...new Array(5).fill(txnWithAbi)];
 
-      // start transactions worker
-      const transactionWorker = new TransactionWorker(aptosConfig, sender);
+      const transactionWorker = createWorker(sender);
       transactionWorker.start();
 
-      // push transactions to queue
       for (const payload of payloads) {
-        transactionWorker.push(payload);
+        await transactionWorker.push(payload);
       }
 
-      // wait for transactions to be processed
-      await new Promise((resolve) => {
-        setTimeout(resolve, 1000 * 30);
-      });
+      await waitUntil(
+        async () => {
+          const accountData = await aptos.getAccountInfo({ accountAddress: sender.accountAddress });
+          return accountData.sequence_number === "10";
+        },
+        {
+          timeoutMs: 90_000,
+          timeoutMessage: "Transaction worker did not commit 10 transactions within 90s",
+        },
+      );
 
       transactionWorker.stop();
       const accountData = await aptos.getAccountInfo({ accountAddress: sender.accountAddress });
-      // expect sender sequence number to be 10
       expect(accountData.sequence_number).toBe("10");
 
-      // Check all are successful
       const txns = await aptos.getAccountTransactions({ accountAddress: sender.accountAddress });
       txns.forEach((userTxn) => {
         if (userTxn.type === TransactionResponseType.User) {
           expect(userTxn.success).toBe(true);
         } else {
-          // All of these should be user transactions, but in the event the API returns an invalid transaction
           throw new Error(`Transaction is not a user transaction ${userTxn.type}`);
         }
       });

--- a/tests/unit/internal/account-getAccounts.test.ts
+++ b/tests/unit/internal/account-getAccounts.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import { createMockClient } from "../../helpers/mockClient.js";
 import { Account } from "../../../src/account/Account.js";
 import { getAccountsForPublicKey } from "../../../src/internal/account.js";
+import { SigningSchemeInput } from "../../../src/types/index.js";
 
 describe("internal/account.getAccountsForPublicKey", () => {
   it("returns the default account when the auth-key address exists on-chain", async () => {
@@ -47,6 +48,114 @@ describe("internal/account.getAccountsForPublicKey", () => {
     expect(result).toHaveLength(1);
     expect(result[0].accountAddress.toString()).toBe(account.accountAddress.toString());
     expect(result[0].lastTransactionVersion).toBe(12);
+  });
+
+  it("does not query owned objects when the account resource exists, even if current_objects would fail", async () => {
+    const mock = createMockClient();
+    // Secp256k1 has a single public-key form, so discovery does not also probe a legacy Ed25519 address.
+    const account = Account.generate({ scheme: SigningSchemeInput.Secp256k1Ecdsa });
+    const authKeyHex = account.publicKey.authKey().toString();
+
+    mock.setResponder((req) => {
+      if (req.method === "GET" && req.url?.includes("/transactions")) {
+        return { data: [{ version: "7", hash: "0x1" }] };
+      }
+      if (req.method === "GET" && req.url?.includes("/resource/0x1::account::Account")) {
+        return {
+          data: {
+            type: "0x1::account::Account",
+            data: { sequence_number: "1", authentication_key: authKeyHex },
+          },
+        };
+      }
+      if (req.method === "POST" && req.body && typeof req.body === "object" && "query" in (req.body as object)) {
+        const body = req.body as { query?: string };
+        if (body.query?.includes("current_objects")) {
+          throw new Error("current_objects should not be queried when the account resource exists");
+        }
+        if (body.query?.includes("public_key_auth_keys")) {
+          return { data: { data: { public_key_auth_keys: [] } } };
+        }
+        if (body.query?.includes("auth_key_account_addresses")) {
+          return { data: { data: { auth_key_account_addresses: [] } } };
+        }
+      }
+      return { data: {} };
+    });
+
+    const result = await getAccountsForPublicKey({
+      aptosConfig: mock.config,
+      publicKey: account.publicKey,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].accountAddress.toString()).toBe(account.accountAddress.toString());
+    expect(
+      mock.requests.some(
+        (req) =>
+          req.method === "POST" &&
+          req.body &&
+          typeof req.body === "object" &&
+          "query" in (req.body as object) &&
+          (req.body as { query?: string }).query?.includes("current_objects"),
+      ),
+    ).toBe(false);
+  });
+
+  it("still queries owned objects to discover a light account without an Account resource", async () => {
+    const mock = createMockClient();
+    const account = Account.generate({ scheme: SigningSchemeInput.Secp256k1Ecdsa });
+    const address = account.accountAddress.toString();
+
+    mock.setResponder((req) => {
+      if (req.method === "GET" && req.url?.includes("/transactions")) {
+        return { data: [] };
+      }
+      if (req.method === "GET" && req.url?.includes("/resource/0x1::account::Account")) {
+        return {
+          status: 404,
+          statusText: "Not Found",
+          data: { message: "resource not found", error_code: "resource_not_found" },
+        };
+      }
+      if (req.method === "POST" && req.body && typeof req.body === "object" && "query" in (req.body as object)) {
+        const body = req.body as { query?: string };
+        if (body.query?.includes("current_objects")) {
+          return {
+            data: {
+              data: {
+                current_objects: [{ object_address: address, owner_address: address, is_deleted: false }],
+              },
+            },
+          };
+        }
+        if (body.query?.includes("public_key_auth_keys")) {
+          return { data: { data: { public_key_auth_keys: [] } } };
+        }
+        if (body.query?.includes("auth_key_account_addresses")) {
+          return { data: { data: { auth_key_account_addresses: [] } } };
+        }
+      }
+      return { data: {} };
+    });
+
+    const result = await getAccountsForPublicKey({
+      aptosConfig: mock.config,
+      publicKey: account.publicKey,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].accountAddress.toString()).toBe(address);
+    expect(
+      mock.requests.some(
+        (req) =>
+          req.method === "POST" &&
+          req.body &&
+          typeof req.body === "object" &&
+          "query" in (req.body as object) &&
+          (req.body as { query?: string }).query?.includes("current_objects"),
+      ),
+    ).toBe(true);
   });
 
   it("discovers multi-key accounts that contain the signer public key", async () => {

--- a/tests/unit/internal/transaction-queries.test.ts
+++ b/tests/unit/internal/transaction-queries.test.ts
@@ -22,7 +22,7 @@ import {
   waitForIndexer,
 } from "../../../src/internal/transaction.js";
 import { TransactionResponseType, type TransactionResponse } from "../../../src/types/index.js";
-import { ProcessorType } from "../../../src/utils/const.js";
+import { DEFAULT_INDEXER_SYNC_TIMEOUT_SEC, ProcessorType } from "../../../src/utils/const.js";
 
 const gasEstimate = (
   overrides: Partial<{
@@ -195,16 +195,36 @@ describe("internal/transaction — basic queries", () => {
       expect(body.variables?.where_condition).toEqual({ processor: { _eq: ProcessorType.DEFAULT } });
     });
 
-    it("throws after the 3 second timeout when the indexer never catches up", async () => {
+    it("throws after the default indexer sync timeout when the indexer never catches up", async () => {
       vi.useFakeTimers({ shouldAdvanceTime: true });
       const mock = createMockClient();
       mock.setDefault({
         data: { data: { processor_status: [{ processor: "default_processor", last_success_version: "1" }] } },
       });
 
-      const pending = waitForIndexer({ aptosConfig: mock.config, minimumLedgerVersion: 9999 });
-      await vi.advanceTimersByTimeAsync(3100);
-      await expect(pending).rejects.toThrow(/waitForLastSuccessIndexerVersionSync timeout/);
+      const assertion = expect(
+        waitForIndexer({ aptosConfig: mock.config, minimumLedgerVersion: 9999 }),
+      ).rejects.toThrow(/waitForLastSuccessIndexerVersionSync timeout after 10000ms/);
+      await vi.advanceTimersByTimeAsync(DEFAULT_INDEXER_SYNC_TIMEOUT_SEC * 1000 + 100);
+      await assertion;
+    });
+
+    it("honors a custom timeoutMilliseconds", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      const mock = createMockClient();
+      mock.setDefault({
+        data: { data: { processor_status: [{ processor: "default_processor", last_success_version: "1" }] } },
+      });
+
+      const assertion = expect(
+        waitForIndexer({
+          aptosConfig: mock.config,
+          minimumLedgerVersion: 9999,
+          timeoutMilliseconds: 500,
+        }),
+      ).rejects.toThrow(/waitForLastSuccessIndexerVersionSync timeout after 500ms/);
+      await vi.advanceTimersByTimeAsync(600);
+      await assertion;
     });
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

E2E flakes were clustering around indexer lag on a busy localnet (4 Vitest workers), racy test patterns, and keyless JWKS fetches over the public internet.

**SDK**

- Increase the default `waitForIndexer` timeout from 3s to 10s (`DEFAULT_INDEXER_SYNC_TIMEOUT_SEC`). The timeout error now includes current vs target versions, and callers can pass `timeoutMilliseconds`.
- Check the `0x1::account::Account` resource first in `doesAccountExistAtAddress` and skip the indexer `current_objects` query when the resource exists. A slow owned-object query no longer fails discovery for standard accounts; light accounts without a resource still use the fallback.

**Tests**

- Account derivation / indexer-backed account queries now pass `minimumLedgerVersion` after the relevant transaction, and derivation tests use a longer timeout.
- Transaction worker tests use an isolated sender per case, await `push`, stop workers in `afterEach`, and poll for the committed sequence number instead of a 30s sleep.
- Keyless e2e installs the federated test JWK from a local `secure_test_jwk.json` fixture instead of fetching GitHub in `beforeEach`. The outdated-JWK case rotates to a different kid locally instead of pulling Auth0 JWKS. The dedicated Auth0 live-install test is unchanged; Firebase remains skipped.
- Unit coverage for the new indexer timeout behavior and for skipping `current_objects` when the account resource exists.

### Test Plan

- [x] `pnpm check`
- [x] `pnpm unit-test` (1714 tests)
- [x] Targeted e2e: `account.test.ts` + `transactionWorker.test.ts` (37 passed)
- [x] `TMPDIR=/tmp pnpm exec vitest run tests/e2e/api/keyless.test.ts` (25 passed, 1 skipped)
- [x] `TMPDIR=/tmp pnpm e2e-test` — 346 passed, 43 skipped

### Related Links

Overlaps with (but does not replace) #858 (indexer sync timeout) and #931 (skip owned-object query during account discovery).

### Checklist
  - [x] Have you ran `pnpm fmt`?
  - [x] Have you updated the `CHANGELOG.md`?

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-86765fc0-03c5-4d05-8054-d1c51e4e1617?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-86765fc0-03c5-4d05-8054-d1c51e4e1617&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

